### PR TITLE
Add link to referer page in "suggest edits" body template

### DIFF
--- a/devyco/modules/suggest_edits.py
+++ b/devyco/modules/suggest_edits.py
@@ -2,11 +2,12 @@
 Adds a 'Suggest Edits' link to pages.
 """
 
+import re
 import urllib
 from devyco.module import Module, noext
 from os import path
 
-CREATE_GITHUB_ISSUE_URL = 'https://github.com/Yubico/developers.yubico.com/issues/new?title=Suggested%20edit%20for%20{0}'
+CREATE_GITHUB_ISSUE_URL = 'https://github.com/Yubico/developers.yubico.com/issues/new?title=Suggested%20edit%20for%20{filename}&body=(Write%20your%20suggestions%20here)%0A%0A---%0ASee%20https://developers.yubico.com/{urlname}'
 
 
 class SuggestedEditsModule(Module):
@@ -22,16 +23,17 @@ class SuggestedEditsModule(Module):
     def _add_suggest_edits_link(self, variables):
         for f in self.list_files('*.partial'):
             basename = noext(path.basename(f))
+            filename = path.join(*(self._context['path'] + [basename]))
+            urlname = re.sub("/index$", "/", filename)
+
             variables.append({
                 'filter': basename,
                 'values': {
                     'sidelinks': [
                         {
                             'url': CREATE_GITHUB_ISSUE_URL.format(
-                                urllib.quote(
-                                    path.join(*(self._context['path']
-                                                + [basename]))
-                                )
+                                filename=urllib.quote(filename),
+                                urlname=urllib.quote(urlname),
                             ),
                             'name': '<i class=\"fa fa-pencil-square-o fa-lg\"></i> Suggest Edits'
                         }


### PR DESCRIPTION
This will prefill the issue body with a link to the referer page. For example, the "Suggest edits" button at https://developers.yubico.com/U2F/Attestation_and_Metadata/ would prefill the issue body with:

```
(Write your suggestions here)

---
See https://developers.yubico.com/U2F/Attestation_and_Metadata/
```