### PR TITLE
libfido2: sync docs

### DIFF
--- a/content/projects/libfido2/Manuals/fido2-assert.partial
+++ b/content/projects/libfido2/Manuals/fido2-assert.partial
@@ -29,6 +29,8 @@
     <td><code class="Nm" title="Nm">fido2-assert</code></td>
     <td><code class="Fl" title="Fl">-G</code>
       [<div class="Op"><code class="Fl" title="Fl">-dhpruv</code></div>]
+      [<div class="Op"><code class="Fl" title="Fl">-t</code>
+      <var class="Ar" title="Ar">option</var></div>]
       [<div class="Op"><code class="Fl" title="Fl">-i</code>
       <var class="Ar" title="Ar">input_file</var></div>]
       [<div class="Op"><code class="Fl" title="Fl">-o</code>
@@ -110,18 +112,38 @@ The options are as follows:
       <code class="Fl" title="Fl">-r</code> is specified,
       <code class="Nm" title="Nm">fido2-assert</code> will not expect a
       credential id in its input, and may output multiple assertions.</dd>
+  <dt><a class="permalink" href="#t"><code class="Fl" title="Fl" id="t">-t</code></a>
+    <var class="Ar" title="Ar">option</var></dt>
+  <dd>Toggles a key/value <var class="Ar" title="Ar">option</var>, where
+      <var class="Ar" title="Ar">option</var> is a string of the form
+      &#x201C;key=value&#x201D;. The options supported at present are:
+    <dl class="Bl-tag">
+      <dt><a class="permalink" href="#up"><code class="Cm" title="Cm" id="up">up</code></a>=<var class="Ar" title="Ar">true|false</var></dt>
+      <dd>Asks the authenticator for user presence to be enabled or
+        disabled.</dd>
+      <dt><a class="permalink" href="#uv"><code class="Cm" title="Cm" id="uv">uv</code></a>=<var class="Ar" title="Ar">true|false</var></dt>
+      <dd>Asks the authenticator for user verification to be enabled or
+          disabled.</dd>
+      <dt><a class="permalink" href="#pin"><code class="Cm" title="Cm" id="pin">pin</code></a>=<var class="Ar" title="Ar">true|false</var></dt>
+      <dd>Tells <code class="Nm" title="Nm">fido2-assert</code> whether to
+          prompt for a PIN and request user verification.</dd>
+    </dl>
+    <div class="Pp"></div>
+    The <code class="Fl" title="Fl">-t</code> option may be specified multiple
+      times.</dd>
   <dt><a class="permalink" href="#u"><code class="Fl" title="Fl" id="u">-u</code></a></dt>
   <dd>Obtain an assertion using U2F. By default,
       <code class="Nm" title="Nm">fido2-assert</code> will use FIDO2 if
       supported by the authenticator, and fallback to U2F otherwise.</dd>
   <dt><a class="permalink" href="#v"><code class="Fl" title="Fl" id="v">-v</code></a></dt>
   <dd>If obtaining an assertion, prompt the user for a PIN and request user
-      verification from the authenticator. If a <i class="Em" title="Em">tty</i>
-      is available, <code class="Nm" title="Nm">fido2-assert</code> will use it
-      to obtain the PIN. Otherwise, <i class="Em" title="Em">stdin</i> is used.
-      If verifying an assertion, check whether the user verification bit was
-      signed by the authenticator.</dd>
+      verification from the authenticator. If verifying an assertion, check
+      whether the user verification bit was signed by the authenticator.</dd>
 </dl>
+<div class="Pp"></div>
+If a <i class="Em" title="Em">tty</i> is available,
+  <code class="Nm" title="Nm">fido2-assert</code> will use it to obtain the PIN.
+  Otherwise, <i class="Em" title="Em">stdin</i> is used.
 <h1 class="Sh" title="Sh" id="INPUT_FORMAT"><a class="permalink" href="#INPUT_FORMAT">INPUT
   FORMAT</a></h1>
 The input of <code class="Nm" title="Nm">fido2-assert</code> consists of base64

--- a/content/projects/libfido2/Manuals/fido2-cred.partial
+++ b/content/projects/libfido2/Manuals/fido2-cred.partial
@@ -29,6 +29,8 @@
     <td><code class="Nm" title="Nm">fido2-cred</code></td>
     <td><code class="Fl" title="Fl">-M</code>
       [<div class="Op"><code class="Fl" title="Fl">-dhqruv</code></div>]
+      [<div class="Op"><code class="Fl" title="Fl">-c</code>
+      <var class="Ar" title="Ar">cred_protect</var></div>]
       [<div class="Op"><code class="Fl" title="Fl">-i</code>
       <var class="Ar" title="Ar">input_file</var></div>]
       [<div class="Op"><code class="Fl" title="Fl">-o</code>
@@ -43,6 +45,8 @@
     <td><code class="Nm" title="Nm">fido2-cred</code></td>
     <td><code class="Fl" title="Fl">-V</code>
       [<div class="Op"><code class="Fl" title="Fl">-dhv</code></div>]
+      [<div class="Op"><code class="Fl" title="Fl">-c</code>
+      <var class="Ar" title="Ar">cred_protect</var></div>]
       [<div class="Op"><code class="Fl" title="Fl">-i</code>
       <var class="Ar" title="Ar">input_file</var></div>]
       [<div class="Op"><code class="Fl" title="Fl">-o</code>
@@ -90,6 +94,12 @@ The options are as follows:
   <dt><a class="permalink" href="#V"><code class="Fl" title="Fl" id="V">-V</code></a></dt>
   <dd>Tells <code class="Nm" title="Nm">fido2-cred</code> to verify a
       credential.</dd>
+  <dt><a class="permalink" href="#c"><code class="Fl" title="Fl" id="c">-c</code></a>
+    <var class="Ar" title="Ar">cred_protect</var></dt>
+  <dd>If making a credential, set the credential's protection level to
+      <var class="Ar" title="Ar">cred_protect</var>. If verifying a credential,
+      check whether the credential's protection level was signed by the
+      authenticator as <var class="Ar" title="Ar">cred_protect</var>.</dd>
   <dt><a class="permalink" href="#d"><code class="Fl" title="Fl" id="d">-d</code></a></dt>
   <dd>Causes <code class="Nm" title="Nm">fido2-cred</code> to emit debugging
       output on <i class="Em" title="Em">stderr</i>.</dd>

--- a/content/projects/libfido2/Manuals/fido_assert_flags.partial
+++ b/content/projects/libfido2/Manuals/fido_assert_flags.partial
@@ -1,0 +1,1 @@
+fido_assert_new.partial

--- a/content/projects/libfido2/Manuals/fido_assert_id_len.partial
+++ b/content/projects/libfido2/Manuals/fido_assert_id_len.partial
@@ -1,0 +1,1 @@
+fido_assert_new.partial

--- a/content/projects/libfido2/Manuals/fido_assert_id_ptr.partial
+++ b/content/projects/libfido2/Manuals/fido_assert_id_ptr.partial
@@ -1,0 +1,1 @@
+fido_assert_new.partial

--- a/content/projects/libfido2/Manuals/fido_assert_new.partial
+++ b/content/projects/libfido2/Manuals/fido_assert_new.partial
@@ -24,6 +24,7 @@
 <code class="Nm" title="Nm">fido_assert_new</code>,
   <code class="Nm" title="Nm">fido_assert_free</code>,
   <code class="Nm" title="Nm">fido_assert_count</code>,
+  <code class="Nm" title="Nm">fido_assert_rp_id</code>,
   <code class="Nm" title="Nm">fido_assert_user_display_name</code>,
   <code class="Nm" title="Nm">fido_assert_user_icon</code>,
   <code class="Nm" title="Nm">fido_assert_user_name</code>,
@@ -32,12 +33,15 @@
   <code class="Nm" title="Nm">fido_assert_hmac_secret_ptr</code>,
   <code class="Nm" title="Nm">fido_assert_user_id_ptr</code>,
   <code class="Nm" title="Nm">fido_assert_sig_ptr</code>,
+  <code class="Nm" title="Nm">fido_assert_id_ptr</code>,
   <code class="Nm" title="Nm">fido_assert_authdata_len</code>,
   <code class="Nm" title="Nm">fido_assert_clientdata_hash_len</code>,
   <code class="Nm" title="Nm">fido_assert_hmac_secret_len</code>,
   <code class="Nm" title="Nm">fido_assert_user_id_len</code>,
   <code class="Nm" title="Nm">fido_assert_sig_len</code>,
-  <code class="Nm" title="Nm">fido_assert_sigcount</code> &#x2014;
+  <code class="Nm" title="Nm">fido_assert_id_len</code>,
+  <code class="Nm" title="Nm">fido_assert_sigcount</code>,
+  <code class="Nm" title="Nm">fido_assert_flags</code> &#x2014;
 <div class="Nd" title="Nd">FIDO 2 assertion API</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
@@ -55,6 +59,11 @@
 <var class="Ft" title="Ft">size_t</var>
 <br/>
 <code class="Fn" title="Fn">fido_assert_count</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_assert_t *assert</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">const char *</var>
+<br/>
+<code class="Fn" title="Fn">fido_assert_rp_id</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_assert_t *assert</var>);
 <div class="Pp"></div>
 <var class="Ft" title="Ft">const char *</var>
@@ -104,6 +113,12 @@
   fido_assert_t *assert</var>,
   <var class="Fa" title="Fa" style="white-space: nowrap;">size_t idx</var>);
 <div class="Pp"></div>
+<var class="Ft" title="Ft">const unsigned char *</var>
+<br/>
+<code class="Fn" title="Fn">fido_assert_id_ptr</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_assert_t *assert</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">size_t idx</var>);
+<div class="Pp"></div>
 <var class="Ft" title="Ft">size_t</var>
 <br/>
 <code class="Fn" title="Fn">fido_assert_authdata_len</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
@@ -133,9 +148,21 @@
   fido_assert_t *assert</var>,
   <var class="Fa" title="Fa" style="white-space: nowrap;">size_t idx</var>);
 <div class="Pp"></div>
