### PR TITLE
software projects: Drop lists of 3rd party repositories.

### DIFF
--- a/content/OATH/Server_libraries.adoc
+++ b/content/OATH/Server_libraries.adoc
@@ -1,4 +1,0 @@
-== OATH Server libraries ==
-C and PAM:: http://www.nongnu.org/oath-toolkit[OATH Toolkit]
-DotNET:: https://github.com/jennings/OATH.Net[OATH.Net]
-Python:: https://pypi.python.org/pypi/oath[oath]

--- a/content/Software_Projects/FIDO_U2F/U2F_Integration_Plug-ins/index.adoc
+++ b/content/Software_Projects/FIDO_U2F/U2F_Integration_Plug-ins/index.adoc
@@ -1,11 +1,6 @@
 == U2F Integration Plug-ins
 These plug-ins let you integrate U2F support into existing systems.
 
-=== By Yubico ===
 PAM:: link:/pam-u2f[pam-u2f]
 
-=== By others ===
-Django:: https://github.com/gavinwahl/django-u2f[django-u2f]
-Flask:: https://github.com/herrjemand/flask-fido-u2f[flask-fido-u2f]
-Ruby on Rails:: https://github.com/TwoFactorAuth/ruby[TwoFactorAuth]
-WordPress:: https://github.com/georgestephanis/two-factor[two-factor]
+Third party plugins can be discovered on link:https://github.com/search?q=u2f[GitHub] for example.

--- a/content/Software_Projects/FIDO_U2F/U2F_Server_Libraries/index.adoc
+++ b/content/Software_Projects/FIDO_U2F/U2F_Server_Libraries/index.adoc
@@ -3,18 +3,9 @@ These libraries deal with the low level primitives of the U2F protocol and are
 a good starting point for anyone intending to implement their own U2F server.
 Learn how to use a U2F server library link:/U2F/Libraries/Using_a_library.html[here].
 
-=== By Yubico
 C:: link:/libu2f-server/[libu2f-server]
 Java:: link:/java-u2flib-server/[java-u2flib-server]
 PHP:: link:/php-u2flib-server/[php-u2flib-server]
 Python:: link:/python-u2flib-server/[python-u2flib-server]
 
-=== By others
-C#:: https://github.com/brucedog/u2flib[u2flib]
-Go:: https://github.com/tstranex/u2f[Go FIDO U2F]
-JavaScript:: https://github.com/ashtuchkin/u2f[u2f]
-Perl:: https://metacpan.org/pod/Authen::U2F[Authen::U2F]
-Ruby:: https://github.com/userbin/ruby-u2f[ruby-u2f]
-Ruby:: https://github.com/TwoFactorAuth/ruby[TwoFactorAuth]
-Rust:: https://github.com/wisespace-io/yubico-rs[yubico-rs]
-
+Third party implementations can be discovered on link:https://github.com/search?q=u2f[GitHub] for example.

--- a/content/Software_Projects/YubiHSM/index.adoc
+++ b/content/Software_Projects/YubiHSM/index.adoc
@@ -2,9 +2,6 @@
 Libraries and utilities for use with the
 https://www.yubico.com/products/yubihsm/[YubiHSM].
 
-=== By Yubico
-
 Python:: link:/python-pyhsm/[python-pyhsm]
 
-=== By others
-Java:: https://github.com/UnitedID/YubiHSM-java-api[YubiHSM-java-api]
+Third party implementations can be discovered on link:https://github.com/search?q=yubihsm[GitHub] for example.

--- a/content/Software_Projects/Yubico_OTP/YubiCloud_Connector_Libraries/index.adoc
+++ b/content/Software_Projects/Yubico_OTP/YubiCloud_Connector_Libraries/index.adoc
@@ -3,8 +3,6 @@ These libraries help with connecting to the YubiCloud for Yubico OTP
 validation from a number of different programming languages. Learn how to use a
 connector library link:/OTP/Libraries/Using_a_library.html[here].
 
-=== By Yubico ===
-
 PHP:: link:/php-yubico/[php-yubico]
 C:: link:/yubico-c-client/[yubico-c-client]
 Java:: link:/yubico-java-client/[yubico-java-client]
@@ -13,12 +11,4 @@ Perl:: link:/yubico-perl-client/[yubico-perl-client]
 Salesforce/Apex:: link:/yubikey-salesforce-client/[yubikey-salesforce-client]
 Windows:: link:/windows-apis[COM API]
 
