### PR TITLE
updated redirect to WebAuthn vs webauthn for case-sensitive links

### DIFF
--- a/content/.htaccess
+++ b/content/.htaccess
@@ -2,9 +2,9 @@ RewriteEngine On
 
 RewriteBase /
 
-# Redirect FIDO2 to webauthn
-RewriteRule ^FIDO2/(.*)$ webauthn/$1 [L,R=301]
-RewriteRule ^FIDO2$ webauthn/ [L,R=301]
+# Redirect FIDO2 to WebAuthn
+RewriteRule ^FIDO2/(.*)$ WebAuthn/$1 [L,R=301]
+RewriteRule ^FIDO2$ WebAuthn/ [L,R=301]
 
 # Redirect yubihsm2 to YubiHSM2
 RewriteRule ^yubihsm2/(.*)$ YubiHSM2/$1 [L,R=301]


### PR DESCRIPTION
This should fix the broken link when selecting the **Strong Authentication** for _WebAuthn_ and _FIDO2_. Both of these redirect to https://developers.yubico.com/WebAuthn/ but the WebAuthn is case-sensitive. 