+<var class="Ft" title="Ft">size_t</var>
+<br/>
+<code class="Fn" title="Fn">fido_assert_id_len</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_assert_t *assert</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">size_t idx</var>);
+<div class="Pp"></div>
 <var class="Ft" title="Ft">uint32_t</var>
 <br/>
 <code class="Fn" title="Fn">fido_assert_sigcount</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_assert_t *assert</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">size_t idx</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">uint8_t</var>
+<br/>
+<code class="Fn" title="Fn">fido_assert_flags</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_assert_t *assert</var>,
   <var class="Fa" title="Fa" style="white-space: nowrap;">size_t idx</var>);
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
@@ -167,6 +194,10 @@ The <code class="Fn" title="Fn">fido_assert_free</code>() function releases the
 The <code class="Fn" title="Fn">fido_assert_count</code>() function returns the
   number of statements in <var class="Fa" title="Fa">assert</var>.
 <div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_assert_rp_id</code>() function returns a
+  pointer to a NUL-terminated string holding the relying party ID of
+  <var class="Fa" title="Fa">assert</var>.
+<div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_assert_user_display_name</code>(),
   <code class="Fn" title="Fn">fido_assert_user_icon</code>(), and
   <code class="Fn" title="Fn">fido_assert_user_name</code>(), functions return
