### PR TITLE
Change redirects to respect X-Forwarded-Proto

### DIFF
--- a/content/.htaccess
+++ b/content/.htaccess
@@ -3,41 +3,41 @@ RewriteEngine On
 RewriteBase /
 
 # Redirect FIDO2 to WebAuthn
-RewriteRule ^FIDO2/(.*)$ WebAuthn/$1 [L,R=301]
-RewriteRule ^FIDO2$ WebAuthn/ [L,R=301]
+RewriteRule ^FIDO2/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/WebAuthn/$1 [L,R=301]
+RewriteRule ^FIDO2$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/WebAuthn/ [L,R=301]
 
 # Redirect yubihsm2 to YubiHSM2
-RewriteRule ^yubihsm2/(.*)$ YubiHSM2/$1 [L,R=301]
-RewriteRule ^yubihsm2$ YubiHSM2/ [L,R=301]
+RewriteRule ^yubihsm2/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/YubiHSM2/$1 [L,R=301]
+RewriteRule ^yubihsm2$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/YubiHSM2/ [L,R=301]
 
 # Redirect u2f to U2F
-RewriteRule ^u2f/(.*)$ U2F/$1 [L,R=301]
-RewriteRule ^u2f$ U2F/ [L,R=301]
+RewriteRule ^u2f/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/U2F/$1 [L,R=301]
+RewriteRule ^u2f$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/U2F/ [L,R=301]
 
 # Redirect ssh to SSH
-RewriteRule ^ssh/(.*)$ SSH/$1 [L,R=301]
-RewriteRule ^ssh$ SSH/ [L,R=301]
+RewriteRule ^ssh/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/SSH/$1 [L,R=301]
+RewriteRule ^ssh$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/SSH/ [L,R=301]
 
 # Redirect mobile to Mobile
-RewriteRule ^mobile/(.*)$ Mobile/$1 [L,R=301]
-RewriteRule ^mobile$ Mobile/ [L,R=301]
+RewriteRule ^mobile/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/Mobile/$1 [L,R=301]
+RewriteRule ^mobile$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/Mobile/ [L,R=301]
 
 # Redirect yubikey5ci to Mobile
-RewriteRule ^yubikey5ci/(.*)$ /Mobile/$1 [L,R=301]
-RewriteRule ^yubikey5ci$ /Mobile/ [L,R=301]
+RewriteRule ^yubikey5ci/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/Mobile/$1 [L,R=301]
+RewriteRule ^yubikey5ci$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/Mobile/ [L,R=301]
 
 # Redirect developer-program to Developer_Program
-RewriteRule ^developer-program/(.*)$ Developer_Program/$1 [L,R=301]
-RewriteRule ^developer-program$ Developer_Program/ [L,R=301]
+RewriteRule ^developer-program/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/Developer_Program/$1 [L,R=301]
+RewriteRule ^developer-program$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/Developer_Program/ [L,R=301]
 
 # Redirects links to releases and documentation
-RewriteRule ^([0-9a-z-]+)/releases/(.*)$ $1/Releases/$2 [L,R=301]
-RewriteRule ^([0-9a-z-]+)/releases.html $1/Releases/ [L,R=301]
-RewriteRule ^([0-9a-z-]+)/doc/(.*)$ $1/$2 [L,R=301]
+RewriteRule ^([0-9a-z-]+)/releases/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/$1/Releases/$2 [L,R=301]
+RewriteRule ^([0-9a-z-]+)/releases.html %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/$1/Releases/ [L,R=301]
+RewriteRule ^([0-9a-z-]+)/doc/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/$1/$2 [L,R=301]
 
 # Redirect .adocfiles to .html
 RewriteCond "! -f %{REQUEST_FILENAME}"
-RewriteRule ^(.*)\.adoc$ $1.html [L,R=301]
+RewriteRule ^(.*)\.adoc$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/$1.html [L,R=301]
 
 # Error pages
 ErrorDocument 404 /404.html

--- a/content/OTP/.htaccess
+++ b/content/OTP/.htaccess
@@ -1,1 +1,4 @@
-Redirect 301 "/OTP/Test_Vectors.html" "/OTP/Specifications/Test_vectors.html"
+RewriteEngine On
+RewriteBase /OTP/
+
+RewriteRule ^Test_Vectors.html$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/OTP/Specifications/Test_vectors.html [L,R=301]

