### PR TITLE
Logging XFF-header in Apache

### DIFF
--- a/httpd.conf
+++ b/httpd.conf
@@ -29,7 +29,7 @@ ErrorLog /dev/stderr
 LogLevel warn
 
 <IfModule log_config_module>
-    LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+    LogFormat "%{X-Forwarded-For}i %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
     CustomLog /dev/stdout combined
 </IfModule>
 


### PR DESCRIPTION
Changing the Logging format for Apache so it logs the contents of the X-Forwarded-For header on each request.