@@ -177,20 +208,26 @@ The <code class="Fn" title="Fn">fido_assert_user_display_name</code>(),
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_assert_user_id_ptr</code>(),
   <code class="Fn" title="Fn">fido_assert_authdata_ptr</code>(),
-  <code class="Fn" title="Fn">fido_assert_hmac_secret_ptr</code>(), and
-  <code class="Fn" title="Fn">fido_assert_sig_ptr</code>() functions return
-  pointers to the user ID, authenticator data, hmac-secret, and signature
-  attributes of statement <var class="Fa" title="Fa">idx</var> in
+  <code class="Fn" title="Fn">fido_assert_hmac_secret_ptr</code>(),
+  <code class="Fn" title="Fn">fido_assert_sig_ptr</code>(), and
+  <code class="Fn" title="Fn">fido_assert_id_ptr</code>() functions return
+  pointers to the user ID, authenticator data, hmac-secret, signature, and
+  credential ID attributes of statement <var class="Fa" title="Fa">idx</var> in
   <var class="Fa" title="Fa">assert</var>. The
   <code class="Fn" title="Fn">fido_assert_user_id_len</code>(),
   <code class="Fn" title="Fn">fido_assert_authdata_len</code>(),
-  <code class="Fn" title="Fn">fido_assert_hmac_secret_len</code>(), and
-  <code class="Fn" title="Fn">fido_assert_sig_len</code>() functions can be used
+  <code class="Fn" title="Fn">fido_assert_hmac_secret_len</code>(),
+  <code class="Fn" title="Fn">fido_assert_sig_len</code>(), and
+  <code class="Fn" title="Fn">fido_assert_id_len</code>() functions can be used
   to retrieve the corresponding length of a specific attribute.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_assert_sigcount</code>() function can be
   used to obtain the signature counter of statement
   <var class="Fa" title="Fa">idx</var> in
+  <var class="Fa" title="Fa">assert</var>.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_assert_flags</code>() function returns the
+  authenticator data flags of statement <var class="Fa" title="Fa">idx</var> in
   <var class="Fa" title="Fa">assert</var>.
 <div class="Pp"></div>
 Please note that the first statement in <var class="Fa" title="Fa">assert</var>

--- a/content/projects/libfido2/Manuals/fido_assert_rp_id.partial
+++ b/content/projects/libfido2/Manuals/fido_assert_rp_id.partial
@@ -1,0 +1,1 @@
+fido_assert_new.partial

--- a/content/projects/libfido2/Manuals/fido_cbor_info_maxcredcntlst.partial
+++ b/content/projects/libfido2/Manuals/fido_cbor_info_maxcredcntlst.partial
@@ -1,0 +1,1 @@
+fido_cbor_info_new.partial

--- a/content/projects/libfido2/Manuals/fido_cbor_info_maxcredidlen.partial
+++ b/content/projects/libfido2/Manuals/fido_cbor_info_maxcredidlen.partial
@@ -1,0 +1,1 @@
+fido_cbor_info_new.partial

--- a/content/projects/libfido2/Manuals/fido_cbor_info_new.partial
+++ b/content/projects/libfido2/Manuals/fido_cbor_info_new.partial
@@ -36,6 +36,8 @@
   <code class="Nm" title="Nm">fido_cbor_info_versions_len</code>,
   <code class="Nm" title="Nm">fido_cbor_info_options_len</code>,
   <code class="Nm" title="Nm">fido_cbor_info_maxmsgsiz</code>,
+  <code class="Nm" title="Nm">fido_cbor_info_maxcredcntlst</code>,
+  <code class="Nm" title="Nm">fido_cbor_info_maxcredidlen</code>,
   <code class="Nm" title="Nm">fido_cbor_info_fwversion</code> &#x2014;
 <div class="Nd" title="Nd">FIDO 2 CBOR Info API</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
@@ -120,6 +122,16 @@
 <div class="Pp"></div>
 <var class="Ft" title="Ft">uint64_t</var>
 <br/>
+<code class="Fn" title="Fn">fido_cbor_info_maxcredcntlst</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cbor_info_t *ci</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">uint64_t</var>
+<br/>
+<code class="Fn" title="Fn">fido_cbor_info_maxcredidlen</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cbor_info_t *ci</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">uint64_t</var>
+<br/>
 <code class="Fn" title="Fn">fido_cbor_info_fwversion</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_cbor_info_t *ci</var>);
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
@@ -149,9 +161,9 @@ The <code class="Fn" title="Fn">fido_cbor_info_aaguid_ptr</code>(),
   <code class="Fn" title="Fn">fido_cbor_info_extensions_ptr</code>(),
   <code class="Fn" title="Fn">fido_cbor_info_protocols_ptr</code>(), and
   <code class="Fn" title="Fn">fido_cbor_info_versions_ptr</code>() functions
