### PR TITLE
PIV: additions to enforce smart card on macOS guide

### DIFF
--- a/content/PIV/Guides/Smart_card-only_authentication_on_macOS.adoc
+++ b/content/PIV/Guides/Smart_card-only_authentication_on_macOS.adoc
@@ -53,6 +53,16 @@ b. Install the profile:
 
 The YubiKey is now required for all authentication tasks on the system.
 
+=== Additional options
+
+Note that even though this guide uses self-signed certificates, any
+pair of certifcates stored in slot 9a and 9d may be used for pairing. To also verify that
+the certificates used are trusted, configure the `checkCertificateTrust` option in the profile.
+
+The `tokenRemovalAction` may be added to the profile to automatically start the screensaver
+when the YubiKey is removed.
+
 === More reading:
 
  * link:https://support.apple.com/en-us/HT208372[Apple: Configure macOS for smart card-only authentication]
+ * `$ man SmartCardServices`


### PR DESCRIPTION
add some phrasing about using non-self signed certificates, and the tokenRemovalAction