### PR TITLE
libfido2: prepend mandoc css

### DIFF
--- a/content/projects/libfido2/Manuals/es256_pk.partial
+++ b/content/projects/libfido2/Manuals/es256_pk.partial
@@ -1,3 +1,15 @@
+<style>
+    table.head, table.foot { width: 100%; }
+    td.head-rtitle, td.foot-os { text-align: right; }
+    td.head-vol { text-align: center; }
+    div.Pp { margin: 1ex 0ex; }
+    div.Nd, div.Bf, div.Op { display: inline; }
+    span.Pa, span.Ad { font-style: italic; }
+    span.Ms { font-weight: bold; }
+    dl.Bl-diag > dt { font-weight: bold; }
+    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
+    code.Cd { font-weight: bold; font-family: inherit; }
+</style>
 <table class="head">
   <tr>
     <td class="head-ltitle">ES256_PK(3)</td>

--- a/content/projects/libfido2/Manuals/fido.partial
+++ b/content/projects/libfido2/Manuals/fido.partial
@@ -1,3 +1,15 @@
+<style>
+    table.head, table.foot { width: 100%; }
+    td.head-rtitle, td.foot-os { text-align: right; }
+    td.head-vol { text-align: center; }
+    div.Pp { margin: 1ex 0ex; }
+    div.Nd, div.Bf, div.Op { display: inline; }
+    span.Pa, span.Ad { font-style: italic; }
+    span.Ms { font-weight: bold; }
+    dl.Bl-diag > dt { font-weight: bold; }
+    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
+    code.Cd { font-weight: bold; font-family: inherit; }
+</style>
 <table class="head">
   <tr>
     <td class="head-ltitle">FIDO(3)</td>

--- a/content/projects/libfido2/Manuals/fido2-assert.partial
+++ b/content/projects/libfido2/Manuals/fido2-assert.partial
@@ -1,3 +1,15 @@
+<style>
+    table.head, table.foot { width: 100%; }
+    td.head-rtitle, td.foot-os { text-align: right; }
+    td.head-vol { text-align: center; }
+    div.Pp { margin: 1ex 0ex; }
+    div.Nd, div.Bf, div.Op { display: inline; }
+    span.Pa, span.Ad { font-style: italic; }
+    span.Ms { font-weight: bold; }
+    dl.Bl-diag > dt { font-weight: bold; }
+    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
+    code.Cd { font-weight: bold; font-family: inherit; }
+</style>
 <table class="head">
   <tr>
     <td class="head-ltitle">FIDO2-ASSERT(1)</td>

--- a/content/projects/libfido2/Manuals/fido2-cred.partial
+++ b/content/projects/libfido2/Manuals/fido2-cred.partial
@@ -1,3 +1,15 @@
+<style>
+    table.head, table.foot { width: 100%; }
+    td.head-rtitle, td.foot-os { text-align: right; }
+    td.head-vol { text-align: center; }
+    div.Pp { margin: 1ex 0ex; }
+    div.Nd, div.Bf, div.Op { display: inline; }
+    span.Pa, span.Ad { font-style: italic; }
+    span.Ms { font-weight: bold; }
+    dl.Bl-diag > dt { font-weight: bold; }
+    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
+    code.Cd { font-weight: bold; font-family: inherit; }
+</style>
 <table class="head">
   <tr>
     <td class="head-ltitle">FIDO2-CRED(1)</td>

--- a/content/projects/libfido2/Manuals/fido2-token.partial
+++ b/content/projects/libfido2/Manuals/fido2-token.partial
@@ -1,3 +1,15 @@
+<style>
+    table.head, table.foot { width: 100%; }
+    td.head-rtitle, td.foot-os { text-align: right; }
+    td.head-vol { text-align: center; }
+    div.Pp { margin: 1ex 0ex; }
+    div.Nd, div.Bf, div.Op { display: inline; }
+    span.Pa, span.Ad { font-style: italic; }
+    span.Ms { font-weight: bold; }
+    dl.Bl-diag > dt { font-weight: bold; }
+    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
+    code.Cd { font-weight: bold; font-family: inherit; }
+</style>
 <table class="head">
   <tr>
     <td class="head-ltitle">FIDO2-TOKEN(1)</td>