-  return pointers to the AAGUID, supported extensions, PIN protocol and CTAP
-  version strings of <var class="Fa" title="Fa">ci</var>. The corresponding
-  length of a given attribute can be obtained by
+  return pointers to the authenticator attestation GUID, supported extensions,
+  PIN protocol and CTAP version strings of <var class="Fa" title="Fa">ci</var>.
+  The corresponding length of a given attribute can be obtained by
   <code class="Fn" title="Fn">fido_cbor_info_aaguid_len</code>(),
   <code class="Fn" title="Fn">fido_cbor_info_extensions_len</code>(),
   <code class="Fn" title="Fn">fido_cbor_info_protocols_len</code>(), or
@@ -166,6 +178,14 @@ The <code class="Fn" title="Fn">fido_cbor_info_options_name_ptr</code>() and
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_cbor_info_maxmsgsiz</code>() function
   returns the maximum message size attribute of
+  <var class="Fa" title="Fa">ci</var>.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_cbor_info_maxcredcntlst</code>() function
+  returns the maximum supported number of credentials in a single credential ID
+  list as reported in <var class="Fa" title="Fa">ci</var>.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_cbor_info_maxcredidlen</code>() function
+  returns the maximum supported length of a credential ID as reported in
   <var class="Fa" title="Fa">ci</var>.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_cbor_info_fwversion</code>() function

--- a/content/projects/libfido2/Manuals/fido_cred_aaguid_len.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_aaguid_len.partial
@@ -1,0 +1,1 @@
+fido_cred_new.partial

--- a/content/projects/libfido2/Manuals/fido_cred_aaguid_ptr.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_aaguid_ptr.partial
@@ -1,0 +1,1 @@
+fido_cred_new.partial

--- a/content/projects/libfido2/Manuals/fido_cred_display_name.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_display_name.partial
@@ -1,0 +1,1 @@
+fido_cred_new.partial

--- a/content/projects/libfido2/Manuals/fido_cred_flags.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_flags.partial
@@ -1,0 +1,1 @@
+fido_cred_new.partial

--- a/content/projects/libfido2/Manuals/fido_cred_new.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_new.partial
@@ -25,18 +25,28 @@
   <code class="Nm" title="Nm">fido_cred_free</code>,
   <code class="Nm" title="Nm">fido_cred_prot</code>,
   <code class="Nm" title="Nm">fido_cred_fmt</code>,
+  <code class="Nm" title="Nm">fido_cred_rp_id</code>,
+  <code class="Nm" title="Nm">fido_cred_rp_name</code>,
+  <code class="Nm" title="Nm">fido_cred_user_name</code>,
+  <code class="Nm" title="Nm">fido_cred_display_name</code>,
   <code class="Nm" title="Nm">fido_cred_authdata_ptr</code>,
   <code class="Nm" title="Nm">fido_cred_clientdata_hash_ptr</code>,
   <code class="Nm" title="Nm">fido_cred_id_ptr</code>,
+  <code class="Nm" title="Nm">fido_cred_aaguid_ptr</code>,
   <code class="Nm" title="Nm">fido_cred_pubkey_ptr</code>,
   <code class="Nm" title="Nm">fido_cred_sig_ptr</code>,
+  <code class="Nm" title="Nm">fido_cred_user_id_ptr</code>,
   <code class="Nm" title="Nm">fido_cred_x5c_ptr</code>,
   <code class="Nm" title="Nm">fido_cred_authdata_len</code>,
   <code class="Nm" title="Nm">fido_cred_clientdata_hash_len</code>,
   <code class="Nm" title="Nm">fido_cred_id_len</code>,
+  <code class="Nm" title="Nm">fido_cred_aaguid_len</code>,
   <code class="Nm" title="Nm">fido_cred_pubkey_len</code>,
   <code class="Nm" title="Nm">fido_cred_sig_len</code>,
-  <code class="Nm" title="Nm">fido_cred_x5c_len</code> &#x2014;
+  <code class="Nm" title="Nm">fido_cred_user_id_len</code>,
+  <code class="Nm" title="Nm">fido_cred_x5c_len</code>,
+  <code class="Nm" title="Nm">fido_cred_type</code>,
+  <code class="Nm" title="Nm">fido_cred_flags</code> &#x2014;
 <div class="Nd" title="Nd">FIDO 2 credential API</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
@@ -61,6 +71,26 @@
 <code class="Fn" title="Fn">fido_cred_fmt</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_cred_t *cred</var>);
 <div class="Pp"></div>
+<var class="Ft" title="Ft">const char *</var>
+<br/>
+<code class="Fn" title="Fn">fido_cred_rp_id</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cred_t *cred</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">const char *</var>
+<br/>
+<code class="Fn" title="Fn">fido_cred_rp_name</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cred_t *cred</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">const char *</var>
+<br/>
+<code class="Fn" title="Fn">fido_cred_user_name</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cred_t *cred</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">const char *</var>
+<br/>
+<code class="Fn" title="Fn">fido_cred_display_name</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cred_t *cred</var>);
+<div class="Pp"></div>
 <var class="Ft" title="Ft">const unsigned char *</var>
 <br/>
 <code class="Fn" title="Fn">fido_cred_authdata_ptr</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
@@ -78,12 +108,22 @@
 <div class="Pp"></div>
 <var class="Ft" title="Ft">const unsigned char *</var>
 <br/>
