### PR TITLE
Include hex

### DIFF
--- a/content/YubiHSM2/Concepts/Algorithms.adoc
+++ b/content/YubiHSM2/Concepts/Algorithms.adoc
@@ -2,52 +2,52 @@
 
 [options="header"]
 |=================================
-|Name | Value | yubihsm-shell name | Comment
-|RSA PKCS1 SHA1 | 1 | rsa-pkcs1-sha1 |
-|RSA PKCS1 SHA256 | 2 | rsa-pkcs1-sha256 |
-|RSA PKCS1 SHA384 | 3 | rsa-pkcs1-sha384 |
-|RSA PKCS1 SHA512 | 4 | rsa-pkcs1-sha512 |
-|RSA PSS SHA1 | 5 | rsa-pss-sha1 |
-|RSA PSS SHA256 | 6 | rsa-pss-sha256 |
-|RSA PSS SHA384 | 7 | rsa-pss-sha384 |
-|RSA PSS SHA512 | 8 | rsa-pss-sha512 |
-|RSA 2048 | 9 | rsa2048 |
-|RSA 3072 | 10 | rsa3072 |
-|RSA 4096 | 11 | rsa4096 |
-|EC P256 | 12 | ecp256 | secp256r1
-|EC P384 | 13 | ecp384 | secp384r1
-|EC P521 | 14 | ecp521 | secp521r1
-|EC K256 | 15 | eck256 | secp256k1
-|EC BP256 | 16 | ecbp256 | brainpool256r1
-|EC BP384 | 17 | ecbp384 | brainpool384r1
-|EC BP512 | 18 | ecbp512 | brainpool512r1
-|HMAC SHA1 | 19 | hmac-sha1 |
-|HMAC SHA256 | 20 | hmac-sha256 |
-|HMAC SHA384 | 21 | hmac-sha384 |
-|HMAC SHA512 | 22 | hmac-sha512 |
-|ECDSA SHA1 | 23 | ecdsa-sha1 |
-|EC ECDH | 24 | ecdh |
-|RSA OAEP SHA1 | 25 | rsa-oaep-sha1 |
-|RSA OAEP SHA256 | 26 | rsa-oaep-sha256 |
-|RSA OAEP SHA384 | 27 | rsa-oaep-sha384 |
-|RSA OAEP SHA512 | 28 | rsa-oaep-sha512 |
-|AES128 CCM WRAP | 29 | aes128-ccm-wrap |
-|OPAQUE DATA | 30 | opaque |
-|OPAQUE X509 CERT | 31 | x509-cert |
-|MGF1 SHA1 | 32 | mgf1-sha1 |
-|MGF1 SHA256 | 33 | mgf1-sha256 |
-|MGF1 SHA384 | 34 | mgf1-sha384 |
-|MGF1 SHA512 | 35 | mgf1-sha512 |
-|SSH Template | 36 | template-ssh |
-|Yubico OTP AES128 | 37 | yubico-otp-aes128 |
-|YUBICO AES AUTH | 38 | yubico-aes-auth |
-|Yubico OTP AES192 | 39 | yubico-otp-aes192 |
-|Yubico OTP AES256 | 40 | yubico-otp-aes256 |
-|AES192 CCM WRAP | 41 | aes192-ccm-wrap |
-|AES256 CCM WRAP | 42 | aes256-ccm-wrap |
-|ECDSA SHA256 | 43 | ecdsa-sha256 |
-|ECDSA SHA384 | 44 | ecdsa-sha384 |
-|ECDSA SHA512 | 45 | ecdsa-sha512 |
-|ED25519 | 46 | ed25519 |
-|EC P224 | 47 | ecp224 | secp224r1
+|Name | Dec Value | Hex Value | yubihsm-shell name | Comment
+|RSA PKCS1 SHA1 | 1 | 0x1 | rsa-pkcs1-sha1 |
+|RSA PKCS1 SHA256 | 2 | 0x2| rsa-pkcs1-sha256 |
+|RSA PKCS1 SHA384 | 3 | 0x3| rsa-pkcs1-sha384 |
+|RSA PKCS1 SHA512 | 4 | 0x4 | rsa-pkcs1-sha512 |
+|RSA PSS SHA1 | 5 | 0x5 | rsa-pss-sha1 |
+|RSA PSS SHA256 | 6 | 0x6 | rsa-pss-sha256 |
+|RSA PSS SHA384 | 7 | 0x7 | rsa-pss-sha384 |
+|RSA PSS SHA512 | 8 | 0x8 | rsa-pss-sha512 |
+|RSA 2048 | 9 | 0x9 | rsa2048 |
+|RSA 3072 | 10 | 0xa | rsa3072 |
+|RSA 4096 | 11 | 0xb | rsa4096 |
+|EC P256 | 12 | 0xc | ecp256 | secp256r1
+|EC P384 | 13 | 0xd | ecp384 | secp384r1
+|EC P521 | 14 | 0xe | ecp521 | secp521r1
+|EC K256 | 15 | 0xf | eck256 | secp256k1
+|EC BP256 | 16 |0x10 | ecbp256 | brainpool256r1
+|EC BP384 | 17 |0x11 | ecbp384 | brainpool384r1
+|EC BP512 | 18 | 0x12 | ecbp512 | brainpool512r1
+|HMAC SHA1 | 19 | 0x13 | hmac-sha1 |
+|HMAC SHA256 | 20 | 0x14 | hmac-sha256 |
+|HMAC SHA384 | 21 | 0x15 | hmac-sha384 |
+|HMAC SHA512 | 22 | 0x16 | hmac-sha512 |
+|ECDSA SHA1 | 23 | 0x17 | ecdsa-sha1 |
+|EC ECDH | 24 | 0x18 | ecdh |
+|RSA OAEP SHA1 | 25 | 0x19 | rsa-oaep-sha1 |
+|RSA OAEP SHA256 | 26 | 0x1a | rsa-oaep-sha256 |
+|RSA OAEP SHA384 | 27 | 0x1b | rsa-oaep-sha384 |
+|RSA OAEP SHA512 | 28 | 0x1c | rsa-oaep-sha512 |
+|AES128 CCM WRAP | 29 | 0x1d | aes128-ccm-wrap |
+|OPAQUE DATA | 30 | 0x1e | opaque |
+|OPAQUE X509 CERT | 31 | 0x1f | x509-cert |
+|MGF1 SHA1 | 32 | 0x20 | mgf1-sha1 |
+|MGF1 SHA256 | 33 | 0x21 | mgf1-sha256 |
+|MGF1 SHA384 | 34 | 0x22 | mgf1-sha384 |
+|MGF1 SHA512 | 35 | 0x23 | mgf1-sha512 |
+|SSH Template | 36 | 0x24 | template-ssh |
+|Yubico OTP AES128 | 37 | 0x25 | yubico-otp-aes128 |
+|YUBICO AES AUTH | 38 | 0x26 | yubico-aes-auth |
+|Yubico OTP AES192 | 39 | 0x27 | yubico-otp-aes192 |
+|Yubico OTP AES256 | 40 | 0x28 | yubico-otp-aes256 |
+|AES192 CCM WRAP | 41 | 0x29 | aes192-ccm-wrap |
+|AES256 CCM WRAP | 42 | 0x2a| aes256-ccm-wrap |
+|ECDSA SHA256 | 43 | 0x2b | ecdsa-sha256 |
+|ECDSA SHA384 | 44 | 0x2c | ecdsa-sha384 |
+|ECDSA SHA512 | 45 | 0x2d | ecdsa-sha512 |
+|ED25519 | 46 | 0x2e | ed25519 |
+|EC P224 | 47 | 0x2f | ecp224 | secp224r1
 |=================================


### PR DESCRIPTION
We use hex in the documentation for other enumerations (e.g. capabilities, object type), but here we use decimal. 

Suggest we either switch to hex here for consistency or include both hex and dec.