### PR TITLE
Add option to serve versioned javadoc

### DIFF
--- a/content/projects/java-webauthn-server/.conf.json
+++ b/content/projects/java-webauthn-server/.conf.json
@@ -23,6 +23,7 @@
   "javadoc": {
     "groupId": "com.yubico",
     "artifactId": "webauthn-server-core",
+    "artifactIds": ["webauthn-server-attestation", "webauthn-server-core"],
     "all_versions": true
   }
 }

--- a/content/projects/java-webauthn-server/.conf.json
+++ b/content/projects/java-webauthn-server/.conf.json
@@ -22,6 +22,7 @@
   ],
   "javadoc": {
     "groupId": "com.yubico",
-    "artifactId": "webauthn-server-core"
+    "artifactId": "webauthn-server-core",
+    "all_versions": true
   }
 }

--- a/devyco/modules/javadoc.py
+++ b/devyco/modules/javadoc.py
@@ -84,35 +84,51 @@ class JavaDocModule(Module):
 
         if not up_to_date or not path.exists(javadoc_cache_path):
             if conf.get('all_versions', False) == True:
-                versions = self.get_release_versions()
-                versions.reverse()
-                for version in versions:
-                    self._extract_javadoc(
-                        path.join(javadoc_cache_path, version),
-                        version)
+                artifact_ids = conf.get('artifactIds', [self.artifact])
 
-                self._extract_javadoc(
-                    path.join(javadoc_cache_path, 'latest'),
-                    self.remote_version)
+                latest_versions = {}
+                versions = {}
+
+                for artifact_id in artifact_ids:
+                    (artifact_versions, artifact_latest) = self.get_versions(artifact_id)
+
+                    for version in artifact_versions:
+                        self._extract_javadoc(
+                            path.join(javadoc_cache_path, artifact_id, version),
+                            artifact_id,
+                            version)
+
+                        versions[version] = versions.get(version, set())
+                        versions[version].add(artifact_id)
+
+                    latest_versions[artifact_id] = artifact_latest
+
+                    self._extract_javadoc(
+                        path.join(javadoc_cache_path, artifact_id, 'latest'),
+                        artifact_id,
+                        artifact_latest)
 
                 outpath = path.join(javadoc_cache_path, 'index.partial')
                 tplt = self.get_template('javadoc-versions')
                 with open(outpath, 'w') as outfile:
                     outfile.write(tplt.render(
-                                  latest=self.remote_version,
-                                  versions=versions
-                                  ).encode('utf-8'))
+                                latest_versions=sorted(latest_versions.items()),
+                                versions=sorted([
+                                    (v, sorted(aids))
+                                    for v, aids in versions.items()
+                                ], reverse=True),
+                                ).encode('utf-8'))
 
             else:
-                self._extract_javadoc(javadoc_cache_path, self.remote_version)
+                self._extract_javadoc(javadoc_cache_path, self.artifact, self.remote_version)
 
             version_store.write(self.remote_version)
 
         shutil.copytree(javadoc_cache_path, path.join(self._target, 'JavaDoc'))
 
-    def _extract_javadoc(self, output_path, version):
+    def _extract_javadoc(self, output_path, artifact_id, version):
         url = JAVADOC_ARCHIVE_URL.format(group_url=self.group_url,
-                                         artifact=self.artifact,
+                                         artifact=artifact_id,
                                          version=version)
         jarfile = urlopen(url).read()
         zipfile = ZipFile(StringIO(jarfile))
@@ -130,15 +146,18 @@ class JavaDocModule(Module):
         self.remote_version = xmldoc.getElementsByTagName('latest')[
             0].firstChild.nodeValue
 
-    def get_release_versions(self):
+    def get_versions(self, artifact_id):
         url = HASH_URL.format(group_url=self.group_url,
-                              artifact=self.artifact)
+                              artifact=artifact_id)
         xml = urlopen(url).read()
         xmldoc = minidom.parseString(xml)
+        latest = xmldoc.getElementsByTagName('latest')[
+            0].firstChild.nodeValue
         versions = [v.firstChild.nodeValue
                     for v in xmldoc.getElementsByTagName('version')]