+<code class="Fn" title="Fn">fido_cred_aaguid_ptr</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cred_t *cred</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">const unsigned char *</var>
+<br/>
 <code class="Fn" title="Fn">fido_cred_pubkey_ptr</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_cred_t *cred</var>);
 <div class="Pp"></div>
 <var class="Ft" title="Ft">const unsigned char *</var>
 <br/>
 <code class="Fn" title="Fn">fido_cred_sig_ptr</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cred_t *cred</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">const unsigned char *</var>
+<br/>
+<code class="Fn" title="Fn">fido_cred_user_id_ptr</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_cred_t *cred</var>);
 <div class="Pp"></div>
 <var class="Ft" title="Ft">const unsigned char *</var>
@@ -108,6 +148,11 @@
 <div class="Pp"></div>
 <var class="Ft" title="Ft">size_t</var>
 <br/>
+<code class="Fn" title="Fn">fido_cred_aaguid_len</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cred_t *cred</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">size_t</var>
+<br/>
 <code class="Fn" title="Fn">fido_cred_pubkey_len</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_cred_t *cred</var>);
 <div class="Pp"></div>
@@ -118,7 +163,22 @@
 <div class="Pp"></div>
 <var class="Ft" title="Ft">size_t</var>
 <br/>
+<code class="Fn" title="Fn">fido_cred_user_id_len</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cred_t *cred</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">size_t</var>
+<br/>
 <code class="Fn" title="Fn">fido_cred_x5c_len</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cred_t *cred</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
+<code class="Fn" title="Fn">fido_cred_type</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cred_t *cred</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">uint8_t</var>
+<br/>
+<code class="Fn" title="Fn">fido_cred_flags</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_cred_t *cred</var>);
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
 FIDO 2 credentials are abstracted in <i class="Em" title="Em">libfido2</i> by
@@ -156,25 +216,46 @@ The <code class="Fn" title="Fn">fido_cred_fmt</code>() function returns a
   <var class="Fa" title="Fa">cred</var>, or NULL if
   <var class="Fa" title="Fa">cred</var> does not have a format set.
 <div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_cred_rp_id</code>(),
+  <code class="Fn" title="Fn">fido_cred_rp_name</code>(),
+  <code class="Fn" title="Fn">fido_cred_user_name</code>(), and
+  <code class="Fn" title="Fn">fido_cred_display_name</code>() functions return
+  pointers to NUL-terminated strings holding the relying party ID, relying party
+  name, user name, and user display name attributes of
+  <var class="Fa" title="Fa">cred</var>, or NULL if the respective entry is not
+  set.
+<div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_cred_authdata_ptr</code>(),
   <code class="Fn" title="Fn">fido_cred_clientdata_hash_ptr</code>(),
   <code class="Fn" title="Fn">fido_cred_id_ptr</code>(),
+  <code class="Fn" title="Fn">fido_cred_aaguid_ptr</code>(),
   <code class="Fn" title="Fn">fido_cred_pubkey_ptr</code>(),
-  <code class="Fn" title="Fn">fido_cred_sig_ptr</code>(), and
+  <code class="Fn" title="Fn">fido_cred_sig_ptr</code>(),
+  <code class="Fn" title="Fn">fido_cred_user_id_ptr</code>(), and
   <code class="Fn" title="Fn">fido_cred_x5c_ptr</code>() functions return
-  pointers to the authenticator data, client data hash, ID, public key,
-  signature and x509 certificate parts of <var class="Fa" title="Fa">cred</var>,
-  or NULL if the respective entry is not set.
+  pointers to the authenticator data, client data hash, ID, authenticator
+  attestation GUID, public key, signature, user ID, and x509 certificate parts
+  of <var class="Fa" title="Fa">cred</var>, or NULL if the respective entry is
+  not set.
 <div class="Pp"></div>
 The corresponding length can be obtained by
   <code class="Fn" title="Fn">fido_cred_authdata_len</code>(),
   <code class="Fn" title="Fn">fido_cred_clientdata_hash_len</code>(),
   <code class="Fn" title="Fn">fido_cred_id_len</code>(),
-  <code class="Fn" title="Fn">fido_cred_pubkey_len</code>(), and
-  <code class="Fn" title="Fn">fido_cred_sig_len</code>().
+  <code class="Fn" title="Fn">fido_cred_aaguid_len</code>(),
+  <code class="Fn" title="Fn">fido_cred_pubkey_len</code>(),
+  <code class="Fn" title="Fn">fido_cred_sig_len</code>(),
+  <code class="Fn" title="Fn">fido_cred_user_id_len</code>(), and
+  <code class="Fn" title="Fn">fido_cred_x5c_len</code>().
 <div class="Pp"></div>
 The authenticator data, x509 certificate, and signature parts of a credential
   are typically passed to a FIDO 2 server for verification.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_cred_type</code>() function returns the
+  COSE algorithm of <var class="Fa" title="Fa">cred</var>.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_cred_flags</code>() function returns the
+  authenticator data flags of <var class="Fa" title="Fa">cred</var>.
 <h1 class="Sh" title="Sh" id="RETURN_VALUES"><a class="permalink" href="#RETURN_VALUES">RETURN
   VALUES</a></h1>
 The authenticator data returned by
@@ -186,6 +267,7 @@ If not NULL, pointers returned by
   <code class="Fn" title="Fn">fido_cred_authdata_ptr</code>(),
   <code class="Fn" title="Fn">fido_cred_clientdata_hash_ptr</code>(),
   <code class="Fn" title="Fn">fido_cred_id_ptr</code>(),
