### PR TITLE
Add -sha256 flag to OpenSSL verify operation

### DIFF
--- a/content/YubiHSM2/Usage_Guides/YubiHSM_quick_start_tutorial.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM_quick_start_tutorial.adoc
@@ -141,7 +141,7 @@ We are going to use OpenSSL for the verification process. Since the signature th
 
 It is now possible to verify the signature with OpenSSL
 
-  $ openssl dgst -signature signature.bin -verify asymmetric_key.pub data.sha
+  $ openssl dgst -sha256 -signature signature.bin -verify asymmetric_key.pub data.sha
   Verified OK
 
 === Export Under Wrap


### PR DESCRIPTION
On my system, I was not able to verify the ECDSA signature until I added the "-sha256" flag to openssl. This matches with the earlier invocation of "openssl dgst".

```
nmooney:bin $ openssl dgst -signature sig.bin -verify mooney.pub data.sha
Verification Failure
nmooney:bin $ openssl dgst -sha256 -signature sig.bin -verify mooney.pub data.sha
Verified OK
```