### PR TITLE
Use --key in place of -K

### DIFF
--- a/content/PIV/Guides/Device_setup.adoc
+++ b/content/PIV/Guides/Device_setup.adoc
@@ -23,14 +23,14 @@ link:/yubikey-piv-manager/PIN_and_Management_Key.html[PIN and Management Key].
 
 === Using yubico-piv-tool for device setup
 The Management Key is set by invoking the `set-mgm-key` action. You will need
-to provide the currently set Management Key (using `-K`), and the new key to
+to provide the currently set Management Key (using `--key`), and the new key to
 set (using `-n`). If the default Management Key is currently set you may omit
-the `-K` argument. Keys are provided as 24-byte hex strings, and should be
+the `--key` argument. Keys are provided as 24-byte hex strings, and should be
 randomly generated.
 
   $ key=`dd if=/dev/random bs=1 count=24 2>/dev/null | hexdump -v -e '/1 "%02X"'`
   $ echo $key
-  $ yubico-piv-tool -a set-mgm-key -n $key -K 010203040506070801020304050607080102030405060708
+  $ yubico-piv-tool -a set-mgm-key -n $key --key 010203040506070801020304050607080102030405060708
 
 Changing the PIN is done by invoking the `change-pin` action and providing the
 current PIN (using the `-P` argument), and a new PIN to set (using `-N`).


### PR DESCRIPTION
The `-K` flag is shorthand for `--key-format`, so the instructions as written produced an error. The documentation probably meant to use `-k`, but the long-form `--key` is clearer.