+  <code class="Fn" title="Fn">fido_cred_aaguid_ptr</code>(),
   <code class="Fn" title="Fn">fido_cred_pubkey_ptr</code>(),
   <code class="Fn" title="Fn">fido_cred_sig_ptr</code>(), and
   <code class="Fn" title="Fn">fido_cred_x5c_ptr</code>() are guaranteed to exist

--- a/content/projects/libfido2/Manuals/fido_cred_rp_id.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_rp_id.partial
@@ -1,0 +1,1 @@
+fido_cred_new.partial

--- a/content/projects/libfido2/Manuals/fido_cred_rp_name.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_rp_name.partial
@@ -1,0 +1,1 @@
+fido_cred_new.partial

--- a/content/projects/libfido2/Manuals/fido_cred_type.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_type.partial
@@ -1,0 +1,1 @@
+fido_cred_new.partial

--- a/content/projects/libfido2/Manuals/fido_cred_user_id_len.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_user_id_len.partial
@@ -1,0 +1,1 @@
+fido_cred_new.partial

--- a/content/projects/libfido2/Manuals/fido_cred_user_id_ptr.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_user_id_ptr.partial
@@ -1,0 +1,1 @@
+fido_cred_new.partial

--- a/content/projects/libfido2/Manuals/fido_cred_user_name.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_user_name.partial
@@ -1,0 +1,1 @@
+fido_cred_new.partial

--- a/content/projects/libfido2/Manuals/fido_dev_get_touch_begin.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_get_touch_begin.partial
@@ -1,0 +1,83 @@
+<style>
+    table.head, table.foot { width: 100%; }
+    td.head-rtitle, td.foot-os { text-align: right; }
+    td.head-vol { text-align: center; }
+    div.Pp { margin: 1ex 0ex; }
+    div.Nd, div.Bf, div.Op { display: inline; }
+    span.Pa, span.Ad { font-style: italic; }
+    span.Ms { font-weight: bold; }
+    dl.Bl-diag > dt { font-weight: bold; }
+    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
+    code.Cd { font-weight: bold; font-family: monospace; }
+    var { font-family: monospace; }
+    .Sh { font-size: 1.5em; padding-top: 1em; padding-bottom: 1em; }
+</style>
+<table class="head">
+  <tr>
+    <td class="head-ltitle">FIDO_DEV_GET_TOUCH_BEGIN(3)</td>
+    <td class="head-vol">Library Functions Manual</td>
+    <td class="head-rtitle">FIDO_DEV_GET_TOUCH_BEGIN(3)</td>
+  </tr>
+</table>
+<div class="manual-text">
+<h1 class="Sh" title="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
+<code class="Nm" title="Nm">fido_dev_get_touch_begin</code>,
+  <code class="Nm" title="Nm">fido_dev_get_touch_status</code> &#x2014;
+<div class="Nd" title="Nd">asynchronously wait for touch on a FIDO 2
+  authenticator</div>
+<h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
+<code class="In" title="In">#include
+  &lt;<a class="In" title="In">fido.h</a>&gt;</code>
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
+<code class="Fn" title="Fn">fido_dev_get_touch_begin</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_dev_t
+  *dev</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
+<code class="Fn" title="Fn">fido_dev_get_touch_status</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_dev_t
+  *dev</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">int
+  *touched</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">int
+  ms</var>);
+<h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
+The functions described in this page allow an application to asynchronously wait
+  for touch on a FIDO authenticator. This is useful when multiple authenticators
+  are present and the application needs to know which one to use.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_dev_get_touch_begin</code>() function
+  initiates a touch request on <var class="Fa" title="Fa">dev</var>.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_dev_get_touch_status</code>() function
+  continues an ongoing touch request on <var class="Fa" title="Fa">dev</var>,
+  blocking up to <var class="Fa" title="Fa">ms</var> milliseconds. On success,
+  <var class="Fa" title="Fa">touched</var> will be updated to reflect the touch
+  request status. If <var class="Fa" title="Fa">touched</var> is 1, the device
+  was touched, and the touch request is terminated. If
+  <var class="Fa" title="Fa">touched</var> is 0, the application may call
+  <code class="Fn" title="Fn">fido_dev_get_touch_status</code>() to continue the
+  touch request, or <code class="Fn" title="Fn">fido_dev_cancel</code>() to
+  terminate it.
+<h1 class="Sh" title="Sh" id="RETURN_VALUES"><a class="permalink" href="#RETURN_VALUES">RETURN
+  VALUES</a></h1>
+The error codes returned by
+  <code class="Fn" title="Fn">fido_dev_get_touch_begin</code>() and
+  <code class="Fn" title="Fn">fido_dev_get_touch_status</code>() are defined in
+  <code class="In" title="In">&lt;<a class="In" title="In">fido/err.h</a>&gt;</code>.
+  On success, <code class="Dv" title="Dv">FIDO_OK</code> is returned.
+<h1 class="Sh" title="Sh" id="EXAMPLES"><a class="permalink" href="#EXAMPLES">EXAMPLES</a></h1>
+Please refer to <i class="Em" title="Em">examples/select.c</i> in
+  <i class="Em" title="Em">libfido2's</i> source tree.
+<h1 class="Sh" title="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
+  ALSO</a></h1>
+<a class="Xr" title="Xr" href="fido_dev_cancel.html">fido_dev_cancel(3)</a>
+<h1 class="Sh" title="Sh" id="CAVEATS"><a class="permalink" href="#CAVEATS">CAVEATS</a></h1>
+The <code class="Fn" title="Fn">fido_dev_get_touch_status</code>() function will
+  cause a command to be transmitted to U2F authenticators. These transmissions
+  should not exceed a frequency of 5Hz.</div>
+<table class="foot">
+  <tr>
+    <td class="foot-date">August 5, 2020</td>
+    <td class="foot-os">Darwin 19.6.0</td>
+  </tr>
+</table>

