### PR TITLE
Fix merge's signing option in PGP/Git_signing

### DIFF
--- a/content/PGP/Git_signing.adoc
+++ b/content/PGP/Git_signing.adoc
@@ -146,7 +146,7 @@ $ git merge --verify-signatures other_branch
 
 If the signatures can not be verified, the merge will be aborted.
 
-Similarly, the `-s` switch can be used to sign the commit resulting from a merge.
+Similarly, the `-S` switch can be used to sign the commit resulting from a merge.
 
 Also, if you created _annotated_ tags, when you merge them Git will create a new commit for you. During this process it will also verify the invovled signatures and include the verification output in the comment of the commit message.
 


### PR DESCRIPTION
The `-s` switch of `git merge` is a shorthand for `--strategy`,
while `--gpg-sign` shortens to `-S` (the same as with `git commit`.)