--- a/content/projects/libfido2/Manuals/fido_assert.partial
+++ b/content/projects/libfido2/Manuals/fido_assert.partial
@@ -1,3 +1,15 @@
+<style>
+    table.head, table.foot { width: 100%; }
+    td.head-rtitle, td.foot-os { text-align: right; }
+    td.head-vol { text-align: center; }
+    div.Pp { margin: 1ex 0ex; }
+    div.Nd, div.Bf, div.Op { display: inline; }
+    span.Pa, span.Ad { font-style: italic; }
+    span.Ms { font-weight: bold; }
+    dl.Bl-diag > dt { font-weight: bold; }
+    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
+    code.Cd { font-weight: bold; font-family: inherit; }
+</style>
 <table class="head">
   <tr>
     <td class="head-ltitle">FIDO_ASSERT(3)</td>

--- a/content/projects/libfido2/Manuals/fido_assert_allow_cred.partial
+++ b/content/projects/libfido2/Manuals/fido_assert_allow_cred.partial
@@ -1,3 +1,15 @@
+<style>
+    table.head, table.foot { width: 100%; }
+    td.head-rtitle, td.foot-os { text-align: right; }
+    td.head-vol { text-align: center; }
+    div.Pp { margin: 1ex 0ex; }
+    div.Nd, div.Bf, div.Op { display: inline; }
+    span.Pa, span.Ad { font-style: italic; }
+    span.Ms { font-weight: bold; }
+    dl.Bl-diag > dt { font-weight: bold; }
+    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
+    code.Cd { font-weight: bold; font-family: inherit; }
+</style>
 <table class="head">
   <tr>
     <td class="head-ltitle">FIDO_ASSERT_ALLOW_CRED(3)</td>

--- a/content/projects/libfido2/Manuals/fido_assert_set.partial
+++ b/content/projects/libfido2/Manuals/fido_assert_set.partial
@@ -1,3 +1,15 @@
+<style>
+    table.head, table.foot { width: 100%; }
+    td.head-rtitle, td.foot-os { text-align: right; }
+    td.head-vol { text-align: center; }
+    div.Pp { margin: 1ex 0ex; }
+    div.Nd, div.Bf, div.Op { display: inline; }
+    span.Pa, span.Ad { font-style: italic; }
+    span.Ms { font-weight: bold; }
+    dl.Bl-diag > dt { font-weight: bold; }
+    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
+    code.Cd { font-weight: bold; font-family: inherit; }
+</style>
 <table class="head">
   <tr>
     <td class="head-ltitle">FIDO_ASSERT_SET(3)</td>

--- a/content/projects/libfido2/Manuals/fido_assert_verify.partial
+++ b/content/projects/libfido2/Manuals/fido_assert_verify.partial
@@ -1,3 +1,15 @@
+<style>
+    table.head, table.foot { width: 100%; }
+    td.head-rtitle, td.foot-os { text-align: right; }
+    td.head-vol { text-align: center; }
+    div.Pp { margin: 1ex 0ex; }
+    div.Nd, div.Bf, div.Op { display: inline; }
+    span.Pa, span.Ad { font-style: italic; }
+    span.Ms { font-weight: bold; }
+    dl.Bl-diag > dt { font-weight: bold; }
+    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
+    code.Cd { font-weight: bold; font-family: inherit; }
+</style>
 <table class="head">
   <tr>
     <td class="head-ltitle">FIDO_ASSERT_VERIFY(3)</td>

--- a/content/projects/libfido2/Manuals/fido_cbor_info.partial
+++ b/content/projects/libfido2/Manuals/fido_cbor_info.partial
@@ -1,3 +1,15 @@
+<style>
+    table.head, table.foot { width: 100%; }
+    td.head-rtitle, td.foot-os { text-align: right; }
+    td.head-vol { text-align: center; }
+    div.Pp { margin: 1ex 0ex; }
+    div.Nd, div.Bf, div.Op { display: inline; }
+    span.Pa, span.Ad { font-style: italic; }
+    span.Ms { font-weight: bold; }
+    dl.Bl-diag > dt { font-weight: bold; }
+    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
+    code.Cd { font-weight: bold; font-family: inherit; }
+</style>
 <table class="head">
   <tr>
     <td class="head-ltitle">FIDO_CBOR_INFO(3)</td>

--- a/content/projects/libfido2/Manuals/fido_cred.partial
+++ b/content/projects/libfido2/Manuals/fido_cred.partial
@@ -1,3 +1,15 @@
+<style>
+    table.head, table.foot { width: 100%; }
+    td.head-rtitle, td.foot-os { text-align: right; }
+    td.head-vol { text-align: center; }
+    div.Pp { margin: 1ex 0ex; }
+    div.Nd, div.Bf, div.Op { display: inline; }
+    span.Pa, span.Ad { font-style: italic; }
+    span.Ms { font-weight: bold; }
+    dl.Bl-diag > dt { font-weight: bold; }
+    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
+    code.Cd { font-weight: bold; font-family: inherit; }
+</style>
 <table class="head">
   <tr>
     <td class="head-ltitle">FIDO_CRED(3)</td>