-        return sorted([v for v in versions
-                       if re.match(r"^\d+\.\d+\.\d+$", v)])
+        versions = sorted([v for v in versions
+                           if re.match(r"^\d+\.\d+\.\d+$", v)])
+        return (versions, latest)
 
 
 module = JavaDocModule()

--- a/devyco/modules/javadoc.py
+++ b/devyco/modules/javadoc.py
@@ -137,8 +137,8 @@ class JavaDocModule(Module):
         xmldoc = minidom.parseString(xml)
         versions = [v.firstChild.nodeValue
                     for v in xmldoc.getElementsByTagName('version')]
-        return [v for v in versions
-                if re.match(r"^\d+\.\d+\.\d+$", v)]
+        return sorted([v for v in versions
+                       if re.match(r"^\d+\.\d+\.\d+$", v)])
 
 
 module = JavaDocModule()

--- a/devyco/modules/javadoc.py
+++ b/devyco/modules/javadoc.py
@@ -5,6 +5,7 @@ Activated by a "javadoc" entry in .conf.json, containing the following settings:
     artifactId: The Maven artifactId for the project
 """
 
+import json
 import os
 import re
 import shutil
@@ -118,6 +119,9 @@ class JavaDocModule(Module):
                                     for v, aids in versions.items()
                                 ], reverse=True),
                                 ).encode('utf-8'))
+
+                with open(path.join(javadoc_cache_path, '.conf.json'), 'w') as excludefile:
+                    json.dump({'exclude': artifact_ids}, excludefile)
 
             else:
                 self._extract_javadoc(javadoc_cache_path, self.artifact, self.remote_version)

--- a/templates/javadoc-versions.template
+++ b/templates/javadoc-versions.template
@@ -1,14 +1,22 @@
 <h2>JavaDoc</h2>
-<p>Below are links to the Javadoc for the latest version and each release version, starting with the most recent version.</p>
+<p>Below are links to the Javadocs for the latest version and each release version, starting with the most recent version.</p>
 <p>Aside from the latest version, Javadoc for pre-release versions is not available here.</p>
 
-<p>Latest version: <a href="latest">{{latest}}</a></p>
+<p>Latest versions:<p>
+<dl>
+  {% for aid, v in latest_versions %}
+    <dt>{{aid}} <a href="{{aid}}/latest">{{v}}</a></dt>
+  {% endfor %}
+</dl>
 
 
 <h3>All release versions</h3>
 
 <dl>
-  {% for version in versions %}
-    <dt><a href="{{version}}">{{version}}</a></dt>
+  {% for version, aids in versions %}
+    <dt>{{version}}</dt>
+    {% for aid in aids %}
+      <dd><a href="{{aid}}/{{version}}">{{aid}} {{version}}</a></dd>
+    {% endfor %}
   {% endfor %}
 </dl>

--- a/templates/javadoc-versions.template
+++ b/templates/javadoc-versions.template
@@ -1,0 +1,14 @@
+<h2>JavaDoc</h2>
+<p>Below are links to the Javadoc for the latest version and each release version, starting with the most recent version.</p>
+<p>Aside from the latest version, Javadoc for pre-release versions is not available here.</p>
+
+<p>Latest version: <a href="latest">{{latest}}</a></p>
+
+
+<h3>All release versions</h3>
+
+<dl>
+  {% for version in versions %}
+    <dt><a href="{{version}}">{{version}}</a></dt>
+  {% endfor %}
+</dl>


### PR DESCRIPTION
If `javadoc.all_versions` is set in `.conf.json`, then the `/JavaDoc/` page will be a list of versions instead of leading directly to the Javadoc index. This page instead links to each of the Javadoc versions under `/JavaDoc/x.y.z/`, and `/JavaDoc/latest/` serves the Javadoc for the most recent version. Thus links into the versioned Javadoc will remain stable at that specific version.

Only release versions (numeric `x.y.z` with no suffix) are included in the list, but `/JavaDoc/latest/` may serve a pre-release version if that is the most recent version.