--- a/content/Software_Projects/.htaccess
+++ b/content/Software_Projects/.htaccess
@@ -2,9 +2,9 @@ RewriteEngine On
 
 # Redirect Yubico_OTP/ to Yubico_OTP/
 RewriteBase /Software_Projects/
-RewriteRule ^YubiKey_OTP/(.*)$ Yubico_OTP/$1 [L,R=301]
+RewriteRule ^YubiKey_OTP/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/Software_Projects/Yubico_OTP/$1 [L,R=301]
 
 # Redirect Mobile_SDK/ to Mobile/
 RewriteBase /Software_Projects/Mobile_SDK/
-RewriteRule ^Mobile_SDK/(.*)$ ../../Mobile/$1 [L,R=301]
-RewriteRule ^Mobile_SDK$ ../../Mobile/ [L,R=301]
+RewriteRule ^Mobile_SDK/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/Mobile/$1 [L,R=301]
+RewriteRule ^Mobile_SDK$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/Mobile/ [L,R=301]

--- a/content/Software_Projects/Yubico_OTP/.htaccess
+++ b/content/Software_Projects/Yubico_OTP/.htaccess
@@ -2,5 +2,5 @@ RewriteEngine On
 
 # Redirect Yubico_OTP/ to Yubico_OTP/
 RewriteBase /Software_Projects/Yubico_OTP/
-RewriteRule ^YubiKey_OTP_Codec_Libraries/(.*)$ Yubico_OTP_Codec_Libraries/$1 [L,R=301]
-RewriteRule ^YubiKey_OTP_Integration_Plug-ins/(.*)$ Yubico_OTP_Integration_Plug-ins/$1 [L,R=301]
+RewriteRule ^YubiKey_OTP_Codec_Libraries/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/Software_Projects/Yubico_OTP/Yubico_OTP_Codec_Libraries/$1 [L,R=301]
+RewriteRule ^YubiKey_OTP_Integration_Plug-ins/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/Software_Projects/Yubico_OTP/Yubico_OTP_Integration_Plug-ins/$1 [L,R=301]

--- a/content/projects/yubico-piv-tool/.htaccess
+++ b/content/projects/yubico-piv-tool/.htaccess
@@ -1,10 +1,12 @@
-Redirect 301 "/yubico-piv-tool/Windows_certificate.html" "/PIV/Guides/Windows_CA_issued_certificate.html"
-Redirect 301 "/yubico-piv-tool/Windows-Certificate.html" "/PIV/Guides/Windows_CA_issued_certificate.html"
-Redirect 301 "/yubico-piv-tool/CertificateAuthorityWithNEO.html" "/PIV/Guides/Certificate_authority.html"
-Redirect 301 "/yubico-piv-tool/Certificate_Authority_with_NEO.html" "/PIV/Guides/Certificate_authority.html"
-Redirect 301 "/yubico-piv-tool/Certificate_Authority.html" "/PIV/Guides/Certificate_authority.html"
-Redirect 301 "/yubico-piv-tool/OS-X-Codesigning.html" "/PIV/Guides/Mac_code_signing.html"
-Redirect 301 "/yubico-piv-tool/OS_X_code_signing.html" "/PIV/Guides/Mac_code_signing.html"
-Redirect 301 "/yubico-piv-tool/SSH_User_certificates.html" "/PIV/Guides/SSH_user_certificates.html"
-Redirect 301 "/yubico-piv-tool/SSH_with_PIV_and_PKCS11.html" "/PIV/Guides/SSH_with_PIV_and_PKCS11.html"
-Redirect 301 "/yubico-piv-tool/Android_code_signing.html" "/PIV/Guides/Android_code_signing.html"
+RewriteEngine On
+RewriteBase /yubico-piv-tool/
+RewriteRule ^Windows_certificate.html$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/PIV/Guides/Windows_CA_issued_certificate.html [L,R=301]
+RewriteRule ^Windows-Certificate.html$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/PIV/Guides/Windows_CA_issued_certificate.html [L,R=301]
+RewriteRule ^CertificateAuthorityWithNEO.html$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/PIV/Guides/Certificate_authority.html [L,R=301]
+RewriteRule ^Certificate_Authority_with_NEO.html$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/PIV/Guides/Certificate_authority.html [L,R=301]
+RewriteRule ^Certificate_Authority.html$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/PIV/Guides/Certificate_authority.html [L,R=301]
+RewriteRule ^OS-X-Codesigning.html$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/PIV/Guides/Mac_code_signing.html [L,R=301]
+RewriteRule ^OS_X_code_signing.html$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/PIV/Guides/Mac_code_signing.html [L,R=301]
+RewriteRule ^SSH_User_certificates.html$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/PIV/Guides/SSH_user_certificates.html [L,R=301]
+RewriteRule ^SSH_with_PIV_and_PKCS11.html$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/PIV/Guides/SSH_with_PIV_and_PKCS11.html [L,R=301]
+RewriteRule ^Android_code_signing.html$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/PIV/Guides/Android_code_signing.html [L,R=301]

