### PR TITLE
Add metadata for YK5 and SKY3

### DIFF
--- a/static/U2F/yubico-metadata.json
+++ b/static/U2F/yubico-metadata.json
@@ -1,6 +1,6 @@
 {
   "identifier": "2fb54029-7613-4f1d-94f1-fb876c14a6fe",
-  "version": 4,
+  "version": 5,
   "vendorInfo": {
     "url": "https://yubico.com",
     "imageUrl": "https://developers.yubico.com/U2F/Images/yubico.png",
@@ -10,6 +10,26 @@
     "-----BEGIN CERTIFICATE-----\nMIIDHjCCAgagAwIBAgIEG1BT9zANBgkqhkiG9w0BAQsFADAuMSwwKgYDVQQDEyNZ\ndWJpY28gVTJGIFJvb3QgQ0EgU2VyaWFsIDQ1NzIwMDYzMTAgFw0xNDA4MDEwMDAw\nMDBaGA8yMDUwMDkwNDAwMDAwMFowLjEsMCoGA1UEAxMjWXViaWNvIFUyRiBSb290\nIENBIFNlcmlhbCA0NTcyMDA2MzEwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK\nAoIBAQC/jwYuhBVlqaiYWEMsrWFisgJ+PtM91eSrpI4TK7U53mwCIawSDHy8vUmk\n5N2KAj9abvT9NP5SMS1hQi3usxoYGonXQgfO6ZXyUA9a+KAkqdFnBnlyugSeCOep\n8EdZFfsaRFtMjkwz5Gcz2Py4vIYvCdMHPtwaz0bVuzneueIEz6TnQjE63Rdt2zbw\nnebwTG5ZybeWSwbzy+BJ34ZHcUhPAY89yJQXuE0IzMZFcEBbPNRbWECRKgjq//qT\n9nmDOFVlSRCt2wiqPSzluwn+v+suQEBsUjTGMEd25tKXXTkNW21wIWbxeSyUoTXw\nLvGS6xlwQSgNpk2qXYwf8iXg7VWZAgMBAAGjQjBAMB0GA1UdDgQWBBQgIvz0bNGJ\nhjgpToksyKpP9xv9oDAPBgNVHRMECDAGAQH/AgEAMA4GA1UdDwEB/wQEAwIBBjAN\nBgkqhkiG9w0BAQsFAAOCAQEAjvjuOMDSa+JXFCLyBKsycXtBVZsJ4Ue3LbaEsPY4\nMYN/hIQ5ZM5p7EjfcnMG4CtYkNsfNHc0AhBLdq45rnT87q/6O3vUEtNMafbhU6kt\nhX7Y+9XFN9NpmYxr+ekVY5xOxi8h9JDIgoMP4VB1uS0aunL1IGqrNooL9mmFnL2k\nLVVee6/VR6C5+KSTCMCWppMuJIZII2v9o4dkoZ8Y7QRjQlLfYzd3qGtKbw7xaF1U\nsG/5xUb/Btwb2X2g4InpiB/yt/3CpQXpiWX/K4mBvUKiGn05ZsqeY1gx4g0xLBqc\nU9psmyPzK+Vsgw2jeRQ5JlKDyqE0hebfC1tvFu0CCrJFcw==\n-----END CERTIFICATE-----"
   ],
   "devices": [
+    {
+      "deviceId": "1.3.6.1.4.1.41482.1.1",
+      "displayName": "Security Key NFC by Yubico",
+      "transports": 12,
+      "deviceUrl": "https://www.yubico.com/product/security-key-nfc-by-yubico/",
+      "imageUrl": "https://developers.yubico.com/U2F/Images/SKY-NFC.png",
+      "selectors": [
+        {
+          "type": "x509Extension",
+          "parameters": {
+            "key": "1.3.6.1.4.1.45724.1.1.4",
+            "value": {
+              "type": "hex",
+              "value": "6d44ba9bf6ec2e49b9300c8fe920cb73"
+            }
+          }
+        }
+      ]
+    },
+
     {
       "deviceId": "1.3.6.1.4.1.41482.1.1",
       "displayName": "Security Key by Yubico",
@@ -104,6 +124,44 @@
           "parameters": {
             "value": "1.3.6.1.4.1.41482.1.5",
             "key": "1.3.6.1.4.1.41482.2"
+          }
+        }
+      ]
+    },
+    {
+      "deviceId": "1.3.6.1.4.1.41482.1.7",
+      "displayName": "YubiKey 5 NFC",
+      "transports": 12,
+      "deviceUrl": "https://www.yubico.com/products/yubikey-5-overview/",
+      "imageUrl": "https://developers.yubico.com/U2F/Images/YK5.png",
+      "selectors": [
+        {
+          "type": "x509Extension",
+          "parameters": {
+            "key": "1.3.6.1.4.1.45724.1.1.4",
+            "value": {
+              "type": "hex",
+              "value": "fa2b99dc9e3942578f924a30d23c4118"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "deviceId": "1.3.6.1.4.1.41482.1.7",
+      "displayName": "YubiKey 5 Series security key",
+      "transports": 4,
+      "deviceUrl": "https://www.yubico.com/products/yubikey-5-overview/",
+      "imageUrl": "https://developers.yubico.com/U2F/Images/YK5-series.png",
+      "selectors": [
+        {
+          "type": "x509Extension",
+          "parameters": {
+            "key": "1.3.6.1.4.1.45724.1.1.4",
+            "value": {
+              "type": "hex",
+              "value": "cb69481e8ff7403993ec0a2729a154a8"
+            }
           }
         }
       ]


### PR DESCRIPTION
Copied from [java-webauthn-server](https://github.com/Yubico/java-webauthn-server/blob/12aa141bf0d4eefa5286c3f3736bf5e3071419ee/webauthn-server-attestation/src/main/resources/metadata.json). Fixes #166.