-=== Third-party ===
-
-Python:: https://github.com/Kami/python-yubico-client[python-yubico-client]
-Ruby:: https://github.com/titanous/yubikey[yubikey]
-PHP:: https://github.com/enygma/yubikey[yubikey]
-Node.js:: https://github.com/Kami/node-yubico/blob/master/lib/yubico.js[node-yubico]
-Node.js:: https://www.npmjs.com/package/yub[yub]
-Go:: https://github.com/GeertJohan/yubigo[Yubigo]
-Erlang:: https://github.com/fredrikt/erlang-yubico[erlang-yubico]
+Third party implementations can be discovered on link:https://github.com/search?q=yubico+client[GitHub] for example.

--- a/content/Software_Projects/Yubico_OTP/YubiCloud_Validation_Servers/index.adoc
+++ b/content/Software_Projects/Yubico_OTP/YubiCloud_Validation_Servers/index.adoc
@@ -1,10 +1,7 @@
 == YubiCloud Validation Servers
 If you don't want to use YubiCloud, you can host one of these validation server(s) yourself.
 
-=== By Yubico
 PHP validation server:: link:/yubikey-val/[yubikey-val]
 PHP key storage module:: link:/yubikey-ksm/[yubikey-ksm]
 
-=== By others
-Go validation server:: https://github.com/digintLab/yubikey-server[yubikey-server]
-Python validation server:: https://github.com/scumjr/yubikeyedup[YubiKeyedUp]
+Third party implementations can be discovered on link:https://github.com/search?q=yubicloud+validation[GitHub] for example.

--- a/content/Software_Projects/Yubico_OTP/Yubico_OTP_Codec_Libraries/index.adoc
+++ b/content/Software_Projects/Yubico_OTP/Yubico_OTP_Codec_Libraries/index.adoc
@@ -1,9 +1,7 @@
 == Yubico OTP Codec Libraries
 Libraries for encoding and decoding the Yubico OTP format.
 
-=== By Yubico
 C:: link:/yubico-c/[yubico-c]
 Java:: link:/yubico-j/[yubico-j]
 
-=== By others
-Ruby:: https://github.com/titanous/yubikey[yubikey]
+Third implementations can be discovered on link:https://github.com/search?q=yubico+otp[GitHub] for example.

--- a/content/Software_Projects/Yubico_OTP/Yubico_OTP_Integration_Plug-ins/index.adoc
+++ b/content/Software_Projects/Yubico_OTP/Yubico_OTP_Integration_Plug-ins/index.adoc
@@ -1,9 +1,6 @@
 == Yubico OTP Integration Plug-ins
 These plug-ins let you integrate Yubico OTP support into existing systems.
 
-
-=== By Yubico
-
 Windows login:: link:/yubico-windows-auth[yubico-windows-auth]
 YubiAuth:: link:/yubiauth[yubiauth]
 PAM module:: link:/yubico-pam[yubico-pam]
@@ -11,13 +8,4 @@ FreeRADIUS:: link:/rlm-yubico[rlm-yubico]
 Shibboleth:: https://github.com/Yubico/yubico-shibboleth-idp-multifactor-login-handler[yubico-shibboleth]
 JAAS:: link:/yubico-java-client[yubico-java-client]
 
-
-=== By others
-
-Wordpress:: https://wordpress.org/plugins/yubikey-plugin/[yubikey-plugin]
-Drupal:: https://www.drupal.org/project/yubikey[YubiKey]
-Django:: https://pypi.python.org/pypi/django-otp-yubikey[django-otp-yubikey]
-phpBB:: https://github.com/Yubico/phpbb3_yubikey_login[joomla-yubikey-authentication]
-Symfony:: https://packagist.org/packages/surfnet/yubikey-api-client-bundle[yubikey-api-client]
-Typo3:: http://typo3.org/extensions/repository/view/sf_yubikey[sf_yubikey]
-Wagtail:: https://github.com/ahopkins/wagtail-yubikey[wagtail-yubikey]
+Third party plugins can be discovered on link:https://github.com/search?q=yubico+otp[GitHub] for example.


### PR DESCRIPTION
Maintaining and verifying the list of 3rd party plugins hasn't been as great as we'd like it be,
and since there isn't enough bandwidth to accept links to all projects we get notified about
it seems fairer to simply link to GitHub searches.