### PR TITLE
Fix ordered list layout

### DIFF
--- a/content/PIV/Guides/Smart_card-only_authentication_on_macOS.adoc
+++ b/content/PIV/Guides/Smart_card-only_authentication_on_macOS.adoc
@@ -41,6 +41,7 @@ c. Verify that your user is paired:
 
   $ sc_auth list
 
++
 You may now use your YubiKey for login, but your password still works as well.
 
 3. Install a configuration profile


### PR DESCRIPTION
Fixes this warning as well:
Error parsing Asciidoc file /developers/htdocs/dist/PIV/Guides/Smart_card-only_authentication_on_macOS.adoc: WARNING: Smart_card-only_authentication_on_macOS.adoc: line 46: list item index: expected 1 got 3