--- a/content/projects/libfido2/Manuals/fido_cred_exclude.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_exclude.partial
@@ -1,3 +1,15 @@
+<style>
+    table.head, table.foot { width: 100%; }
+    td.head-rtitle, td.foot-os { text-align: right; }
+    td.head-vol { text-align: center; }
+    div.Pp { margin: 1ex 0ex; }
+    div.Nd, div.Bf, div.Op { display: inline; }
+    span.Pa, span.Ad { font-style: italic; }
+    span.Ms { font-weight: bold; }
+    dl.Bl-diag > dt { font-weight: bold; }
+    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
+    code.Cd { font-weight: bold; font-family: inherit; }
+</style>
 <table class="head">
   <tr>
     <td class="head-ltitle">FIDO_CRED_EXCLUDE(3)</td>

--- a/content/projects/libfido2/Manuals/fido_cred_set.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_set.partial
@@ -1,3 +1,15 @@
+<style>
+    table.head, table.foot { width: 100%; }
+    td.head-rtitle, td.foot-os { text-align: right; }
+    td.head-vol { text-align: center; }
+    div.Pp { margin: 1ex 0ex; }
+    div.Nd, div.Bf, div.Op { display: inline; }
+    span.Pa, span.Ad { font-style: italic; }
+    span.Ms { font-weight: bold; }
+    dl.Bl-diag > dt { font-weight: bold; }
+    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
+    code.Cd { font-weight: bold; font-family: inherit; }
+</style>
 <table class="head">
   <tr>
     <td class="head-ltitle">FIDO_CRED_SET(3)</td>

--- a/content/projects/libfido2/Manuals/fido_cred_verify.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_verify.partial
@@ -1,3 +1,15 @@
+<style>
+    table.head, table.foot { width: 100%; }
+    td.head-rtitle, td.foot-os { text-align: right; }
+    td.head-vol { text-align: center; }
+    div.Pp { margin: 1ex 0ex; }
+    div.Nd, div.Bf, div.Op { display: inline; }
+    span.Pa, span.Ad { font-style: italic; }
+    span.Ms { font-weight: bold; }
+    dl.Bl-diag > dt { font-weight: bold; }
+    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
+    code.Cd { font-weight: bold; font-family: inherit; }
+</style>
 <table class="head">
   <tr>
     <td class="head-ltitle">FIDO_CRED_VERIFY(3)</td>

--- a/content/projects/libfido2/Manuals/fido_dev_get_assert.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_get_assert.partial
@@ -1,3 +1,15 @@
+<style>
+    table.head, table.foot { width: 100%; }
+    td.head-rtitle, td.foot-os { text-align: right; }
+    td.head-vol { text-align: center; }
+    div.Pp { margin: 1ex 0ex; }
+    div.Nd, div.Bf, div.Op { display: inline; }
+    span.Pa, span.Ad { font-style: italic; }
+    span.Ms { font-weight: bold; }
+    dl.Bl-diag > dt { font-weight: bold; }
+    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
+    code.Cd { font-weight: bold; font-family: inherit; }
+</style>
 <table class="head">
   <tr>
     <td class="head-ltitle">FIDO_DEV_GET_ASSERT(3)</td>

--- a/content/projects/libfido2/Manuals/fido_dev_info_manifest.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_info_manifest.partial
@@ -1,3 +1,15 @@
+<style>
+    table.head, table.foot { width: 100%; }
+    td.head-rtitle, td.foot-os { text-align: right; }
+    td.head-vol { text-align: center; }
+    div.Pp { margin: 1ex 0ex; }
+    div.Nd, div.Bf, div.Op { display: inline; }
+    span.Pa, span.Ad { font-style: italic; }
+    span.Ms { font-weight: bold; }
+    dl.Bl-diag > dt { font-weight: bold; }
+    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
+    code.Cd { font-weight: bold; font-family: inherit; }
+</style>
 <table class="head">
   <tr>
     <td class="head-ltitle">FIDO_DEV_INFO_MANIFEST(3)</td>

