### PR TITLE
Fix incorrect capability names

### DIFF
--- a/content/YubiHSM2/Usage_Guides/Admin_guide.adoc
+++ b/content/YubiHSM2/Usage_Guides/Admin_guide.adoc
@@ -27,7 +27,7 @@ yubihsm> session open 1 password
 Created session 0
 
 # Create an Authentication Key for Auditing
-yubihsm> put authkey 0 0 "Audit auth key" all audit none $AUDIT_PASS
+yubihsm> put authkey 0 0 "Audit auth key" all get-log-entries none $AUDIT_PASS
 Stored Authentication key 0xd054
 
 # Create a Wrap Key for importing application Authentication Keys and secrets
@@ -94,7 +94,7 @@ Stored Authentication key 0xd054
 yubihsm> put option 0 force-audit 01
 
 # Create an Authentication Key for usage with the PKCS11 module
-yubihsm> put authkey 0 0 "PKCS11 RSA" 1 delete-asymmetric:generate-asymmetric-key:sign-pkcs:sign-pss sign-pkcs:sign-pss $PKCS11_PASS
+yubihsm> put authkey 0 0 "PKCS11 RSA" 1 delete-asymmetric-key:generate-asymmetric-key:sign-pkcs:sign-pss sign-pkcs:sign-pss $PKCS11_PASS
 Stored Authentication key 0xf10f
 
 # Delete the default Authentication Key


### PR DESCRIPTION
Tried following the referenced example with a new YubiHSM2 device and some of the commands failed because the capabilities were not correct.