### PR TITLE
piv: mac-friendly secret generation

### DIFF
--- a/content/PIV/Guides/Certificate_authority.adoc
+++ b/content/PIV/Guides/Certificate_authority.adoc
@@ -91,11 +91,11 @@ This step is parametrized with the name of the YubiKey user.
 Generate new management code, PIN and PUK as follows:
 
   $ user=Simon
-  $ key=`dd if=/dev/urandom 2>/dev/null | tr -d '[:lower:]' | tr -cd '[:xdigit:]' | fold -w48 | head -1`
+  $ key=$(export LC_CTYPE=C; dd if=/dev/urandom 2>/dev/null | tr -d '[:lower:]' | tr -cd '[:xdigit:]' | fold -w48 | head -1)
   $ echo $key > yubico-internal-https-$user-key.txt
-  $ pin=`dd if=/dev/urandom 2>/dev/null | tr -cd '[:digit:]' | fold -w6 | head -1`
+  $ pin=$(export LC_CTYPE=C; dd if=/dev/urandom 2>/dev/null | tr -cd '[:digit:]' | fold -w6 | head -1)
   $ echo $pin > yubico-internal-https-$user-pin.txt
-  $ puk=`dd if=/dev/urandom 2>/dev/null | tr -cd '[:digit:]' | fold -w8 | head -1`
+  $ puk=$(export LC_CTYPE=C; dd if=/dev/urandom 2>/dev/null | tr -cd '[:digit:]' | fold -w8 | head -1)
   $ echo $puk > yubico-internal-https-$user-puk.txt
 
 Configure a fresh YubiKey with these parameters as follows:

--- a/content/PIV/Guides/Device_setup.adoc
+++ b/content/PIV/Guides/Device_setup.adoc
@@ -28,7 +28,7 @@ set (using `--new-key`). If the default Management Key is currently set you may 
 the `--key` argument. Keys are provided as 24-byte hex strings, and should be
 randomly generated.
 
-  $ key=`dd if=/dev/urandom 2>/dev/null | tr -d '[:lower:]' | tr -cd '[:xdigit:]' | fold -w48 | head -1`
+  $ key=$(export LC_CTYPE=C; dd if=/dev/urandom 2>/dev/null | tr -d '[:lower:]' | tr -cd '[:xdigit:]' | fold -w48 | head -1)
   $ echo $key
   $ yubico-piv-tool -a set-mgm-key --new-key=$key --key=010203040506070801020304050607080102030405060708
 


### PR DESCRIPTION
MacOS's tr chokes on /dev/urandom input if LC_CTYPE != C. This
commit reflects changes to yubico-piv-tool and
yubikey-personalization.