### PR TITLE
Remove Google Plus icon from footer

### DIFF
--- a/templates/site.template
+++ b/templates/site.template
@@ -155,7 +155,6 @@
             <tr>
               <td style="padding:10px"><a title="Blog RSS" href="https://www.yubico.com/feed/" target="_blank"><i class="fa fa-rss"></i></a></td>
               <td style="padding:10px"><a title="Twitter" href="https://twitter.com/yubico" target="_blank"><i class="fa fa-twitter"></i></a></td>
-              <td style="padding:10px"><a title="Google Plus" href="https://plus.google.com/114531431015898699937" target="_blank"><i class="fa fa-google-plus"></i></a></td>
               <td style="padding:10px"><a title="Facebook" href="https://www.facebook.com/Yubikey" target="_blank"><i class="fa fa-facebook"></i></a></td>
               <td style="padding:10px"><a title="YouTube" href="https://www.youtube.com/c/Yubico" target="_blank"><i class="fa fa-youtube"></i></a></td>
               <td style="padding:10px 0 10px 10px"><a title="GitHub" href="https://github.com/Yubico" target="_blank"><i class="fa fa-github"></i></a></td>


### PR DESCRIPTION
Google+ has been permanently shut down and the linked url no longer exists.