### PR TITLE
libfido2: sync docs

### DIFF
--- a/content/projects/libfido2/Manuals/es256_pk_new.partial
+++ b/content/projects/libfido2/Manuals/es256_pk_new.partial
@@ -93,7 +93,9 @@ The <code class="Fn" title="Fn">es256_pk_from_ptr</code>() function fills
   <var class="Fa" title="Fa">pk</var> with the contents of
   <var class="Fa" title="Fa">ptr</var>, where
   <var class="Fa" title="Fa">ptr</var> points to
-  <var class="Fa" title="Fa">len</var> bytes. No references to
+  <var class="Fa" title="Fa">len</var> bytes. The
+  <var class="Fa" title="Fa">ptr</var> pointer may point to an uncompressed
+  point, or to the concatenation of the x and y coordinates. No references to
   <var class="Fa" title="Fa">ptr</var> are kept.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">es256_pk_to_EVP_PKEY</code>() function converts

--- a/content/projects/libfido2/Manuals/fido_bio_dev_get_info.partial
+++ b/content/projects/libfido2/Manuals/fido_bio_dev_get_info.partial
@@ -97,8 +97,9 @@
   *pin</var>);
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
 The functions described in this page allow biometric templates on a FIDO2
-  authenticator to be listed, created, removed, and customised. For a
-  description of the types involved, please refer to
+  authenticator to be listed, created, removed, and customised. Please note that
+  not all FIDO2 authenticators support biometric enrollment. For a description
+  of the types involved, please refer to
   <a class="Xr" title="Xr" href="fido_bio_info_new.html">fido_bio_info_new(3)</a>,
   <a class="Xr" title="Xr" href="fido_bio_enroll_new.html">fido_bio_enroll_new(3)</a>,
   and
@@ -153,7 +154,14 @@ The error codes returned by
   ALSO</a></h1>
 <a class="Xr" title="Xr" href="fido_bio_enroll_new.html">fido_bio_enroll_new(3)</a>,
   <a class="Xr" title="Xr" href="fido_bio_info_new.html">fido_bio_info_new(3)</a>,
-  <a class="Xr" title="Xr" href="fido_bio_template.html">fido_bio_template(3)</a></div>
+  <a class="Xr" title="Xr" href="fido_bio_template.html">fido_bio_template(3)</a>
+<h1 class="Sh" title="Sh" id="CAVEATS"><a class="permalink" href="#CAVEATS">CAVEATS</a></h1>
+Biometric enrollment is a tentative feature of FIDO 2.1. Applications willing to
+  strictly abide by FIDO 2.0 should refrain from using biometric enrollment.
+  Applications using biometric enrollment should ensure it is supported by the
+  authenticator prior to using the API. Since FIDO 2.1 hasn't been finalised,
+  there is a chance the functionality and associated data structures may
+  change.</div>
 <table class="foot">
   <tr>
     <td class="foot-date">September 13, 2019</td>

--- a/content/projects/libfido2/Manuals/fido_bio_template.partial
+++ b/content/projects/libfido2/Manuals/fido_bio_template.partial
@@ -84,17 +84,17 @@
 <var class="Ft" title="Ft">void</var>
 <br/>
 <code class="Fn" title="Fn">fido_bio_template_array_free</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_bio_template_array_t
-  **template_array_p</var>);
+  **array_p</var>);
 <div class="Pp"></div>
 <var class="Ft" title="Ft">size_t</var>
 <br/>
 <code class="Fn" title="Fn">fido_bio_template_array_count</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
-  fido_bio_template_array_t *template_array</var>);
+  fido_bio_template_array_t *array</var>);
 <div class="Pp"></div>
 <var class="Ft" title="Ft">const fido_bio_template_t *</var>
 <br/>
 <code class="Fn" title="Fn">fido_bio_template</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
-  fido_bio_template_array_t *template_array</var>,
+  fido_bio_template_array_t *array</var>,
   <var class="Fa" title="Fa" style="white-space: nowrap;">size_t idx</var>);
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
 Existing FIDO 2 biometric enrollments are abstracted in
@@ -149,23 +149,21 @@ The <code class="Fn" title="Fn">fido_bio_template_array_new</code>() function
   cannot be allocated, NULL is returned.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_bio_template_array_free</code>() function
-  releases the memory backing
-  <var class="Fa" title="Fa">*template_array_p</var>, where
-  <var class="Fa" title="Fa">*template_array_p</var> must have been previously
-  allocated by <code class="Fn" title="Fn">fido_bio_template_array_new</code>().
-  On return, <var class="Fa" title="Fa">*template_array_p</var> is set to NULL.
-  Either <var class="Fa" title="Fa">template_array_p</var> or
-  <var class="Fa" title="Fa">*template_array_p</var> may be NULL, in which case
+  releases the memory backing <var class="Fa" title="Fa">*array_p</var>, where
+  <var class="Fa" title="Fa">*array_p</var> must have been previously allocated
+  by <code class="Fn" title="Fn">fido_bio_template_array_new</code>(). On
+  return, <var class="Fa" title="Fa">*array_p</var> is set to NULL. Either
+  <var class="Fa" title="Fa">array_p</var> or
+  <var class="Fa" title="Fa">*array_p</var> may be NULL, in which case
   <code class="Fn" title="Fn">fido_bio_template_array_free</code>() is a NOP.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_bio_template_array_count</code>() function