--- a/content/projects/libfido2/Manuals/fido_dev_open.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_open.partial
@@ -29,6 +29,9 @@
   <code class="Nm" title="Nm">fido_dev_force_fido2</code>,
   <code class="Nm" title="Nm">fido_dev_force_u2f</code>,
   <code class="Nm" title="Nm">fido_dev_is_fido2</code>,
+  <code class="Nm" title="Nm">fido_dev_supports_cred_prot</code>,
+  <code class="Nm" title="Nm">fido_dev_supports_pin</code>,
+  <code class="Nm" title="Nm">fido_dev_has_pin</code>,
   <code class="Nm" title="Nm">fido_dev_protocol</code>,
   <code class="Nm" title="Nm">fido_dev_build</code>,
   <code class="Nm" title="Nm">fido_dev_flags</code>,
@@ -77,6 +80,21 @@
 <var class="Ft" title="Ft">bool</var>
 <br/>
 <code class="Fn" title="Fn">fido_dev_is_fido2</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_dev_t *dev</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">bool</var>
+<br/>
+<code class="Fn" title="Fn">fido_dev_supports_cred_prot</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_dev_t *dev</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">bool</var>
+<br/>
+<code class="Fn" title="Fn">fido_dev_supports_pin</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_dev_t *dev</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">bool</var>
+<br/>
+<code class="Fn" title="Fn">fido_dev_has_pin</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_dev_t *dev</var>);
 <div class="Pp"></div>
 <var class="Ft" title="Ft">uint8_t</var>
@@ -139,6 +157,18 @@ The <code class="Fn" title="Fn">fido_dev_force_u2f</code>() function can be used
 The <code class="Fn" title="Fn">fido_dev_is_fido2</code>() function returns
   <code class="Dv" title="Dv">true</code> if
   <var class="Fa" title="Fa">dev</var> is a FIDO 2 device.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_dev_supports_cred_prot</code>() function
+  returns <code class="Dv" title="Dv">true</code> if
+  <var class="Fa" title="Fa">dev</var> supports FIDO 2.1 Credential Protection.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_dev_supports_pin</code>() function returns
+  <code class="Dv" title="Dv">true</code> if
+  <var class="Fa" title="Fa">dev</var> supports FIDO 2.0 Client PINs.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_dev_has_pin</code>() function returns
+  <code class="Dv" title="Dv">true</code> if
+  <var class="Fa" title="Fa">dev</var> has a FIDO 2.0 Client PIN set.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_dev_protocol</code>() function returns the
   CTAPHID protocol version identifier of <var class="Fa" title="Fa">dev</var>.

--- a/content/projects/libfido2/Manuals/fido_dev_set_io_functions.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_set_io_functions.partial
@@ -33,12 +33,16 @@ typedef void *fido_dev_io_open_t(const char *);
 typedef void  fido_dev_io_close_t(void *); 
 typedef int   fido_dev_io_read_t(void *, unsigned char *, size_t, int); 
 typedef int   fido_dev_io_write_t(void *, const unsigned char *, size_t); 
+typedef int   fido_dev_io_rx_t(struct fido_dev *, uint8_t, unsigned char *, size_t, int); 
+typedef int   fido_dev_io_tx_t(struct fido_dev *, uint8_t, const unsigned char *, size_t); 
  
 typedef struct fido_dev_io { 
 	fido_dev_io_open_t  *open; 
 	fido_dev_io_close_t *close; 
 	fido_dev_io_read_t  *read; 
 	fido_dev_io_write_t *write; 
+	fido_dev_io_rx_t    *rx; 
+	fido_dev_io_tx_t    *tx; 
 } fido_dev_io_t;
 </pre>
 </div>
@@ -50,9 +54,10 @@ typedef struct fido_dev_io {
   fido_dev_io_t *io</var>);
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
 The <code class="Nm" title="Nm">fido_dev_set_io_functions</code> interface
-  defines the I/O handlers used to talk to <var class="Fa" title="Fa">dev</var>.
-  Its usage is optional. By default, <i class="Em" title="Em">libfido2</i> will
-  use the operating system's native HID interface to talk to a FIDO device.
+  defines the I/O and transmission handlers used to talk to
+  <var class="Fa" title="Fa">dev</var>. Its usage is optional. By default,
+  <i class="Em" title="Em">libfido2</i> will use the operating system's native
+  HID interface to talk CTAP2 to a FIDO device.
 <div class="Pp"></div>
 A <var class="Vt" title="Vt">fido_dev_io_open_t</var> function is expected to
   return a non-NULL opaque pointer on success, and NULL on error. The returned
@@ -63,24 +68,53 @@ A <var class="Vt" title="Vt">fido_dev_io_close_t</var> function receives the
   <var class="Vt" title="Vt">fido_dev_io_open_t</var>. It is not expected to be
   idempotent.
 <div class="Pp"></div>
