### PR TITLE
Fix name of decrypt-otp capability in example

### DIFF
--- a/content/YubiHSM2/Commands/Put_Otp_Aead_Key.adoc
+++ b/content/YubiHSM2/Commands/Put_Otp_Aead_Key.adoc
@@ -11,7 +11,7 @@ Import an OTP AEAD Key used for Yubico OTP Decryption.
 Import OTP AEAD Key with Nonce ID `0x01020304` and key value
 `000102030405060708090a0b0c0d0e0f` (AES-128):
 
-  yubihsm> put otpaeadkey 0 0 otpaeadkey 1 otp-decrypt 0x01020304 000102030405060708090a0b0c0d0e0f
+  yubihsm> put otpaeadkey 0 0 otpaeadkey 1 decrypt-otp 0x01020304 000102030405060708090a0b0c0d0e0f
   Stored OTP AEAD key 0xe34f
 
 == Protocol Details


### PR DESCRIPTION
```
yubihsm> put otpaeadkey 0 0x22 yubicloud-test-key 1 otp-decrypt 0x01020304 5b483e85b528d170667d4fe8f6c9f5e65b483e85b528d170667d4fe8f6c9f5e6
Invalid argument 6: otp-decrypt (c:capabilities)

yubihsm> put otpaeadkey 0 0x22 yubicloud-test-key 1 decrypt-otp 0x01020304 5b483e85b528d170667d4fe8f6c9f5e65b483e85b528d170667d4fe8f6c9f5e6
Stored OTP AEAD key 0x0022
```