--- a/content/projects/libfido2/Manuals/fido_dev_make_cred.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_make_cred.partial
@@ -1,3 +1,15 @@
+<style>
+    table.head, table.foot { width: 100%; }
+    td.head-rtitle, td.foot-os { text-align: right; }
+    td.head-vol { text-align: center; }
+    div.Pp { margin: 1ex 0ex; }
+    div.Nd, div.Bf, div.Op { display: inline; }
+    span.Pa, span.Ad { font-style: italic; }
+    span.Ms { font-weight: bold; }
+    dl.Bl-diag > dt { font-weight: bold; }
+    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
+    code.Cd { font-weight: bold; font-family: inherit; }
+</style>
 <table class="head">
   <tr>
     <td class="head-ltitle">FIDO_DEV_MAKE_CRED(3)</td>

--- a/content/projects/libfido2/Manuals/fido_dev_open.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_open.partial
@@ -1,3 +1,15 @@
+<style>
+    table.head, table.foot { width: 100%; }
+    td.head-rtitle, td.foot-os { text-align: right; }
+    td.head-vol { text-align: center; }
+    div.Pp { margin: 1ex 0ex; }
+    div.Nd, div.Bf, div.Op { display: inline; }
+    span.Pa, span.Ad { font-style: italic; }
+    span.Ms { font-weight: bold; }
+    dl.Bl-diag > dt { font-weight: bold; }
+    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
+    code.Cd { font-weight: bold; font-family: inherit; }
+</style>
 <table class="head">
   <tr>
     <td class="head-ltitle">FIDO_DEV_OPEN(3)</td>

--- a/content/projects/libfido2/Manuals/fido_dev_set_io_functions.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_set_io_functions.partial
@@ -1,3 +1,15 @@
+<style>
+    table.head, table.foot { width: 100%; }
+    td.head-rtitle, td.foot-os { text-align: right; }
+    td.head-vol { text-align: center; }
+    div.Pp { margin: 1ex 0ex; }
+    div.Nd, div.Bf, div.Op { display: inline; }
+    span.Pa, span.Ad { font-style: italic; }
+    span.Ms { font-weight: bold; }
+    dl.Bl-diag > dt { font-weight: bold; }
+    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
+    code.Cd { font-weight: bold; font-family: inherit; }
+</style>
 <table class="head">
   <tr>
     <td class="head-ltitle">FIDO_DEV_SET_IO_FUNCTIONS(3)</td>

--- a/content/projects/libfido2/Manuals/fido_dev_set_pin.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_set_pin.partial
@@ -1,3 +1,15 @@
+<style>
+    table.head, table.foot { width: 100%; }
+    td.head-rtitle, td.foot-os { text-align: right; }
+    td.head-vol { text-align: center; }
+    div.Pp { margin: 1ex 0ex; }
+    div.Nd, div.Bf, div.Op { display: inline; }
+    span.Pa, span.Ad { font-style: italic; }
+    span.Ms { font-weight: bold; }
+    dl.Bl-diag > dt { font-weight: bold; }
+    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
+    code.Cd { font-weight: bold; font-family: inherit; }
+</style>
 <table class="head">
   <tr>
     <td class="head-ltitle">FIDO_DEV_SET_PIN(3)</td>

--- a/content/projects/libfido2/Manuals/fido_strerr.partial
+++ b/content/projects/libfido2/Manuals/fido_strerr.partial
@@ -1,3 +1,15 @@
+<style>
+    table.head, table.foot { width: 100%; }
+    td.head-rtitle, td.foot-os { text-align: right; }
+    td.head-vol { text-align: center; }
+    div.Pp { margin: 1ex 0ex; }
+    div.Nd, div.Bf, div.Op { display: inline; }
+    span.Pa, span.Ad { font-style: italic; }
+    span.Ms { font-weight: bold; }
+    dl.Bl-diag > dt { font-weight: bold; }
+    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
+    code.Cd { font-weight: bold; font-family: inherit; }
+</style>
 <table class="head">
   <tr>
     <td class="head-ltitle">FIDO_STRERR(3)</td>

--- a/content/projects/libfido2/Manuals/rs256_pk.partial
+++ b/content/projects/libfido2/Manuals/rs256_pk.partial
@@ -1,3 +1,15 @@
+<style>
+    table.head, table.foot { width: 100%; }
+    td.head-rtitle, td.foot-os { text-align: right; }
+    td.head-vol { text-align: center; }
+    div.Pp { margin: 1ex 0ex; }
+    div.Nd, div.Bf, div.Op { display: inline; }
+    span.Pa, span.Ad { font-style: italic; }
+    span.Ms { font-weight: bold; }
+    dl.Bl-diag > dt { font-weight: bold; }
+    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
+    code.Cd { font-weight: bold; font-family: inherit; }
+</style>
 <table class="head">
   <tr>
     <td class="head-ltitle">RS256_PK(3)</td>


### PR DESCRIPTION
fixes mangled synopsis sections, and improves overall readability.