--- a/devyco/modules/git.py
+++ b/devyco/modules/git.py
@@ -150,6 +150,7 @@ class GitModule(Module):
         if redirects:
             htaccess = path.join(self._target, '.htaccess')
             with open(htaccess, 'a') as f:
+                f.writelines(["RewriteEngine On\n"])
                 f.writelines(redirects)
 
     def _get_old_names(self, repo_dir, directory, fname, subs):
@@ -179,8 +180,8 @@ class GitModule(Module):
         basepath = path.join(*self._context['path'])
         new_path = path.join(basepath, names[0])
         for old_name in names[1:]:
-            redirects.add('Redirect 301 "/%s" "/%s"\n' % (
-                path.join(basepath, old_name), new_path))
+            redirects.add('RewriteRule ^%s$ %%{ENV:REQUEST_PROTO}://%%{HTTP_HOST}/%s [L,R=301]\n' % (
+                old_name, new_path))
         return list(redirects)
 
 

--- a/devyco/modules/releases.py
+++ b/devyco/modules/releases.py
@@ -157,15 +157,15 @@ class ReleasesModule(Module):
         with open(confpath, 'w') as f:
             json.dump(conf, f)
 
-        redirects = self._create_latest(entries, path.join(self._context['path'][0], target))
+        redirects = self._create_latest(entries, path.join(self._context['path'][0], target), target)
 
         if redirects:
             htaccess = path.join(self._target, '.htaccess')
             with open(htaccess, 'a') as f:
                 f.writelines(redirects)
 
-    def _create_latest(self, entries, path):
-        ret = ""
+    def _create_latest(self, entries, path, relpath):
+        ret = 'RewriteEngine On\n'
         created = {}
         for entry in entries:
             ver = entry["version"]
@@ -179,13 +179,13 @@ class ReleasesModule(Module):
                         continue
                     created[suffix] = 1
                     link = re.sub(r"-" + ver, "-latest", name)
-                    redir = 'Redirect 302 "/%s/%s" "/%s/%s"\n' % (
-                            path, link, path, name)
+                    redir = 'RewriteRule ^%s/%s$ %%{ENV:REQUEST_PROTO}://%%{HTTP_HOST}/%s/%s [L,R=302]\n' % (
+                            relpath, link, path, name)
                     ret += redir
                     if sig:
                         link = re.sub(r"-" + ver, "-latest", sig)
-                        redir = 'Redirect 302 "/%s/%s" "/%s/%s"\n' % (
-                                path, link, path, sig)
+                        redir = 'RewriteRule ^%s/%s$ %%{ENV:REQUEST_PROTO}://%%{HTTP_HOST}/%s/%s [L,R=302]\n' % (
+                                relpath, link, path, sig)
                         ret += redir
         return ret
 

--- a/httpd.conf
+++ b/httpd.conf
@@ -24,6 +24,10 @@ LoadModule dir_module modules/mod_dir.so
 LoadModule negotiation_module modules/mod_negotiation.so
 LoadModule alias_module modules/mod_alias.so
 LoadModule rewrite_module modules/mod_rewrite.so
+LoadModule setenvif_module modules/mod_setenvif.so
+
+SetEnvIf Request_URI "^.*" REQUEST_PROTO=https
+SetEnvIf X-Forwarded-Proto "^http$" REQUEST_PROTO=http
 
 ErrorLog /dev/stderr
 LogLevel warn


### PR DESCRIPTION
We need to redirect to https if the client is using https for the
original request. So adding support for X-Forwarded-Proto. This means no
longer being able to rely on Redirect from mod_alias, and instead using
mod_rewrite to do all 301s/302s.