### PR TITLE
Revert "Addressing https://tools.ietf.org/id/draft-knodel-terminology-00.html"

### DIFF
--- a/content/Mobile/iOS/App_Registration_Process/index.adoc
+++ b/content/Mobile/iOS/App_Registration_Process/index.adoc
@@ -63,7 +63,7 @@ b. https://developer.apple.com/app-store/review/guidelines/[App Store Review Gui
 
 c. https://developer.apple.com/design/human-interface-guidelines/ios/overview/themes/[Human Interface Guidelines for iOS]
 
-Please note that Yubico reserves the right to remove apps from its allowlist at any time, in our sole discretion, including but not limited to if apps no longer adhere to Yubico’s guidelines.
+Please note that Yubico reserves the right to remove apps from its whitelist at any time, in our sole discretion, including but not limited to if apps no longer adhere to Yubico’s guidelines.
 
 Contact For questions or comments not covered by this document please open a https://support.yubico.com/support/tickets/new[developer support ticket].
 

--- a/content/OTP/Guides/Migrating_to_python-pyhsm.adoc
+++ b/content/OTP/Guides/Migrating_to_python-pyhsm.adoc
@@ -159,7 +159,7 @@ yhsm-yubikey-val it will not be able to access the KSM without further
 configuration. While it is possible to configure yhsm-yubikey-ksm to listen on
 any interface, the recommended approach is to not expose it to the Internet to
 prevent possible denial of service attacks. Instead, the recommended approach
-is to allowlist only your own validation servers to connect to the KSM, using
+is to whitelist only your own validation servers to connect to the KSM, using
 for example SSH tunnels or firewall rules.
 ====
 

--- a/content/WebAuthn/WebAuthn_Developer_Guide/Integration_Review_Standard_FIDO.adoc
+++ b/content/WebAuthn/WebAuthn_Developer_Guide/Integration_Review_Standard_FIDO.adoc
@@ -139,8 +139,8 @@ Attestation is used to validate that the certificates being generated come from 
 4. How is attestation being checked?
 
    * When and where is attestation being checked?
-   * How are allowlist and blocklists being handled?
-   * What is the behavior when rejecting devices based on allowlist/blocklist?
+   * How are whitelisting and blacklisting being handled?
+   * What is the behavior when rejecting devices based on whitelisting/blacklisting?
 
 5. How are changes to attestation certificates being handled?
 6. How is the metadata being stored, secured and backed up?

--- a/content/YubiHSM2/Component_Reference/yubihsm-connector/index.adoc
+++ b/content/YubiHSM2/Component_Reference/yubihsm-connector/index.adoc
@@ -57,10 +57,10 @@ syslog: false
 
 # Use to enable host header filtering. Default to "false".
 # Use this if there is an absolute need to use a web browser on the host where the YubiHSM 2 is installed to connect to untrusted web sites on the Internet.
-enable-host-allowlist: false
+enable-host-whitelist: false
 
 # Default list for the host header filter
-host-allowlist: localhost,localhost.,127.0.0.1,[::1]
+host-whitelist: localhost,localhost.,127.0.0.1,[::1]
 ----
 
 Sample udev rule to be placed into `/etc/udev/rules.d/`:

--- a/content/projects/yubihsm-connector/Manuals/yubihsm-connector.1.adoc
+++ b/content/projects/yubihsm-connector/Manuals/yubihsm-connector.1.adoc
@@ -19,14 +19,14 @@ string                   config file
 *-d, --debug*::
 debug output
 
-*--enable-host-header-allowlist*::
-Enable Host header allowlist
+*--enable-host-header-whitelist*::
+Enable Host header whitelisting
 
 *-h, --help*::
 help for yubihsm-connector
 
-*--host-header-allowlist*::
-strings   Host header allowlist (default [localhost,localhost.,127.0.0.1,[::1]])
+*--host-header-whitelist*::
+strings   Host header whitelist (default [localhost,localhost.,127.0.0.1,[::1]])
 
 *--key*::
 string                      certificate key

--- a/static/vendor/modernizr/feature-detects/contenteditable.js
+++ b/static/vendor/modernizr/feature-detects/contenteditable.js
@@ -2,7 +2,7 @@
 // http://www.whatwg.org/specs/web-apps/current-work/multipage/editing.html#contenteditable
 
 // this is known to false positive in some mobile browsers
-// here is a list of verified working browsers:
+// here is a whitelist of verified working browsers:
 // https://github.com/NielsLeenheer/html5test/blob/549f6eac866aa861d9649a0707ff2c0157895706/scripts/engine.js#L2083
 
 Modernizr.addTest('contenteditable',

--- a/static/vendor/modernizr/test/js/unit.js
+++ b/static/vendor/modernizr/test/js/unit.js
@@ -550,7 +550,7 @@ test('Modernizr.prefixed() - css and DOM resolving', function(){
 });
 
 
-// FIXME: so a few of these are explicitly allowed for webkit. i'd like to improve that.
+// FIXME: so a few of these are whitelisting for webkit. i'd like to improve that.
 test('Modernizr.prefixed autobind', function(){
 
   var rAFName;


### PR DESCRIPTION
Reverts Yubico/developers.yubico.com#316

The changes are not reflected in the yubihsm tooling yet.