-A <var class="Vt" title="Vt">fido_dev_io_read_t</var> function reads from
-  <var class="Fa" title="Fa">dev</var>. The first parameter taken is the opaque
-  handle obtained from <var class="Vt" title="Vt">fido_dev_io_open_t</var>. The
-  read buffer is pointed to by the second parameter, and the third parameter
-  holds its size. Finally, the last argument passed to
+A <var class="Vt" title="Vt">fido_dev_io_read_t</var> function reads a single
+  HID report from <var class="Fa" title="Fa">dev</var>. The first parameter
+  taken is the opaque handle obtained from
+  <var class="Vt" title="Vt">fido_dev_io_open_t</var>. The read buffer is
+  pointed to by the second parameter, and the third parameter holds its size.
+  The last argument passed to
   <var class="Vt" title="Vt">fido_dev_io_read_t</var> is the number of
   milliseconds the caller is willing to sleep, should the call need to block. If
   this value holds -1, <var class="Vt" title="Vt">fido_dev_io_read_t</var> may
   block indefinitely. The number of bytes read is returned. On error, -1 is
   returned.
 <div class="Pp"></div>
-Conversely, a <var class="Vt" title="Vt">fido_dev_io_write_t</var> function
-  writes to <var class="Fa" title="Fa">dev</var>. The first parameter taken is
-  the opaque handle returned by
+A <var class="Vt" title="Vt">fido_dev_io_write_t</var> function writes a single
+  HID report to <var class="Fa" title="Fa">dev</var>. The first parameter taken
+  is the opaque handle returned by
   <var class="Vt" title="Vt">fido_dev_io_open_t</var>. The write buffer is
   pointed to by the second parameter, and the third parameter holds its size. A
   <var class="Vt" title="Vt">fido_dev_io_write_t</var> function may block. The
   number of bytes written is returned. On error, -1 is returned.
+<div class="Pp"></div>
+A <var class="Vt" title="Vt">fido_dev_io_rx_t</var> function receives a complete
+  CTAP2 message from <var class="Fa" title="Fa">dev</var>. The first parameter
+  taken is a pointer to <var class="Fa" title="Fa">dev</var>. The second
+  parameter holds the expected CTAP2 command byte. The read buffer is pointed to
+  by the third parameter, and the fourth parameter holds its size. The last
+  argument passed to <var class="Vt" title="Vt">fido_dev_io_rx_t</var> is the
+  number of milliseconds the caller is willing to sleep, should the call need to
+  block. If this value holds -1,
+  <var class="Vt" title="Vt">fido_dev_io_rx_t</var> may block indefinitely. The
+  number of bytes read is returned. On error, -1 is returned.
+<div class="Pp"></div>
+A <var class="Vt" title="Vt">fido_dev_io_tx_t</var> function transmits a
+  complete CTAP2 message to <var class="Fa" title="Fa">dev</var>. The first
+  parameter taken is a pointer to <var class="Fa" title="Fa">dev</var>. The
+  second parameter holds the CTAP2 command byte. The write buffer is pointed to
+  by the third parameter, and the fourth parameter holds its size. A
+  <var class="Vt" title="Vt">fido_dev_io_tx_t</var> function may block. On
+  success, 0 is returned. On error, -1 is returned.
+<div class="Pp"></div>
+When calling <code class="Fn" title="Fn">fido_dev_set_io_functions</code>(), the
+  <var class="Fa" title="Fa">open</var>, <var class="Fa" title="Fa">close</var>,
+  <var class="Fa" title="Fa">read</var> and
+  <var class="Fa" title="Fa">write</var> fields of
+  <var class="Fa" title="Fa">io</var> may not be NULL. Either
+  <var class="Fa" title="Fa">rx</var> or <var class="Fa" title="Fa">tx</var> may
+  be NULL, in which case <i class="Em" title="Em">libfido2</i> uses its
+  corresponding CTAP2 HID transport method.
 <div class="Pp"></div>
 No references to <var class="Fa" title="Fa">io</var> are held by
   <code class="Fn" title="Fn">fido_dev_set_io_functions</code>().

--- a/content/projects/libfido2/Manuals/fido_dev_supports_cred_prot.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_supports_cred_prot.partial
@@ -1,0 +1,1 @@
+fido_dev_open.partial

--- a/content/projects/libfido2/Manuals/fido_dev_supports_pin.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_supports_pin.partial
@@ -1,0 +1,1 @@
+fido_dev_open.partial


### PR DESCRIPTION
- document option -t (set toggle) in fido2-{assert,cred};
- add documentation for existing API calls:
  * fido_assert_flags();
  * fido_assert_id_len();
  * fido_assert_id_ptr();
  * fido_assert_rp_id();
  * fido_assert_sigcount();
  * fido_cred_display_name();
  * fido_cred_flags();
  * fido_cred_rp_id();
  * fido_cred_rp_name();
  * fido_cred_type();
  * fido_cred_user_id_len();
  * fido_cred_user_id_ptr();
  * fido_cred_user_name().
- new API calls:
  * fido_cbor_info_maxcredcntlst();
  * fido_cbor_info_maxcredidlen();
  * fido_cred_aaguid_len();
  * fido_cred_aaguid_ptr();
  * fido_dev_get_touch_begin();
  * fido_dev_get_touch_status();
  * fido_dev_has_pin();
  * fido_dev_supports_cred_prot();
  * fido_dev_supports_pin().