-  returns the number of templates in
-  <var class="Fa" title="Fa">template_array</var>.
+  returns the number of templates in <var class="Fa" title="Fa">array</var>.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_bio_template</code>() function returns a
   pointer to the template at index <var class="Fa" title="Fa">idx</var> in
-  <var class="Fa" title="Fa">template_array</var>. Please note that the first
-  template in <var class="Fa" title="Fa">template_array</var> has an
+  <var class="Fa" title="Fa">array</var>. Please note that the first template in
+  <var class="Fa" title="Fa">array</var> has an
   <var class="Fa" title="Fa">idx</var> (index) value of 0.
 <h1 class="Sh" title="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>

--- a/content/projects/libfido2/Manuals/fido_cbor_info_fwversion.partial
+++ b/content/projects/libfido2/Manuals/fido_cbor_info_fwversion.partial
@@ -1,0 +1,1 @@
+fido_cbor_info_new.partial

--- a/content/projects/libfido2/Manuals/fido_cbor_info_new.partial
+++ b/content/projects/libfido2/Manuals/fido_cbor_info_new.partial
@@ -35,7 +35,8 @@
   <code class="Nm" title="Nm">fido_cbor_info_protocols_len</code>,
   <code class="Nm" title="Nm">fido_cbor_info_versions_len</code>,
   <code class="Nm" title="Nm">fido_cbor_info_options_len</code>,
-  <code class="Nm" title="Nm">fido_cbor_info_maxmsgsiz</code> &#x2014;
+  <code class="Nm" title="Nm">fido_cbor_info_maxmsgsiz</code>,
+  <code class="Nm" title="Nm">fido_cbor_info_fwversion</code> &#x2014;
 <div class="Nd" title="Nd">FIDO 2 CBOR Info API</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
@@ -116,6 +117,11 @@
 <br/>
 <code class="Fn" title="Fn">fido_cbor_info_maxmsgsiz</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_cbor_info_t *ci</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">uint64_t</var>
+<br/>
+<code class="Fn" title="Fn">fido_cbor_info_fwversion</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cbor_info_t *ci</var>);
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
 The <code class="Fn" title="Fn">fido_cbor_info_new</code>() function returns a
   pointer to a newly allocated, empty
@@ -159,7 +165,11 @@ The <code class="Fn" title="Fn">fido_cbor_info_options_name_ptr</code>() and
   <code class="Fn" title="Fn">fido_cbor_info_options_len</code>().
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_cbor_info_maxmsgsiz</code>() function
-  returns the maximum message size of <var class="Fa" title="Fa">ci</var>.
+  returns the maximum message size attribute of
+  <var class="Fa" title="Fa">ci</var>.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_cbor_info_fwversion</code>() function
+  returns the firmware version attribute of <var class="Fa" title="Fa">ci</var>.
 <div class="Pp"></div>
 A complete example of how to use these functions can be found in the
   <span class="Pa" title="Pa">example/info.c</span> file shipped with

--- a/content/projects/libfido2/Manuals/fido_cred_new.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_new.partial
@@ -23,6 +23,7 @@
 <h1 class="Sh" title="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
 <code class="Nm" title="Nm">fido_cred_new</code>,
   <code class="Nm" title="Nm">fido_cred_free</code>,
+  <code class="Nm" title="Nm">fido_cred_prot</code>,
   <code class="Nm" title="Nm">fido_cred_fmt</code>,
   <code class="Nm" title="Nm">fido_cred_authdata_ptr</code>,
   <code class="Nm" title="Nm">fido_cred_clientdata_hash_ptr</code>,
@@ -49,6 +50,11 @@
 <br/>
 <code class="Fn" title="Fn">fido_cred_free</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_cred_t
   **cred_p</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
+<code class="Fn" title="Fn">fido_cred_prot</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_cred_t
+  *cred</var>);
 <div class="Pp"></div>
 <var class="Ft" title="Ft">const char *</var>
 <br/>
@@ -139,6 +145,11 @@ The <code class="Fn" title="Fn">fido_cred_free</code>() function releases the
   <var class="Fa" title="Fa">cred_p</var> or
   <var class="Fa" title="Fa">*cred_p</var> may be NULL, in which case
   <code class="Fn" title="Fn">fido_cred_free</code>() is a NOP.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_cred_prot</code>() function returns the
+  protection of <var class="Fa" title="Fa">cred</var>. See
+  <a class="Xr" title="Xr" href="fido_cred_set_prot.html">fido_cred_set_prot(3)</a>
+  for the values understood by <i class="Em" title="Em">libfido2</i>.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_cred_fmt</code>() function returns a
   pointer to a NUL-terminated string containing the format of

--- a/content/projects/libfido2/Manuals/fido_cred_prot.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_prot.partial
@@ -1,0 +1,1 @@
+fido_cred_new.partial

