### PR TITLE
pgp: Add usage blurb.

### DIFF
--- a/content/PGP/Importing_keys.adoc
+++ b/content/PGP/Importing_keys.adoc
@@ -19,6 +19,9 @@ Where "01 00 05" means version 1.0.5.
 If you have an existing key you want to import, that key must be a RSA
 2048 bit key.
 
+
+You'll also need the YubiKey's link:https://developers.yubico.com/PGP/[Admin PIN].
+
 == Generate a key
 
 Skip this step if you already have a key.

--- a/content/PGP/index.adoc
+++ b/content/PGP/index.adoc
@@ -10,6 +10,11 @@ PGP has the following advantages:
  - *De facto standard* in the Gnu/Linux world and for e-mail encryption.
  - *Flexible*. PGP is a crypto toolbox that can be used to perform all common operations.
 
+=== Usage
+
+The OpenPGP functionality of YubiKeys is typically used through GnuPG so we refer to its documentation for the full reference.
+
+The default PIN set is ‘123456’ and the default admin PIN is ‘12345678’, these should be change through link:https://developers.yubico.com/PGP/Card_edit.html[Card edit].
 
 == Software with OpenPGP Card support
 

--- a/content/PGP/index.adoc
+++ b/content/PGP/index.adoc
@@ -14,7 +14,7 @@ PGP has the following advantages:
 
 The OpenPGP functionality of YubiKeys is typically used through GnuPG so we refer to its documentation for the full reference.
 
-The default PIN set is ‘123456’ and the default admin PIN is ‘12345678’, these should be change through link:https://developers.yubico.com/PGP/Card_edit.html[Card edit].
+The default PIN set is ‘123456’ and the default admin PIN is ‘12345678’, these should be changed, see link:https://developers.yubico.com/PGP/Card_edit.html[Card edit].
 
 == Software with OpenPGP Card support
 


### PR DESCRIPTION
Add a small blurb on OpenPGP usage with Yubikeys, primarly to document
the default pin codes.