### PR TITLE
Move binaries repo to GitHub lfs

### DIFF
--- a/README
+++ b/README
@@ -32,7 +32,7 @@ http://localhost:8080
 
 === Building fast and locally for local development
 For faster local development for document, use the following command.  This will run with both
-NOPROJECTS = true and NORLEASES = true
+NOPROJECTS = true and NORELEASES = true
 
  make build_noprojects httpd
 

--- a/content/.conf.json
+++ b/content/.conf.json
@@ -56,7 +56,7 @@
               }
             ]
           }, {
-            "url": "git@gitlab.in.yubico.org:engineering/yubico-binaries.git",
+            "url": "https://github.com/Yubico/yubico-binaries.git",
             "preserve_mtimes": true,
             "files": [
               ["%(name)s/releases/*", "Releases/"],

--- a/content/YubiHSM2/.conf.json
+++ b/content/YubiHSM2/.conf.json
@@ -11,7 +11,7 @@
   "suggest-edits": {},
   "git": [
     {
-      "url": "git@gitlab.in.yubico.org:engineering/yubico-binaries.git",
+      "url": "https://github.com/Yubico/yubico-binaries.git",
       "preserve_mtimes": true,
       "files": [
         ["yubihsm2/releases/*", "Releases/"]

--- a/content/projects/windows-apis/.conf.json
+++ b/content/projects/windows-apis/.conf.json
@@ -7,7 +7,7 @@
     },
     "git": [
       {
-        "url": "git@gitlab.in.yubico.org:engineering/yubico-binaries.git",
+        "url": "https://github.com/Yubico/yubico-binaries.git",
     	"files": [["windows-apis/releases/*", "Releases/"]]
       }
     ]

--- a/devyco/modules/git.py
+++ b/devyco/modules/git.py
@@ -32,7 +32,7 @@ class GitModule(Module):
         super(GitModule, self).__init__()
         self._updated = []
         if os.environ.get('NORELEASES'):
-            self._updated.append('git@gitlab.in.yubico.org:engineering/yubico-binaries.git')
+            self._updated.append('https://github.com/Yubico/yubico-binaries.git')
 
     def _run(self):
         if os.environ.get('NOPROJECTS'):


### PR DESCRIPTION
Works for me (TM) locally with correct time stamps on releases etc.

Git LFS got deactivated because we overreached our quote with 655% when I converted the old repo to github+lfs so wait with testing until @andreaso has confirmed it is active again.

![Screenshot from 2020-03-05 09-40-27](https://user-images.githubusercontent.com/208243/75963396-ab13ef00-5ec5-11ea-9db7-e3efb2f0ba8d.png)
