### PR TITLE
Add an ssh landing page

### DIFF
--- a/content/.conf.json
+++ b/content/.conf.json
@@ -9,7 +9,7 @@
     "YubiHSM2",
     "Software_Projects"
   ],
-  "hidden": ["404", "Developer_Program", "Mobile"],
+  "hidden": ["404", "Developer_Program", "Mobile", "SSH"],
   "project": "projects",
   "releases_aggregate_feed": "Software_Projects/atom.xml",
   "vars": [

--- a/content/.htaccess
+++ b/content/.htaccess
@@ -14,6 +14,10 @@ RewriteRule ^yubihsm2$ YubiHSM2/ [L,R=301]
 RewriteRule ^u2f/(.*)$ U2F/$1 [L,R=301]
 RewriteRule ^u2f$ U2F/ [L,R=301]
 
+# Redirect ssh to SSH
+RewriteRule ^ssh/(.*)$ SSH/$1 [L,R=301]
+RewriteRule ^ssh$ SSH/ [L,R=301]
+
 # Redirect mobile to Mobile
 RewriteRule ^mobile/(.*)$ Mobile/$1 [L,R=301]
 RewriteRule ^mobile$ Mobile/ [L,R=301]

--- a/content/PIV/Guides/Securing_SSH_with_OpenPGP_or_PIV.adoc
+++ b/content/PIV/Guides/Securing_SSH_with_OpenPGP_or_PIV.adoc
@@ -54,6 +54,9 @@ means OpenPGP is not supported. This and the fact that OpenPGP on a smart card Y
 key (split into 3 sub-keys), credential management services and certificate authorities have not added native support
 for OpenPGP credentials.
 
+++++
+<p><a name="piv"></a></p>
+++++
 === PIV
 OpenSSH is one of the most widely used utilities suite based on the SSH protocol, which provides a secure channel
 over an unsecured network in a client-server architecture. The YubiKey stores and manages RSA and EC asymmetric keys

--- a/content/SSH/.conf.json
+++ b/content/SSH/.conf.json
@@ -1,0 +1,6 @@
+{
+  "order": [
+	""
+  ],
+  "suggest-edits": {}
+}

--- a/content/SSH/index.adoc
+++ b/content/SSH/index.adoc
@@ -1,0 +1,41 @@
+= Securing SSH with the YubiKey
+Secure Shell (SSH) is often used to access remote systems. It provides a cryptographically secure channel over an unsecured network. SSH uses public-key cryptography to authenticate the remote system and allow it to authenticate the user. 
+
+SSH also offers passwordless authentication. In this scenario, a public-private key pair is manually generated. The public key is placed on all remote systems and allows access to the owner of the matching private key. The owner is responsible for keeping the private key secret. Owners can secure private keys with the YubiKey by importing them or, better yet, generating the private key directly on the YubiKey. Private keys cannot be exported or extracted from the YubiKey.
+
+The YubiKey supports various methods to enable hardware-backed SSH authentication.
+
+
+== PIV 
+The YubiKey stores and manages RSA and Elliptic Curve (EC) asymmetric keys within its PIV module. It will work with SSH clients that can communicate with smart cards through the PKCS#11 interface.
+
+* Read about the link:/PIV/Guides/Securing_SSH_with_OpenPGP_or_PIV.html#piv[advantages and considerations of configuring OpenSSH with the YubiKey with PIV] 
+* Follow the link:/PIV/Guides/SSH_user_certificates.html[step-by-step instructions to configure OpenSSH with the YubiKey]
+
+== PGP
+The YubiKey stores and manages OpenPGP keys within its OpenPGP module. It will work with SSH clients that have integrated with the OpenPGP standard.
+
+* Read about the link:/PIV/Guides/Securing_SSH_with_OpenPGP_or_PIV.html[advantages and considerations of configuring OpenSSH with the YubiKey with OpenPGP]
+* Follow the link:/PGP/SSH_authentication/index.html[step-by-step configuration instructions to enable SSH authentication with the YubiKey and OpenPGP]
+
+== FIDO U2F
+OpenSSH version 8.2 added support for FIDO U2F hardware authenticators. FIDO devices are supported by the public key types “ecdsa-sk” and “ed25519-sk", along with corresponding
+certificate types.
+
+ssh-keygen may be used to generate a FIDO token-backed SSH key, after which such keys may be used much like any other key type supported by OpenSSH, provided that the YubiKey is plugged in when the keys are used. YubiKeys require the user to explicitly authorize operations by touching or tapping them.
+
+To generate a FIDO token-backed SSH key, plug in the YubiKey and touch it when prompted.
+
+  $ ssh-keygen -t ecdsa-sk -f ~/.ssh/id_ecdsa_sk
+  Generating public/private ecdsa-sk key pair.
+  You may need to touch your security key to authorize key generation.
+  Enter file in which to save the key (/home/djm/.ssh/id_ecdsa_sk): 
+  Enter passphrase (empty for no passphrase): 
+  Enter same passphrase again: 
+  Your identification has been saved in /home/djm/.ssh/id_ecdsa_sk
+  Your public key has been saved in /home/djm/.ssh/id_ecdsa_sk.pub
+
+== OTP
+Systems administrators can configure two factor authentication for SSH authentication using the YubiKey through the link:/yubico-pam/[Yubico PAM module].
+
+* Follow the link:/yubico-pam/YubiKey_and_SSH_via_PAM.html[step-by-step instructions to configure the Yubico PAM module for SSH with OTP].


### PR DESCRIPTION
This landing page enables users interested in the remote worker ssh use case to understand what options they have available to them and where to go to find the respective detailed instructions.