### PR TITLE
pgp: Add blurb on key size limits.

### DIFF
--- a/content/PGP/Importing_keys.adoc
+++ b/content/PGP/Importing_keys.adoc
@@ -38,8 +38,9 @@ Please select what kind of key you want:
 Your selection?
 ....
 
-YubiKey NEO currently only supports RSA keys of 2048 bits length. So
-here we select 1, and go with the default of 2048 bits on the next question.
+As there are key size and type limits depending on the type of your YubiKey, see
+the link:https://www.yubico.com/products/yubikey-hardware/[comparison page],
+we will select option 1, and go with the default of 2048 bits for the next question.
 
 ....
 RSA keys may be between 1024 and 4096 bits long.


### PR DESCRIPTION
Link to the comparison page, but stick with the default of 2048.

Addresses #28