### PR TITLE
Add link to up to date YubiKey Ubuntu guide

### DIFF
--- a/content/PGP/SSH_authentication/index.adoc
+++ b/content/PGP/SSH_authentication/index.adoc
@@ -9,6 +9,6 @@ using your YubiKey we recommend disabling password login on your SSH server.
  - link:Windows.html[Windows]
  - https://florin.myip.org/blog/easy-multifactor-authentication-ssh-using-yubikey-neo-tokens[OS X]
  - https://www.esev.com/blog/post/2015-01-pgp-ssh-key-on-yubikey-neo[Linux]
- - https://github.com/dainnilsson/scripts/blob/master/base-install/gpg.sh[Ubuntu]
+ - https://gist.github.com/artizirk/d09ce3570021b0f65469cb450bee5e29[Ubuntu (18.04 and newer)]
  - https://chromium.googlesource.com/apps/libapps/+/HEAD/nassh/doc/hardware-keys.md[ChromeOS]
  - https://jclement.ca/articles/2015/gpg-smartcard/[Another guide for Windows, OS X and Linux]


### PR DESCRIPTION
Other links have not been kept up to date with upstream GnuPG changes and are now broken on modern Linux distrobutions.

This change comes from https://github.com/dainnilsson/scripts/issues/6