### PR TITLE
Replace openssl.conf with openssl.cnf

### DIFF
--- a/content/YubiHSM2/Usage_Guides/OpenSSL_with_pkcs11_engine.adoc
+++ b/content/YubiHSM2/Usage_Guides/OpenSSL_with_pkcs11_engine.adoc
@@ -2,14 +2,14 @@
 
 Install `engine_pkcs11` and `pkcs11-tool` from OpenSC before proceeding.
 
-OpenSSL requires engine settings in the `openssl.conf` file.
+OpenSSL requires engine settings in the `openssl.cnf` file.
 Some OpenSSL commands allow specifying `-conf ossl.conf` and some do not.
 Setting the environment variable `OPENSSL_CONF` always works, but be aware that
-sometimes the default `openssl.conf` contains entries that are needed by
+sometimes the default `openssl.cnf` contains entries that are needed by
 commands like `openssl req`.
 
 In other words, you may have to add the engine entries to your default OpenSSL
-config file (`openssl.conf` in the directory shown by `openssl version -d`) or
+config file (`openssl.cnf` in the directory shown by `openssl version -d`) or
 add other requirements for your OpenSSL command into the config file.
 
 Here is an example of generating a key in the device, creating a self-signed
@@ -99,8 +99,8 @@ engine "pkcs11" set.
 ....
 
 The following two examples will fail if you are only using the config above
-because it doesn't have the req entries in `openssl.conf`.
-You can integrate the `engine.conf` entries into the system's `openssl.conf`, or add
+because it doesn't have the req entries in `openssl.cnf`.
+You can integrate the `engine.conf` entries into the system's `openssl.cnf`, or add
 the following to the end of the above `engine.conf`:
 
 [source,cfg]


### PR DESCRIPTION
The default name for the openssl config file is openssl.cnf.

This name difference tripped me up when starting with the YubiHSM with OpenSSL and PKCS11.  My head wasn't on straight and I couldn't `find` openssl.conf.  This correction will clarify the documentation.