### PR TITLE
Add security advisory to PGP/Card_edit

### DIFF
--- a/content/PGP/Card_edit.adoc
+++ b/content/PGP/Card_edit.adoc
@@ -1,5 +1,11 @@
 = YubiKey NEO OpenPGP Applet configuration
 
+[IMPORTANT]
+====
+Yubico has learned of a security issue with the OpenPGP Card applet project that is used in the YubiKey NEO. This vulnerability applies to you only if you are using OpenPGP, and you have the OpenPGP applet version 1.0.9 or earlier.
+link:https://developers.yubico.com/ykneo-openpgp/SecurityAdvisory%202015-04-14.html[SecurityAdvisory 2015-04-14]
+====
+
 == Introduction
 
 To configure the OpenPGP applet on a YubiKey NEO you can use GnuPG.
@@ -31,7 +37,7 @@ github repository.)  To check the applet version you may run:
  OK
 ....
 
-Where "01 00 05" means version 1.0.5.
+Where "01 00 05" means version 1.0.5. (see security advisory above if version < 1.0.10)
 
 == Example
 


### PR DESCRIPTION
Ensure users viewing [this page on the developers website](https://developers.yubico.com/PGP/Card_edit.html) are aware that the applet needs to be updated or the Yubikey NEO replaced if version number is < `1.0.9`.

Per #21 the entire document should also be reviewed for accuracy.