### PR TITLE
Updated three pages: index, detailed front-end design and manual back-end deployment

### DIFF
--- a/content/Developer_Program/WebAuthn_Starter_Kit/Detailed_Front-End_System_Design/Front-End_System_Design.adoc
+++ b/content/Developer_Program/WebAuthn_Starter_Kit/Detailed_Front-End_System_Design/Front-End_System_Design.adoc
@@ -134,11 +134,11 @@ The WebAuthn Relying Party is the server component for WebAuthn registration and
 ==== AWS Amplify
 
 Within the context of the WebAuthn Starter Kit project,
-link:https://id.atlassian.com/login?continue=https%3A%2F%2Fyubico.atlassian.net%2Flogin%3FredirectCount%3D1%26dest-url%3D%252Fwiki%252Fspaces%252FSOL%252Fpages%252F884113429%252FDetailed%252Bfront-end%252Bsystem%252Bdesign%26application%3Dconfluence&application=confluence#AWS-Amplify[AWS Amplify] is used for hosting the WebAuthn React web app, which can be executed in web browsers and thereby authenticate the client’s application with the WebAuthn protocol. More information on this is available in the section Re act web app development.
+AWS Amplify is used for hosting the WebAuthn React web app, which can be executed in web browsers and thereby authenticate the client’s application with the WebAuthn protocol. More information on this is available in the section Re act web app development.
 
 ==== AWS Cognito
 
-link:https://id.atlassian.com/login?continue=https%3A%2F%2Fyubico.atlassian.net%2Flogin%3FredirectCount%3D1%26dest-url%3D%252Fwiki%252Fspaces%252FSOL%252Fpages%252F884113429%252FDetailed%252Bfront-end%252Bsystem%252Bdesign%26application%3Dconfluence&application=confluence#AWS-Cognito[AWS Cognito] operates the User Pool, which supports the WebAuthn protocol as a custom authentication flow. Within the scope of the WebAuth Starter Kit, AWS Cognito is invoked from AWS Amplify that hosts the React app; both these apps authenticates to the AWS Cognito User Pool using WebAuthn.
+AWS Cognito operates the User Pool, which supports the WebAuthn protocol as a custom authentication flow. Within the scope of the WebAuth Starter Kit, AWS Cognito is invoked from AWS Amplify that hosts the React app; both these apps authenticates to the AWS Cognito User Pool using WebAuthn.
 
 AWS Cognito is also integrated with the AWS Lambda functions in the back-end. More information on the back-end integration is available in the section Lambda functions.
 
@@ -178,8 +178,7 @@ The following WebAuthn implementations are used on each desktop client:
 
  * *Apple Safari on Apple iOS*
 
-The JavaScript APIs `navigator.credentials.create()` and `navigator.credentials.get()` are exposed by each WebAuthn SDK, as described in section
-link:https://id.atlassian.com/login?continue=https%3A%2F%2Fyubico.atlassian.net%2Flogin%3FredirectCount%3D1%26dest-url%3D%252Fwiki%252Fspaces%252FSOL%252Fpages%252F884113429%252FDetailed%252Bfront-end%252Bsystem%252Bdesign%26application%3Dconfluence&application=confluence#WebAuthn-API[WebAuthn API].
+The JavaScript APIs `navigator.credentials.create()` and `navigator.credentials.get()` are exposed by each WebAuthn SDK.
 
 ===== Google Chrome with Microsoft Windows 10
 

--- a/content/Developer_Program/WebAuthn_Starter_Kit/Installation/Manually_Deploy_Webauthn_Back-End/Manual_Back-End_Deployment.adoc
+++ b/content/Developer_Program/WebAuthn_Starter_Kit/Installation/Manually_Deploy_Webauthn_Back-End/Manual_Back-End_Deployment.adoc
@@ -323,17 +323,17 @@ If the CORS policy is not properly enabled at the API Gateway, take the followin
 
 *Step 7.1:* Login to the AWS console, and select the *Service* called `API Gateway`.
 
-image::mback22-enable-CORS-policy-api-gateway-service-v1.jpg[]
+image::mback22-enable-cors-policy-api-gateway-service-v1.jpg[]
 *Figure 22 - Enabling the CORS policy at API Gateway - Select Service*
 
 *Step 7.2:* In the list under APIs, select the API named `WebAuthnKitAPI<suffix>`. In this example, the API is called `WebAuthnKitAPISeb`. The following window appears:
 
-image::mback23-enable-CORS-policy-api-gateway-api-v1.jpg[]
+image::mback23-enable-cors-policy-api-gateway-api-v1.jpg[]
 *Figure 23 - Enabling the CORS policy at API Gateway - Select API*
 
 *Step 7.3:* In this window, press the *Create* button.
 
-image::mback24-enable-CORS-policy-api-gateway-new-model-v1.jpg[]
+image::mback24-enable-cors-policy-api-gateway-new-model-v1.jpg[]
 *Figure 24 - Enabling the CORS policy at API Gateway - New model*
 
 *Step 7.4:* In the *New Model* pane, enter the following information:
@@ -358,7 +358,7 @@ image::mback24-enable-CORS-policy-api-gateway-new-model-v1.jpg[]
 
 *Step 7.7:* The credentials methods will be listed, as shown in the screenshot below.
 
-image::mback25-enable-CORS-policy-api-gateway-resources-v1.jpg[]
+image::mback25-enable-cors-policy-api-gateway-resources-v1.jpg[]
 *Figure 25 - Enabling the CORS policy at API Gateway - On Resources*
 
 *Step 7.8:* For each object called `/credentials`, `/codes`, `/fido2`, `/register`, `/pin` do the following:
@@ -369,17 +369,17 @@ b) Press the *Actions* button, and select the option `Enable CORS` in the drop-d
 
 *Step 7.9:* When all objects have been updated, select press the *Actions* button and select the option `Deploy API`:
 
-image::mback26-enable-CORS-policy-apigat-eway-select-deploy-api-v1.jpg[]
+image::mback26-enable-cors-policy-apigat-eway-select-deploy-api-v1.jpg[]
 *Figure 26 - Enabling the CORS policy at API Gateway - Select Deploy API*
 
 *Step 7.10:* In the *Deploy API* window, select *Deployment* stage `dev` and insert a deployment description. Press the *Deploy* button.
 
-image::mback27-enable-CORS-policy-api-gateway-select-deploy-api-v1.jpg[]
+image::mback27-enable-cors-policy-api-gateway-select-deploy-api-v1.jpg[]
 *Figure 27 - Enabling the CORS policy at API Gateway - Deploy API*
 
 *Step 7.11:* When the API has been deployed, the following window appears with the `dev` stage deployed.
 
-image::mback28-enable-CORS-policy-api-gateway-complete-v1.jpg[]
+image::mback28-enable-cors-policy-api-gateway-complete-v1.jpg[]
 *Figure 28 - Enabling the CORS policy at API Gateway - Complete*
 
 This completes the CORS deployment checks.

--- a/content/Developer_Program/WebAuthn_Starter_Kit/index.adoc
+++ b/content/Developer_Program/WebAuthn_Starter_Kit/index.adoc
@@ -11,7 +11,7 @@ We wanted to make this easier by describing the identifier first authentication 
 
 The starter kit adds WebAuthn to the AWS Cognito identity provider by integrating Yubico’s java webauthn server library into Cognito’s user pool custom authentication flow. It hosts an example web app on AWS Amplify Console so that you can try out the identifier-first authentication flow.
 
-video:https://www.youtube.com/watch?v=wZ1s4SOOqOQ[youtube]
+[![Watch the video](https://img.youtube.com/vi/wZ1s4SOOqOQ/maxresdefault.jpg)](https://youtu.be/wZ1s4SOOqOQ)
 
 The Yubico WebAuthn Starter kit is a project anyone can deploy on their own AWS account, providing a powerful tool for anyone looking to test a proof of concept for their organization, empowering them to deliver the vision and promise of WebAuthn with an end-to-end example of how to implement WebAuthn in their own services.
 

--- a/content/Developer_Program/WebAuthn_Starter_Kit/index.adoc
+++ b/content/Developer_Program/WebAuthn_Starter_Kit/index.adoc
@@ -11,7 +11,7 @@ We wanted to make this easier by describing the identifier first authentication 
 
 The starter kit adds WebAuthn to the AWS Cognito identity provider by integrating Yubico’s java webauthn server library into Cognito’s user pool custom authentication flow. It hosts an example web app on AWS Amplify Console so that you can try out the identifier-first authentication flow.
 
-video::wZ1s4SOOqOQ[youtube]
+video:https://www.youtube.com/watch?v=wZ1s4SOOqOQ[youtube]
 
 The Yubico WebAuthn Starter kit is a project anyone can deploy on their own AWS account, providing a powerful tool for anyone looking to test a proof of concept for their organization, empowering them to deliver the vision and promise of WebAuthn with an end-to-end example of how to implement WebAuthn in their own services.
 

--- a/content/Developer_Program/WebAuthn_Starter_Kit/index.adoc
+++ b/content/Developer_Program/WebAuthn_Starter_Kit/index.adoc
@@ -11,7 +11,7 @@ We wanted to make this easier by describing the identifier first authentication 
 
 The starter kit adds WebAuthn to the AWS Cognito identity provider by integrating Yubico’s java webauthn server library into Cognito’s user pool custom authentication flow. It hosts an example web app on AWS Amplify Console so that you can try out the identifier-first authentication flow.
 
-[![Watch the video](https://img.youtube.com/vi/wZ1s4SOOqOQ/maxresdefault.jpg)](https://youtu.be/wZ1s4SOOqOQ)
+link:https://youtu.be/wZ1s4SOOqOQ[Watch the video]
 
 The Yubico WebAuthn Starter kit is a project anyone can deploy on their own AWS account, providing a powerful tool for anyone looking to test a proof of concept for their organization, empowering them to deliver the vision and promise of WebAuthn with an end-to-end example of how to implement WebAuthn in their own services.
 


### PR DESCRIPTION
The following pages have been updated, and need to be merged with the WebAuthnKit repo and published at dyc:
Index page (https://github.com/Yubi-David/developers.yubico.com/blob/master/content/Developer_Program/WebAuthn_Starter_Kit/index.adoc):
Fixed the video link
Front-end system design (https://github.com/Yubi-David/developers.yubico.com/blob/master/content/Developer_Program/WebAuthn_Starter_Kit/Detailed_Front-End_System_Design/Front-End_System_Design.adoc):
Removed links to internal Confluence pages
Manual backend deployment (https://github.com/Yubi-David/developers.yubico.com/blob/master/content/Developer_Program/WebAuthn_Starter_Kit/Installation/Manually_Deploy_Webauthn_Back-End/Manual_Back-End_Deployment.adoc):
Updated links to images mback22*.jpg to mback28*.jpg.