--- a/content/projects/libfido2/Manuals/fido_cred_set_authdata.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_set_authdata.partial
@@ -29,6 +29,7 @@
   <code class="Nm" title="Nm">fido_cred_set_rp</code>,
   <code class="Nm" title="Nm">fido_cred_set_user</code>,
   <code class="Nm" title="Nm">fido_cred_set_extensions</code>,
+  <code class="Nm" title="Nm">fido_cred_set_prot</code>,
   <code class="Nm" title="Nm">fido_cred_set_rk</code>,
   <code class="Nm" title="Nm">fido_cred_set_uv</code>,
   <code class="Nm" title="Nm">fido_cred_set_fmt</code>,
@@ -111,6 +112,12 @@ typedef enum {
 <div class="Pp"></div>
 <var class="Ft" title="Ft">int</var>
 <br/>
+<code class="Fn" title="Fn">fido_cred_set_prot</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_cred_t
+  *cred</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">int
+  prot</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
 <code class="Fn" title="Fn">fido_cred_set_rk</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_cred_t
   *cred</var>,
   <var class="Fa" title="Fa" style="white-space: nowrap;">fido_opt_t rk</var>);
@@ -189,9 +196,19 @@ The <code class="Fn" title="Fn">fido_cred_set_user</code>() function sets the
 The <code class="Fn" title="Fn">fido_cred_set_extensions</code>() function sets
   the extensions of <var class="Fa" title="Fa">cred</var> to the bitmask
   <var class="Fa" title="Fa">flags</var>. At the moment, only the
-  <code class="Dv" title="Dv">FIDO_EXT_HMAC_SECRET</code> extension is
+  <code class="Dv" title="Dv">FIDO_EXT_HMAC_SECRET</code> and
+  <code class="Dv" title="Dv">FIDO_EXT_CRED_PROTECT</code> extensions are
   supported. If <var class="Fa" title="Fa">flags</var> is zero, the extensions
   of <var class="Fa" title="Fa">cred</var> are cleared.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_cred_set_prot</code>() function sets the
+  protection of <var class="Fa" title="Fa">cred</var> to the scalar
+  <var class="Fa" title="Fa">prot</var>. At the moment, only the
+  <code class="Dv" title="Dv">FIDO_CRED_PROT_UV_OPTIONAL</code>,
+  <code class="Dv" title="Dv">FIDO_CRED_PROT_UV_OPTIONAL_WITH_ID</code>, and
+  <code class="Dv" title="Dv">FIDO_CRED_PROT_UV_REQUIRED</code> protections are
+  supported. If <var class="Fa" title="Fa">prot</var> is zero, the protection of
+  <var class="Fa" title="Fa">cred</var> is cleared.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_cred_set_rk</code>() and
   <code class="Fn" title="Fn">fido_cred_set_uv</code>() functions set the

--- a/content/projects/libfido2/Manuals/fido_cred_set_prot.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_set_prot.partial
@@ -1,0 +1,1 @@
+fido_cred_set_authdata.partial

--- a/content/projects/libfido2/Manuals/fido_credman_metadata_new.partial
+++ b/content/projects/libfido2/Manuals/fido_credman_metadata_new.partial
@@ -165,7 +165,7 @@
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
 The credential management API of <i class="Em" title="Em">libfido2</i> allows
   resident credentials on a FIDO2 authenticator to be listed, inspected, and
-  removed. Please note that not all authenticators support credential
+  removed. Please note that not all FIDO2 authenticators support credential
   management. To obtain information on what an authenticator supports, please
   refer to
   <a class="Xr" title="Xr" href="fido_cbor_info_new.html">fido_cbor_info_new(3)</a>.
@@ -293,7 +293,14 @@ The <code class="Fn" title="Fn">fido_credman_get_dev_metadata</code>(),
 <h1 class="Sh" title="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
 <a class="Xr" title="Xr" href="fido_cbor_info_new.html">fido_cbor_info_new(3)</a>,
-  <a class="Xr" title="Xr" href="fido_cred_new.html">fido_cred_new(3)</a></div>
+  <a class="Xr" title="Xr" href="fido_cred_new.html">fido_cred_new(3)</a>
+<h1 class="Sh" title="Sh" id="CAVEATS"><a class="permalink" href="#CAVEATS">CAVEATS</a></h1>
+Credential management is a tentative feature of FIDO 2.1. Applications willing
+  to strictly abide by FIDO 2.0 should refrain from using credential management.
+  Applications using credential management should ensure it is supported by the
+  authenticator prior to using the API. Since FIDO 2.1 hasn't been finalised,
+  there is a chance the functionality and associated data structures may
+  change.</div>
 <table class="foot">
   <tr>
     <td class="foot-date">June 28, 2019</td>


### PR DESCRIPTION
- expand on what can be passed to es256_pk_from_ptr();
- blurb about credential management and biometric API not being in FIDO 2.0;
- shorter variable names in fido_bio_template.partial;
- new API calls:
  * fido_cbor_info_fwversion();
  * fido_cred_prot();
  * fido_cred_set_prot().

note to the reviewer: please delete the existing `libfido2_sync` branch. my bad; I forgot to gc it while i still had access.