### PR TITLE
libfido2: sync docs with 1.7.0

### DIFF
--- a/content/projects/libfido2/Manuals/fido2-assert.partial
+++ b/content/projects/libfido2/Manuals/fido2-assert.partial
@@ -28,7 +28,7 @@
   <tr>
     <td><code class="Nm" title="Nm">fido2-assert</code></td>
     <td><code class="Fl" title="Fl">-G</code>
-      [<div class="Op"><code class="Fl" title="Fl">-dhpruv</code></div>]
+      [<div class="Op"><code class="Fl" title="Fl">-bdhpruv</code></div>]
       [<div class="Op"><code class="Fl" title="Fl">-t</code>
       <var class="Ar" title="Ar">option</var></div>]
       [<div class="Op"><code class="Fl" title="Fl">-i</code>
@@ -85,6 +85,9 @@ The options are as follows:
       (denoting EDDSA over Curve25519 with SHA-512). If
       <var class="Ar" title="Ar">type</var> is not specified,
       <i class="Em" title="Em">es256</i> is assumed.</dd>
+  <dt><a class="permalink" href="#b"><code class="Fl" title="Fl" id="b">-b</code></a></dt>
+  <dd>Request the credential's &#x201C;largeBlobKey&#x201D;, a 32-byte symmetric
+      key associated with the asserted credential.</dd>
   <dt><a class="permalink" href="#h"><code class="Fl" title="Fl" id="h">-h</code></a></dt>
   <dd>If obtaining an assertion, enable the FIDO2 hmac-secret extension. If
       verifying an assertion, check whether the extension data bit was signed by
@@ -190,6 +193,8 @@ For each generated assertion, <code class="Nm" title="Nm">fido2-assert</code>
   <li>user id, if credential resident (base64 blob);</li>
   <li>hmac secret, if the FIDO2 hmac-secret extension is enabled (base64
     blob);</li>
+  <li>the credential's associated 32-byte symmetric key
+      (&#x201C;largeBlobKey&#x201D;), if requested (base64 blob).</li>
 </ol>
 <div class="Pp"></div>
 When verifying an assertion, <code class="Nm" title="Nm">fido2-assert</code>

--- a/content/projects/libfido2/Manuals/fido2-cred.partial
+++ b/content/projects/libfido2/Manuals/fido2-cred.partial
@@ -28,7 +28,7 @@
   <tr>
     <td><code class="Nm" title="Nm">fido2-cred</code></td>
     <td><code class="Fl" title="Fl">-M</code>
-      [<div class="Op"><code class="Fl" title="Fl">-dhqruv</code></div>]
+      [<div class="Op"><code class="Fl" title="Fl">-bdhqruv</code></div>]
       [<div class="Op"><code class="Fl" title="Fl">-c</code>
       <var class="Ar" title="Ar">cred_protect</var></div>]
       [<div class="Op"><code class="Fl" title="Fl">-i</code>
@@ -94,12 +94,19 @@ The options are as follows:
   <dt><a class="permalink" href="#V"><code class="Fl" title="Fl" id="V">-V</code></a></dt>
   <dd>Tells <code class="Nm" title="Nm">fido2-cred</code> to verify a
       credential.</dd>
+  <dt><a class="permalink" href="#b"><code class="Fl" title="Fl" id="b">-b</code></a></dt>
+  <dd>Request the credential's &#x201C;largeBlobKey&#x201D;, a 32-byte symmetric
+      key associated with the generated credential.</dd>
   <dt><a class="permalink" href="#c"><code class="Fl" title="Fl" id="c">-c</code></a>
     <var class="Ar" title="Ar">cred_protect</var></dt>
   <dd>If making a credential, set the credential's protection level to
-      <var class="Ar" title="Ar">cred_protect</var>. If verifying a credential,
-      check whether the credential's protection level was signed by the
-      authenticator as <var class="Ar" title="Ar">cred_protect</var>.</dd>
+      <var class="Ar" title="Ar">cred_protect</var>, where
+      <var class="Ar" title="Ar">cred_protect</var> is the credential's
+      protection level in decimal notation. Please refer to
+      <code class="In" title="In">&lt;<a class="In" title="In">fido/param.h</a>&gt;</code>
+      for the set of possible values. If verifying a credential, check whether
+      the credential's protection level was signed by the authenticator as
+      <var class="Ar" title="Ar">cred_protect</var>.</dd>
   <dt><a class="permalink" href="#d"><code class="Fl" title="Fl" id="d">-d</code></a></dt>
   <dd>Causes <code class="Nm" title="Nm">fido2-cred</code> to emit debugging
       output on <i class="Em" title="Em">stderr</i>.</dd>
@@ -180,6 +187,8 @@ Upon the successful generation of a credential,
   <li>credential id (base64 blob);</li>
   <li>attestation signature (base64 blob);</li>
   <li>attestation certificate, if present (base64 blob).</li>
+  <li>the credential's associated 32-byte symmetric key
+      (&#x201C;largeBlobKey&#x201D;), if present (base64 blob).</li>
 </ol>
 <div class="Pp"></div>
 Upon the successful verification of a credential,
@@ -210,7 +219,9 @@ Create a new <i class="Em" title="Em">es256</i> credential on
   <a class="Xr" title="Xr" href="fido2-token.html">fido2-token(1)</a>
 <h1 class="Sh" title="Sh" id="CAVEATS"><a class="permalink" href="#CAVEATS">CAVEATS</a></h1>
 Please note that <code class="Nm" title="Nm">fido2-cred</code> handles Basic
-  Attestation and Self Attestation transparently.</div>
+  Attestation and Self Attestation transparently. In the case of Basic
+  Attestation, the validity of the authenticator's attestation certificate is
+  <i class="Em" title="Em">not</i> verified.</div>
 <table class="foot">
   <tr>
     <td class="foot-date">November 5, 2019</td>

--- a/content/projects/libfido2/Manuals/fido2-token.partial
+++ b/content/projects/libfido2/Manuals/fido2-token.partial
@@ -27,7 +27,7 @@
 <table class="Nm">
   <tr>
     <td><code class="Nm" title="Nm">fido2-token</code></td>
-    <td>[<div class="Op"><code class="Fl" title="Fl">-CR</code></div>]
+    <td><code class="Fl" title="Fl">-C</code>
       [<div class="Op"><code class="Fl" title="Fl">-d</code></div>]
       <var class="Ar" title="Ar">device</var></td>
   </tr>
@@ -37,8 +37,75 @@
   <tr>
     <td><code class="Nm" title="Nm">fido2-token</code></td>
     <td><code class="Fl" title="Fl">-D</code>
-      [<div class="Op"><code class="Fl" title="Fl">-de</code></div>]
-      <code class="Fl" title="Fl">-i</code> <var class="Ar" title="Ar">id</var>
+      [<div class="Op"><code class="Fl" title="Fl">-d</code></div>]
+      <code class="Fl" title="Fl">-i</code>
+      <var class="Ar" title="Ar">cred_id</var>
+      <var class="Ar" title="Ar">device</var></td>
+  </tr>
+</table>
+<br/>
+<table class="Nm">
+  <tr>
+    <td><code class="Nm" title="Nm">fido2-token</code></td>
+    <td><code class="Fl" title="Fl">-D</code>
+      <code class="Fl" title="Fl">-b</code>
+      [<div class="Op"><code class="Fl" title="Fl">-d</code></div>]
+      <code class="Fl" title="Fl">-k</code>
+      <var class="Ar" title="Ar">key_path</var>
+      <var class="Ar" title="Ar">device</var></td>
+  </tr>
+</table>
+<br/>
+<table class="Nm">
+  <tr>
+    <td><code class="Nm" title="Nm">fido2-token</code></td>
+    <td><code class="Fl" title="Fl">-D</code>
+      <code class="Fl" title="Fl">-b</code>
+      [<div class="Op"><code class="Fl" title="Fl">-d</code></div>]
+      <code class="Fl" title="Fl">-n</code>
+      <var class="Ar" title="Ar">rp_id</var>
+      [<div class="Op"><code class="Fl" title="Fl">-i</code>
+      <var class="Ar" title="Ar">cred_id</var></div>]
+      <var class="Ar" title="Ar">device</var></td>
+  </tr>
+</table>
+<br/>
+<table class="Nm">
+  <tr>
+    <td><code class="Nm" title="Nm">fido2-token</code></td>
+    <td><code class="Fl" title="Fl">-D</code>
+      <code class="Fl" title="Fl">-e</code>
+      [<div class="Op"><code class="Fl" title="Fl">-d</code></div>]
+      <code class="Fl" title="Fl">-i</code>
+      <var class="Ar" title="Ar">template_id</var>
+      <var class="Ar" title="Ar">device</var></td>
+  </tr>
+</table>
+<br/>
+<table class="Nm">
+  <tr>
+    <td><code class="Nm" title="Nm">fido2-token</code></td>
+    <td><code class="Fl" title="Fl">-G</code>
+      <code class="Fl" title="Fl">-b</code>
+      [<div class="Op"><code class="Fl" title="Fl">-d</code></div>]
+      <code class="Fl" title="Fl">-k</code>
+      <var class="Ar" title="Ar">key_path</var>
+      <var class="Ar" title="Ar">blob_path</var>
+      <var class="Ar" title="Ar">device</var></td>
+  </tr>
+</table>
+<br/>
+<table class="Nm">
+  <tr>
+    <td><code class="Nm" title="Nm">fido2-token</code></td>
+    <td><code class="Fl" title="Fl">-G</code>
+      <code class="Fl" title="Fl">-b</code>
+      [<div class="Op"><code class="Fl" title="Fl">-d</code></div>]
+      <code class="Fl" title="Fl">-n</code>
+      <var class="Ar" title="Ar">rp_id</var>
+      [<div class="Op"><code class="Fl" title="Fl">-i</code>
+      <var class="Ar" title="Ar">cred_id</var></div>]
+      <var class="Ar" title="Ar">blob_path</var>
       <var class="Ar" title="Ar">device</var></td>
   </tr>
 </table>
@@ -60,7 +127,7 @@
   <tr>
     <td><code class="Nm" title="Nm">fido2-token</code></td>
     <td><code class="Fl" title="Fl">-L</code>
-      [<div class="Op"><code class="Fl" title="Fl">-der</code></div>]
+      [<div class="Op"><code class="Fl" title="Fl">-bder</code></div>]
       [<div class="Op"><code class="Fl" title="Fl">-k</code>
       <var class="Ar" title="Ar">rp_id</var></div>]
       [<div class="Op">device</div>]</td>
@@ -70,12 +137,68 @@
 <table class="Nm">
   <tr>
     <td><code class="Nm" title="Nm">fido2-token</code></td>
+    <td><code class="Fl" title="Fl">-R</code>
+      [<div class="Op"><code class="Fl" title="Fl">-d</code></div>]
+      <var class="Ar" title="Ar">device</var></td>
+  </tr>
+</table>
+<br/>
+<table class="Nm">
+  <tr>
+    <td><code class="Nm" title="Nm">fido2-token</code></td>
     <td><code class="Fl" title="Fl">-S</code>
-      [<div class="Op"><code class="Fl" title="Fl">-de</code></div>]
-      [<div class="Op"><code class="Fl" title="Fl">-i</code>
+      [<div class="Op"><code class="Fl" title="Fl">-adeu</code></div>]
+      <var class="Ar" title="Ar">device</var></td>
+  </tr>
+</table>
+<br/>
+<table class="Nm">
+  <tr>
+    <td><code class="Nm" title="Nm">fido2-token</code></td>
+    <td><code class="Fl" title="Fl">-S</code>
+      [<div class="Op"><code class="Fl" title="Fl">-d</code></div>]
+      <code class="Fl" title="Fl">-i</code>
       <var class="Ar" title="Ar">template_id</var>
       <code class="Fl" title="Fl">-n</code>
-      <var class="Ar" title="Ar">template_name</var></div>]
+      <var class="Ar" title="Ar">template_name</var></td>
+  </tr>
+</table>
+<br/>
+<table class="Nm">
+  <tr>
+    <td><code class="Nm" title="Nm">fido2-token</code></td>
+    <td><code class="Fl" title="Fl">-S</code>
+      [<div class="Op"><code class="Fl" title="Fl">-d</code></div>]
+      <code class="Fl" title="Fl">-l</code>
+      <var class="Ar" title="Ar">pin_length</var>
+      <var class="Ar" title="Ar">device</var></td>
+  </tr>
+</table>
+<br/>
+<table class="Nm">
+  <tr>
+    <td><code class="Nm" title="Nm">fido2-token</code></td>
+    <td><code class="Fl" title="Fl">-S</code>
+      <code class="Fl" title="Fl">-b</code>
+      [<div class="Op"><code class="Fl" title="Fl">-d</code></div>]
+      <code class="Fl" title="Fl">-k</code>
+      <var class="Ar" title="Ar">key_path</var>
+      <var class="Ar" title="Ar">blob_path</var>
+      <var class="Ar" title="Ar">device</var></td>
+  </tr>
+</table>
+<br/>
+<table class="Nm">
+  <tr>
+    <td><code class="Nm" title="Nm">fido2-token</code></td>
+    <td><code class="Fl" title="Fl">-S</code>
+      <code class="Fl" title="Fl">-b</code>
+      [<div class="Op"><code class="Fl" title="Fl">-d</code></div>]
+      <code class="Fl" title="Fl">-n</code>
+      <var class="Ar" title="Ar">rp_id</var>
+      [<div class="Op"><code class="Fl" title="Fl">-i</code>
+      <var class="Ar" title="Ar">cred_id</var></div>]
+      <var class="Ar" title="Ar">blob_path</var>
       <var class="Ar" title="Ar">device</var></td>
   </tr>
 </table>
@@ -104,6 +227,31 @@ The options are as follows:
       <var class="Ar" title="Ar">id</var> is the credential's base64-encoded id.
       The user will be prompted for the PIN.</dd>
   <dt><a class="permalink" href="#D_2"><code class="Fl" title="Fl" id="D_2">-D</code></a>
+    <code class="Fl" title="Fl">-b</code> <code class="Fl" title="Fl">-k</code>
+    <var class="Ar" title="Ar">key_path</var>
+    <var class="Ar" title="Ar">device</var></dt>
+  <dd>Deletes a &#x201C;largeBlob&#x201D; encrypted with
+      <var class="Ar" title="Ar">key_path</var> from
+      <var class="Ar" title="Ar">device</var>, where
+      <var class="Ar" title="Ar">key_path</var> must hold the blob's
+      base64-encoded encryption key. A PIN or equivalent user-verification
+      gesture is required.</dd>
+  <dt><a class="permalink" href="#D_3"><code class="Fl" title="Fl" id="D_3">-D</code></a>
+    <code class="Fl" title="Fl">-b</code> <code class="Fl" title="Fl">-n</code>
+    <var class="Ar" title="Ar">rp_id</var>
+    [<div class="Op"><code class="Fl" title="Fl">-i</code>
+    <var class="Ar" title="Ar">cred_id</var></div>]
+    <var class="Ar" title="Ar">device</var></dt>
+  <dd>Deletes a &#x201C;largeBlob&#x201D; corresponding to
+      <var class="Ar" title="Ar">rp_id</var> from
+      <var class="Ar" title="Ar">device</var>. If
+      <var class="Ar" title="Ar">rp_id</var> has multiple credentials enrolled
+      on <var class="Ar" title="Ar">device</var>, the credential ID must be
+      specified using <code class="Fl" title="Fl">-i</code>
+      <var class="Ar" title="Ar">cred_id</var>, where
+      <var class="Ar" title="Ar">cred_id</var> is a base64-encoded blob. A PIN
+      or equivalent user-verification gesture is required.</dd>
+  <dt><a class="permalink" href="#D_4"><code class="Fl" title="Fl" id="D_4">-D</code></a>
     <code class="Fl" title="Fl">-e</code> <code class="Fl" title="Fl">-i</code>
     <var class="Ar" title="Ar">id</var>
     <var class="Ar" title="Ar">device</var></dt>
@@ -112,6 +260,40 @@ The options are as follows:
       <var class="Ar" title="Ar">device</var>, where
       <var class="Ar" title="Ar">id</var> is the enrollment's template
       base64-encoded id. The user will be prompted for the PIN.</dd>
+  <dt><a class="permalink" href="#D_5"><code class="Fl" title="Fl" id="D_5">-D</code></a>
+    <code class="Fl" title="Fl">-u</code>
+    <var class="Ar" title="Ar">device</var></dt>
+  <dd>Disables the FIDO 2.1 &#x201C;user verification always&#x201D; feature on
+      <var class="Ar" title="Ar">device</var>.</dd>
+  <dt><a class="permalink" href="#G"><code class="Fl" title="Fl" id="G">-G</code></a>
+    <code class="Fl" title="Fl">-b</code> <code class="Fl" title="Fl">-k</code>
+    <var class="Ar" title="Ar">key_path</var>
+    <var class="Ar" title="Ar">blob_path</var>
+    <var class="Ar" title="Ar">device</var></dt>
+  <dd>Gets a FIDO 2.1 &#x201C;largeBlob&#x201D; encrypted with
+      <var class="Ar" title="Ar">key_path</var> from
+      <var class="Ar" title="Ar">device</var>, where
+      <var class="Ar" title="Ar">key_path</var> must hold the blob's
+      base64-encoded encryption key. The blob is written to
+      <var class="Ar" title="Ar">blob_path</var>. A PIN or equivalent
+      user-verification gesture is required.</dd>
+  <dt><a class="permalink" href="#G_2"><code class="Fl" title="Fl" id="G_2">-G</code></a>
+    <code class="Fl" title="Fl">-b</code> <code class="Fl" title="Fl">-n</code>
+    <var class="Ar" title="Ar">rp_id</var>
+    [<div class="Op"><code class="Fl" title="Fl">-i</code>
+    <var class="Ar" title="Ar">cred_id</var></div>]
+    <var class="Ar" title="Ar">blob_path</var>
+    <var class="Ar" title="Ar">device</var></dt>
+  <dd>Gets a FIDO 2.1 &#x201C;largeBlob&#x201D; associated with
+      <var class="Ar" title="Ar">rp_id</var> from
+      <var class="Ar" title="Ar">device</var>. If
+      <var class="Ar" title="Ar">rp_id</var> has multiple credentials enrolled
+      on <var class="Ar" title="Ar">device</var>, the credential ID must be
+      specified using <code class="Fl" title="Fl">-i</code>
+      <var class="Ar" title="Ar">cred_id</var>, where
+      <var class="Ar" title="Ar">cred_id</var> is a base64-encoded blob. The
+      blob is written to <var class="Ar" title="Ar">blob_path</var>. A PIN or
+      equivalent user-verification gesture is required.</dd>
   <dt><a class="permalink" href="#I"><code class="Fl" title="Fl" id="I">-I</code></a>
     <var class="Ar" title="Ar">device</var></dt>
   <dd>Retrieves information on <var class="Ar" title="Ar">device</var>.</dd>
@@ -136,18 +318,24 @@ The options are as follows:
   <dt><a class="permalink" href="#L"><code class="Fl" title="Fl" id="L">-L</code></a></dt>
   <dd>Produces a list of authenticators found by the operating system.</dd>
   <dt><a class="permalink" href="#L_2"><code class="Fl" title="Fl" id="L_2">-L</code></a>
+    <code class="Fl" title="Fl">-b</code>
+    <var class="Ar" title="Ar">device</var></dt>
+  <dd>Produces a list of FIDO 2.1 &#x201C;largeBlobs&#x201D; on
+      <var class="Ar" title="Ar">device</var>. A PIN or equivalent
+      user-verification gesture is required.</dd>
+  <dt><a class="permalink" href="#L_3"><code class="Fl" title="Fl" id="L_3">-L</code></a>
     <code class="Fl" title="Fl">-e</code>
     <var class="Ar" title="Ar">device</var></dt>
   <dd>Produces a list of biometric enrollments on
       <var class="Ar" title="Ar">device</var>. The user will be prompted for the
       PIN.</dd>
-  <dt><a class="permalink" href="#L_3"><code class="Fl" title="Fl" id="L_3">-L</code></a>
+  <dt><a class="permalink" href="#L_4"><code class="Fl" title="Fl" id="L_4">-L</code></a>
     <code class="Fl" title="Fl">-r</code>
     <var class="Ar" title="Ar">device</var></dt>
   <dd>Produces a list of relying parties with resident credentials on
       <var class="Ar" title="Ar">device</var>. The user will be prompted for the
       PIN.</dd>
-  <dt><a class="permalink" href="#L_4"><code class="Fl" title="Fl" id="L_4">-L</code></a>
+  <dt><a class="permalink" href="#L_5"><code class="Fl" title="Fl" id="L_5">-L</code></a>
     <code class="Fl" title="Fl">-k</code> <var class="Ar" title="Ar">rp_id</var>
     <var class="Ar" title="Ar">device</var></dt>
   <dd>Produces a list of resident credentials corresponding to relying party
@@ -162,12 +350,47 @@ The options are as follows:
   <dd>Sets the PIN of <var class="Ar" title="Ar">device</var>. The user will be
       prompted for the PIN.</dd>
   <dt><a class="permalink" href="#S_2"><code class="Fl" title="Fl" id="S_2">-S</code></a>
+    <code class="Fl" title="Fl">-a</code>
+    <var class="Ar" title="Ar">device</var></dt>
+  <dd>Enables FIDO 2.1 Enterprise Attestation on
+      <var class="Ar" title="Ar">device</var>.</dd>
+  <dt><a class="permalink" href="#S_3"><code class="Fl" title="Fl" id="S_3">-S</code></a>
+    <code class="Fl" title="Fl">-b</code> <code class="Fl" title="Fl">-k</code>
+    <var class="Ar" title="Ar">key_path</var>
+    <var class="Ar" title="Ar">blob_path</var>
+    <var class="Ar" title="Ar">device</var></dt>
+  <dd>Sets <var class="Ar" title="Ar">blob_path</var> as a FIDO 2.1
+      &#x201C;largeBlob&#x201D; encrypted with
+      <var class="Ar" title="Ar">key_path</var> on
+      <var class="Ar" title="Ar">device</var>, where
+      <var class="Ar" title="Ar">blob_path</var> holds the blob's plaintext, and
+      <var class="Ar" title="Ar">key_path</var> the blob's base64-encoded
+      encryption. A PIN or equivalent user-verification gesture is
+    required.</dd>
+  <dt><a class="permalink" href="#S_4"><code class="Fl" title="Fl" id="S_4">-S</code></a>
+    <code class="Fl" title="Fl">-b</code> <code class="Fl" title="Fl">-n</code>
+    <var class="Ar" title="Ar">rp_id</var>
+    [<div class="Op"><code class="Fl" title="Fl">-i</code>
+    <var class="Ar" title="Ar">cred_id</var></div>]
+    <var class="Ar" title="Ar">blob_path</var>
+    <var class="Ar" title="Ar">device</var></dt>
+  <dd>Sets <var class="Ar" title="Ar">blob_path</var> as a FIDO 2.1
+      &#x201C;largeBlob&#x201D; associated with
+      <var class="Ar" title="Ar">rp_id</var> on
+      <var class="Ar" title="Ar">device</var>. If
+      <var class="Ar" title="Ar">rp_id</var> has multiple credentials enrolled
+      on <var class="Ar" title="Ar">device</var>, the credential ID must be
+      specified using <code class="Fl" title="Fl">-i</code>
+      <var class="Ar" title="Ar">cred_id</var>, where
+      <var class="Ar" title="Ar">cred_id</var> is a base64-encoded blob. A PIN
+      or equivalent user-verification gesture is required.</dd>
+  <dt><a class="permalink" href="#S_5"><code class="Fl" title="Fl" id="S_5">-S</code></a>
     <code class="Fl" title="Fl">-e</code>
     <var class="Ar" title="Ar">device</var></dt>
   <dd>Performs a new biometric enrollment on
       <var class="Ar" title="Ar">device</var>. The user will be prompted for the
       PIN.</dd>
-  <dt><a class="permalink" href="#S_3"><code class="Fl" title="Fl" id="S_3">-S</code></a>
+  <dt><a class="permalink" href="#S_6"><code class="Fl" title="Fl" id="S_6">-S</code></a>
     <code class="Fl" title="Fl">-e</code> <code class="Fl" title="Fl">-i</code>
     <var class="Ar" title="Ar">template_id</var>
     <code class="Fl" title="Fl">-n</code>
@@ -180,6 +403,23 @@ The options are as follows:
       <var class="Ar" title="Ar">template_id</var> is base64-encoded and
       <var class="Ar" title="Ar">template_name</var> is a UTF-8 string. The user
       will be prompted for the PIN.</dd>
+  <dt><a class="permalink" href="#S_7"><code class="Fl" title="Fl" id="S_7">-S</code></a>
+    <code class="Fl" title="Fl">-f</code>
+    <var class="Ar" title="Ar">device</var></dt>
+  <dd>Forces a PIN change on <var class="Ar" title="Ar">device</var>. The user
+      will be prompted for the PIN.</dd>
+  <dt><a class="permalink" href="#S_8"><code class="Fl" title="Fl" id="S_8">-S</code></a>
+    <code class="Fl" title="Fl">-l</code>
+    <var class="Ar" title="Ar">pin_length</var>
+    <var class="Ar" title="Ar">device</var></dt>
+  <dd>Sets the minimum PIN length of <var class="Ar" title="Ar">device</var> to
+      <var class="Ar" title="Ar">pin_length</var>. The user will be prompted for
+      the PIN.</dd>
+  <dt><a class="permalink" href="#S_9"><code class="Fl" title="Fl" id="S_9">-S</code></a>
+    <code class="Fl" title="Fl">-u</code>
+    <var class="Ar" title="Ar">device</var></dt>
+  <dd>Enables the FIDO 2.1 &#x201C;user verification always&#x201D; feature on
+      <var class="Ar" title="Ar">device</var>.</dd>
   <dt><a class="permalink" href="#V"><code class="Fl" title="Fl" id="V">-V</code></a></dt>
   <dd>Prints version information.</dd>
   <dt><a class="permalink" href="#d"><code class="Fl" title="Fl" id="d">-d</code></a></dt>
@@ -206,7 +446,11 @@ The actual user-flow to perform a reset is outside the scope of the FIDO2
 An authenticator's path may contain spaces.
 <div class="Pp"></div>
 Resident credentials are called &#x201C;discoverable credentials&#x201D; in
-  FIDO2.1.</div>
+  FIDO2.1.
+<div class="Pp"></div>
+Whether the FIDO 2.1 &#x201C;user verification always&#x201D; feature is
+  activated or deactivated after an authenticator reset is
+  vendor-specific.</div>
 <table class="foot">
   <tr>
     <td class="foot-date">September 13, 2019</td>

--- a/content/projects/libfido2/Manuals/fido_assert_blob_len.partial
+++ b/content/projects/libfido2/Manuals/fido_assert_blob_len.partial
@@ -1,0 +1,1 @@
+fido_assert_new.partial

--- a/content/projects/libfido2/Manuals/fido_assert_blob_ptr.partial
+++ b/content/projects/libfido2/Manuals/fido_assert_blob_ptr.partial
@@ -1,0 +1,1 @@
+fido_assert_new.partial

--- a/content/projects/libfido2/Manuals/fido_assert_largeblob_key_len.partial
+++ b/content/projects/libfido2/Manuals/fido_assert_largeblob_key_len.partial
@@ -1,0 +1,1 @@
+fido_assert_new.partial

--- a/content/projects/libfido2/Manuals/fido_assert_largeblob_key_ptr.partial
+++ b/content/projects/libfido2/Manuals/fido_assert_largeblob_key_ptr.partial
@@ -1,0 +1,1 @@
+fido_assert_new.partial

--- a/content/projects/libfido2/Manuals/fido_assert_new.partial
+++ b/content/projects/libfido2/Manuals/fido_assert_new.partial
@@ -29,14 +29,18 @@
   <code class="Nm" title="Nm">fido_assert_user_icon</code>,
   <code class="Nm" title="Nm">fido_assert_user_name</code>,
   <code class="Nm" title="Nm">fido_assert_authdata_ptr</code>,
+  <code class="Nm" title="Nm">fido_assert_blob_ptr</code>,
   <code class="Nm" title="Nm">fido_assert_clientdata_hash_ptr</code>,
   <code class="Nm" title="Nm">fido_assert_hmac_secret_ptr</code>,
+  <code class="Nm" title="Nm">fido_assert_largeblob_key_ptr</code>,
   <code class="Nm" title="Nm">fido_assert_user_id_ptr</code>,
   <code class="Nm" title="Nm">fido_assert_sig_ptr</code>,
   <code class="Nm" title="Nm">fido_assert_id_ptr</code>,
   <code class="Nm" title="Nm">fido_assert_authdata_len</code>,
+  <code class="Nm" title="Nm">fido_assert_blob_len</code>,
   <code class="Nm" title="Nm">fido_assert_clientdata_hash_len</code>,
   <code class="Nm" title="Nm">fido_assert_hmac_secret_len</code>,
+  <code class="Nm" title="Nm">fido_assert_largeblob_key_len</code>,
   <code class="Nm" title="Nm">fido_assert_user_id_len</code>,
   <code class="Nm" title="Nm">fido_assert_sig_len</code>,
   <code class="Nm" title="Nm">fido_assert_id_len</code>,
@@ -97,7 +101,18 @@
 <div class="Pp"></div>
 <var class="Ft" title="Ft">const unsigned char *</var>
 <br/>
+<code class="Fn" title="Fn">fido_assert_blob_ptr</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_assert_t *assert</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">const unsigned char *</var>
+<br/>
 <code class="Fn" title="Fn">fido_assert_hmac_secret_ptr</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_assert_t *assert</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">size_t idx</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">const unsigned char *</var>
+<br/>
+<code class="Fn" title="Fn">fido_assert_largeblob_key_ptr</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_assert_t *assert</var>,
   <var class="Fa" title="Fa" style="white-space: nowrap;">size_t idx</var>);
 <div class="Pp"></div>
@@ -132,7 +147,18 @@
 <div class="Pp"></div>
 <var class="Ft" title="Ft">size_t</var>
 <br/>
+<code class="Fn" title="Fn">fido_assert_blob_len</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_assert_t *assert</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">size_t</var>
+<br/>
 <code class="Fn" title="Fn">fido_assert_hmac_secret_len</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_assert_t *assert</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">size_t idx</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">size_t</var>
+<br/>
+<code class="Fn" title="Fn">fido_assert_largeblob_key_len</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_assert_t *assert</var>,
   <var class="Fa" title="Fa" style="white-space: nowrap;">size_t idx</var>);
 <div class="Pp"></div>
@@ -208,16 +234,21 @@ The <code class="Fn" title="Fn">fido_assert_user_display_name</code>(),
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_assert_user_id_ptr</code>(),
   <code class="Fn" title="Fn">fido_assert_authdata_ptr</code>(),
+  <code class="Fn" title="Fn">fido_assert_blob_ptr</code>(),
   <code class="Fn" title="Fn">fido_assert_hmac_secret_ptr</code>(),
+  <code class="Fn" title="Fn">fido_assert_largeblob_key_ptr</code>(),
   <code class="Fn" title="Fn">fido_assert_sig_ptr</code>(), and
   <code class="Fn" title="Fn">fido_assert_id_ptr</code>() functions return
-  pointers to the user ID, CBOR-encoded authenticator data, hmac-secret,
-  signature, and credential ID attributes of statement
-  <var class="Fa" title="Fa">idx</var> in
-  <var class="Fa" title="Fa">assert</var>. The
-  <code class="Fn" title="Fn">fido_assert_user_id_len</code>(),
+  pointers to the user ID, CBOR-encoded authenticator data, cred blob,
+  hmac-secret, &#x201C;largeBlobKey&#x201D;, signature, and credential ID
+  attributes of statement <var class="Fa" title="Fa">idx</var> in
+  <var class="Fa" title="Fa">assert</var>.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_assert_user_id_len</code>(),
   <code class="Fn" title="Fn">fido_assert_authdata_len</code>(),
+  <code class="Fn" title="Fn">fido_assert_blob_len</code>(),
   <code class="Fn" title="Fn">fido_assert_hmac_secret_len</code>(),
+  <code class="Fn" title="Fn">fido_assert_largeblob_key_len</code>(),
   <code class="Fn" title="Fn">fido_assert_sig_len</code>(), and
   <code class="Fn" title="Fn">fido_assert_id_len</code>() functions can be used
   to retrieve the corresponding length of a specific attribute.
@@ -253,6 +284,8 @@ The <code class="Fn" title="Fn">fido_assert_user_display_name</code>(),
   <code class="Fn" title="Fn">fido_assert_user_name</code>(),
   <code class="Fn" title="Fn">fido_assert_authdata_ptr</code>(),
   <code class="Fn" title="Fn">fido_assert_clientdata_hash_ptr</code>(),
+  <code class="Fn" title="Fn">fido_assert_hmac_secret_ptr</code>(),
+  <code class="Fn" title="Fn">fido_assert_largeblob_key_ptr</code>(),
   <code class="Fn" title="Fn">fido_assert_user_id_ptr</code>(), and
   <code class="Fn" title="Fn">fido_assert_sig_ptr</code>() functions return NULL
   if the respective field in <var class="Fa" title="Fa">assert</var> is not set.
@@ -264,7 +297,8 @@ The <code class="Fn" title="Fn">fido_assert_user_display_name</code>(),
 <a class="Xr" title="Xr" href="fido_assert_allow_cred.html">fido_assert_allow_cred(3)</a>,
   <a class="Xr" title="Xr" href="fido_assert_set_authdata.html">fido_assert_set_authdata(3)</a>,
   <a class="Xr" title="Xr" href="fido_assert_verify.html">fido_assert_verify(3)</a>,
-  <a class="Xr" title="Xr" href="fido_dev_get_assert.html">fido_dev_get_assert(3)</a></div>
+  <a class="Xr" title="Xr" href="fido_dev_get_assert.html">fido_dev_get_assert(3)</a>,
+  <a class="Xr" title="Xr" href="fido_dev_largeblob_get.html">fido_dev_largeblob_get(3)</a></div>
 <table class="foot">
   <tr>
     <td class="foot-date">October 22, 2019</td>

--- a/content/projects/libfido2/Manuals/fido_assert_set_authdata.partial
+++ b/content/projects/libfido2/Manuals/fido_assert_set_authdata.partial
@@ -27,6 +27,7 @@
   <code class="Nm" title="Nm">fido_assert_set_count</code>,
   <code class="Nm" title="Nm">fido_assert_set_extensions</code>,
   <code class="Nm" title="Nm">fido_assert_set_hmac_salt</code>,
+  <code class="Nm" title="Nm">fido_assert_set_hmac_secret</code>,
   <code class="Nm" title="Nm">fido_assert_set_up</code>,
   <code class="Nm" title="Nm">fido_assert_set_uv</code>,
   <code class="Nm" title="Nm">fido_assert_set_rp</code>,
@@ -90,6 +91,13 @@ typedef enum {
 <div class="Pp"></div>
 <var class="Ft" title="Ft">int</var>
 <br/>
+<code class="Fn" title="Fn">fido_assert_set_hmac_secret</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_assert_t
+  *assert</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
+  unsigned char *ptr</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">size_t len</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
 <code class="Fn" title="Fn">fido_assert_set_up</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_assert_t
   *assert</var>,
   <var class="Fa" title="Fa" style="white-space: nowrap;">fido_opt_t up</var>);
@@ -147,8 +155,9 @@ The <code class="Fn" title="Fn">fido_assert_set_authdata</code>() and
   a raw binary blob may be passed to
   <code class="Fn" title="Fn">fido_assert_set_authdata_raw</code>().
 <div class="Pp"></div>
-The <code class="Fn" title="Fn">fido_assert_set_clientdata_hash</code>() and
-  <code class="Fn" title="Fn">fido_assert_set_hmac_salt</code>() functions set
+The <code class="Fn" title="Fn">fido_assert_set_clientdata_hash</code>(),
+  <code class="Fn" title="Fn">fido_assert_set_hmac_salt</code>(), and
+  <code class="Fn" title="Fn">fido_assert_set_hmac_secret</code>() functions set
   the client data hash and hmac-salt parts of
   <var class="Fa" title="Fa">assert</var> to
   <var class="Fa" title="Fa">ptr</var>, where
@@ -167,7 +176,9 @@ The <code class="Fn" title="Fn">fido_assert_set_rp</code>() function sets the
 The <code class="Fn" title="Fn">fido_assert_set_extensions</code>() function
   sets the extensions of <var class="Fa" title="Fa">assert</var> to the bitmask
   <var class="Fa" title="Fa">flags</var>. At the moment, only the
-  <code class="Dv" title="Dv">FIDO_EXT_HMAC_SECRET</code> extension is
+  <code class="Dv" title="Dv">FIDO_EXT_CRED_BLOB</code>,
+  <code class="Dv" title="Dv">FIDO_EXT_HMAC_SECRET</code>, and
+  <code class="Dv" title="Dv">FIDO_EXT_LARGEBLOB_KEY</code> extensions are
   supported. If <var class="Fa" title="Fa">flags</var> is zero, the extensions
   of <var class="Fa" title="Fa">assert</var> are cleared.
 <div class="Pp"></div>
@@ -194,6 +205,11 @@ For a complete description of the generation of a FIDO 2 assertion and its
   functions can be found in the
   <span class="Pa" title="Pa">examples/assert.c</span> file shipped with
   <i class="Em" title="Em">libfido2</i>.
+<div class="Pp"></div>
+<code class="Fn" title="Fn">fido_assert_set_hmac_secret</code>() is not normally
+  useful in a FIDO client or server &#x2014; it is provided to enable testing
+  other functionality that relies on retrieving the HMAC secret from an
+  assertion obtained from an authenticator.
 <h1 class="Sh" title="Sh" id="RETURN_VALUES"><a class="permalink" href="#RETURN_VALUES">RETURN
   VALUES</a></h1>
 The <code class="Nm" title="Nm">fido_assert_set_authdata</code> functions return

--- a/content/projects/libfido2/Manuals/fido_assert_set_hmac_secret.partial
+++ b/content/projects/libfido2/Manuals/fido_assert_set_hmac_secret.partial
@@ -1,0 +1,1 @@
+fido_assert_set_authdata.partial

--- a/content/projects/libfido2/Manuals/fido_cbor_info_maxcredbloblen.partial
+++ b/content/projects/libfido2/Manuals/fido_cbor_info_maxcredbloblen.partial
@@ -1,0 +1,1 @@
+fido_cbor_info_new.partial

--- a/content/projects/libfido2/Manuals/fido_cbor_info_new.partial
+++ b/content/projects/libfido2/Manuals/fido_cbor_info_new.partial
@@ -122,6 +122,11 @@
 <div class="Pp"></div>
 <var class="Ft" title="Ft">uint64_t</var>
 <br/>
+<code class="Fn" title="Fn">fido_cbor_info_maxcredbloblen</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cbor_info_t *ci</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">uint64_t</var>
+<br/>
 <code class="Fn" title="Fn">fido_cbor_info_maxcredcntlst</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_cbor_info_t *ci</var>);
 <div class="Pp"></div>
@@ -179,6 +184,10 @@ The <code class="Fn" title="Fn">fido_cbor_info_options_name_ptr</code>() and
 The <code class="Fn" title="Fn">fido_cbor_info_maxmsgsiz</code>() function
   returns the maximum message size attribute of
   <var class="Fa" title="Fa">ci</var>.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_cbor_info_maxcredbloblen</code>() function
+  returns the maximum &#x201C;credBlob&#x201D; length in bytes supported by the
+  authenticator as reported in <var class="Fa" title="Fa">ci</var>.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_cbor_info_maxcredcntlst</code>() function
   returns the maximum supported number of credentials in a single credential ID

--- a/content/projects/libfido2/Manuals/fido_cred_largeblob_key_len.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_largeblob_key_len.partial
@@ -1,0 +1,1 @@
+fido_cred_new.partial

--- a/content/projects/libfido2/Manuals/fido_cred_largeblob_key_ptr.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_largeblob_key_ptr.partial
@@ -1,0 +1,1 @@
+fido_cred_new.partial

--- a/content/projects/libfido2/Manuals/fido_cred_new.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_new.partial
@@ -34,6 +34,7 @@
   <code class="Nm" title="Nm">fido_cred_clientdata_hash_ptr</code>,
   <code class="Nm" title="Nm">fido_cred_id_ptr</code>,
   <code class="Nm" title="Nm">fido_cred_aaguid_ptr</code>,
+  <code class="Nm" title="Nm">fido_cred_largeblob_key_ptr</code>,
   <code class="Nm" title="Nm">fido_cred_pubkey_ptr</code>,
   <code class="Nm" title="Nm">fido_cred_sig_ptr</code>,
   <code class="Nm" title="Nm">fido_cred_user_id_ptr</code>,
@@ -43,6 +44,7 @@
   <code class="Nm" title="Nm">fido_cred_clientdata_hash_len</code>,
   <code class="Nm" title="Nm">fido_cred_id_len</code>,
   <code class="Nm" title="Nm">fido_cred_aaguid_len</code>,
+  <code class="Nm" title="Nm">fido_cred_largeblob_key_len</code>,
   <code class="Nm" title="Nm">fido_cred_pubkey_len</code>,
   <code class="Nm" title="Nm">fido_cred_sig_len</code>,
   <code class="Nm" title="Nm">fido_cred_user_id_len</code>,
@@ -121,6 +123,11 @@
 <div class="Pp"></div>
 <var class="Ft" title="Ft">const unsigned char *</var>
 <br/>
+<code class="Fn" title="Fn">fido_cred_largeblob_key_ptr</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cred_t *cred</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">const unsigned char *</var>
+<br/>
 <code class="Fn" title="Fn">fido_cred_pubkey_ptr</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_cred_t *cred</var>);
 <div class="Pp"></div>
@@ -162,6 +169,11 @@
 <var class="Ft" title="Ft">size_t</var>
 <br/>
 <code class="Fn" title="Fn">fido_cred_aaguid_len</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cred_t *cred</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">size_t</var>
+<br/>
+<code class="Fn" title="Fn">fido_cred_largeblob_key_len</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_cred_t *cred</var>);
 <div class="Pp"></div>
 <var class="Ft" title="Ft">size_t</var>
@@ -248,14 +260,16 @@ The <code class="Fn" title="Fn">fido_cred_authdata_ptr</code>(),
   <code class="Fn" title="Fn">fido_cred_clientdata_hash_ptr</code>(),
   <code class="Fn" title="Fn">fido_cred_id_ptr</code>(),
   <code class="Fn" title="Fn">fido_cred_aaguid_ptr</code>(),
+  <code class="Fn" title="Fn">fido_cred_largeblob_key_ptr</code>(),
   <code class="Fn" title="Fn">fido_cred_pubkey_ptr</code>(),
   <code class="Fn" title="Fn">fido_cred_sig_ptr</code>(),
   <code class="Fn" title="Fn">fido_cred_user_id_ptr</code>(), and
   <code class="Fn" title="Fn">fido_cred_x5c_ptr</code>() functions return
   pointers to the CBOR-encoded and raw authenticator data, client data hash, ID,
-  authenticator attestation GUID, public key, signature, user ID, and x509
-  certificate parts of <var class="Fa" title="Fa">cred</var>, or NULL if the
-  respective entry is not set.
+  authenticator attestation GUID, &#x201C;largeBlobKey&#x201D;, public key,
+  signature, user ID, and x509 certificate parts of
+  <var class="Fa" title="Fa">cred</var>, or NULL if the respective entry is not
+  set.
 <div class="Pp"></div>
 The corresponding length can be obtained by
   <code class="Fn" title="Fn">fido_cred_authdata_len</code>(),
@@ -263,6 +277,7 @@ The corresponding length can be obtained by
   <code class="Fn" title="Fn">fido_cred_clientdata_hash_len</code>(),
   <code class="Fn" title="Fn">fido_cred_id_len</code>(),
   <code class="Fn" title="Fn">fido_cred_aaguid_len</code>(),
+  <code class="Fn" title="Fn">fido_cred_largeblob_key_len</code>(),
   <code class="Fn" title="Fn">fido_cred_pubkey_len</code>(),
   <code class="Fn" title="Fn">fido_cred_sig_len</code>(),
   <code class="Fn" title="Fn">fido_cred_user_id_len</code>(), and
@@ -292,6 +307,7 @@ If not NULL, pointers returned by
   <code class="Fn" title="Fn">fido_cred_clientdata_hash_ptr</code>(),
   <code class="Fn" title="Fn">fido_cred_id_ptr</code>(),
   <code class="Fn" title="Fn">fido_cred_aaguid_ptr</code>(),
+  <code class="Fn" title="Fn">fido_cred_largeblob_key_ptr</code>(),
   <code class="Fn" title="Fn">fido_cred_pubkey_ptr</code>(),
   <code class="Fn" title="Fn">fido_cred_sig_ptr</code>(), and
   <code class="Fn" title="Fn">fido_cred_x5c_ptr</code>() are guaranteed to exist
@@ -303,6 +319,7 @@ If not NULL, pointers returned by
   <a class="Xr" title="Xr" href="fido_cred_set_authdata.html">fido_cred_set_authdata(3)</a>,
   <a class="Xr" title="Xr" href="fido_cred_verify.html">fido_cred_verify(3)</a>,
   <a class="Xr" title="Xr" href="fido_credman_metadata_new.html">fido_credman_metadata_new(3)</a>,
+  <a class="Xr" title="Xr" href="fido_dev_largeblob_get.html">fido_dev_largeblob_get(3)</a>,
   <a class="Xr" title="Xr" href="fido_dev_make_cred.html">fido_dev_make_cred(3)</a></div>
 <table class="foot">
   <tr>

--- a/content/projects/libfido2/Manuals/fido_cred_set_authdata.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_set_authdata.partial
@@ -29,6 +29,7 @@
   <code class="Nm" title="Nm">fido_cred_set_rp</code>,
   <code class="Nm" title="Nm">fido_cred_set_user</code>,
   <code class="Nm" title="Nm">fido_cred_set_extensions</code>,
+  <code class="Nm" title="Nm">fido_cred_set_blob</code>,
   <code class="Nm" title="Nm">fido_cred_set_prot</code>,
   <code class="Nm" title="Nm">fido_cred_set_rk</code>,
   <code class="Nm" title="Nm">fido_cred_set_uv</code>,
@@ -109,6 +110,13 @@ typedef enum {
 <code class="Fn" title="Fn">fido_cred_set_extensions</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_cred_t
   *cred</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">int
   flags</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
+<code class="Fn" title="Fn">fido_cred_set_blob</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_cred_t
+  *cred</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
+  unsigned char *ptr</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">size_t len</var>);
 <div class="Pp"></div>
 <var class="Ft" title="Ft">int</var>
 <br/>
@@ -196,10 +204,18 @@ The <code class="Fn" title="Fn">fido_cred_set_user</code>() function sets the
 The <code class="Fn" title="Fn">fido_cred_set_extensions</code>() function sets
   the extensions of <var class="Fa" title="Fa">cred</var> to the bitmask
   <var class="Fa" title="Fa">flags</var>. At the moment, only the
-  <code class="Dv" title="Dv">FIDO_EXT_HMAC_SECRET</code> and
-  <code class="Dv" title="Dv">FIDO_EXT_CRED_PROTECT</code> extensions are
+  <code class="Dv" title="Dv">FIDO_EXT_CRED_BLOB</code>,
+  <code class="Dv" title="Dv">FIDO_EXT_CRED_PROTECT</code>,
+  <code class="Dv" title="Dv">FIDO_EXT_HMAC_SECRET</code>, and
+  <code class="Dv" title="Dv">FIDO_EXT_LARGEBLOB_KEY</code> extensions are
   supported. If <var class="Fa" title="Fa">flags</var> is zero, the extensions
   of <var class="Fa" title="Fa">cred</var> are cleared.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_cred_set_blob</code>() function sets the
+  &#x201C;credBlob&#x201D; to be stored with
+  <var class="Fa" title="Fa">cred</var> to the data pointed to by
+  <var class="Fa" title="Fa">ptr</var>, which must be
+  <var class="Fa" title="Fa">len</var> bytes long.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_cred_set_prot</code>() function sets the
   protection of <var class="Fa" title="Fa">cred</var> to the scalar

--- a/content/projects/libfido2/Manuals/fido_cred_set_blob.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_set_blob.partial
@@ -1,0 +1,1 @@
+fido_cred_set_authdata.partial

--- a/content/projects/libfido2/Manuals/fido_dev_enable_entattest.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_enable_entattest.partial
@@ -1,0 +1,112 @@
+<style>
+    table.head, table.foot { width: 100%; }
+    td.head-rtitle, td.foot-os { text-align: right; }
+    td.head-vol { text-align: center; }
+    div.Pp { margin: 1ex 0ex; }
+    div.Nd, div.Bf, div.Op { display: inline; }
+    span.Pa, span.Ad { font-style: italic; }
+    span.Ms { font-weight: bold; }
+    dl.Bl-diag > dt { font-weight: bold; }
+    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
+    code.Cd { font-weight: bold; font-family: monospace; }
+    var { font-family: monospace; }
+    .Sh { font-size: 1.5em; padding-top: 1em; padding-bottom: 1em; }
+</style>
+<table class="head">
+  <tr>
+    <td class="head-ltitle">FIDO_DEV_ENABLE_ENTATTEST(3)</td>
+    <td class="head-vol">Library Functions Manual</td>
+    <td class="head-rtitle">FIDO_DEV_ENABLE_ENTATTEST(3)</td>
+  </tr>
+</table>
+<div class="manual-text">
+<h1 class="Sh" title="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
+<code class="Nm" title="Nm">fido_dev_enable_entattest</code>,
+  <code class="Nm" title="Nm">fido_dev_toggle_always_uv</code>,
+  <code class="Nm" title="Nm">fido_dev_force_pin_change</code>,
+  <code class="Nm" title="Nm">fido_dev_set_pin_minlen</code> &#x2014;
+<div class="Nd" title="Nd">FIDO 2.1 configuration authenticator API</div>
+<h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
+<code class="In" title="In">#include
+  &lt;<a class="In" title="In">fido.h</a>&gt;</code>
+<br/>
+<code class="In" title="In">#include
+  &lt;<a class="In" title="In">fido/config.h</a>&gt;</code>
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
+<code class="Fn" title="Fn">fido_dev_enable_entattest</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_dev_t
+  *dev</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const char
+  *pin</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
+<code class="Fn" title="Fn">fido_dev_toggle_always_uv</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_dev_t
+  *dev</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const char
+  *pin</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
+<code class="Fn" title="Fn">fido_dev_force_pin_change</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_dev_t
+  *dev</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const char
+  *pin</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
+<code class="Fn" title="Fn">fido_dev_set_pin_minlen</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_dev_t
+  *dev</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">size_t
+  len</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const char
+  *pin</var>);
+<h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
+The functions described in this page allow configuration of a FIDO 2.1
+  authenticator.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_dev_enable_entattest</code>() function
+  enables the <i class="Em" title="Em">Enterprise Attestation</i> feature on
+  <var class="Fa" title="Fa">dev</var>. <i class="Em" title="Em">Enterprise
+  Attestation</i> instructs the authenticator to include uniquely identifying
+  information in subsequent attestation statements. The
+  <var class="Fa" title="Fa">pin</var> parameter may be NULL if
+  <var class="Fa" title="Fa">dev</var> does not have a PIN set.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_dev_toggle_always_uv</code>() function
+  toggles the &#x201C;user verification always&#x201D; feature on
+  <var class="Fa" title="Fa">dev</var>. When set, this toggle enforces user
+  verification at the authenticator level for all known credentials. If
+  <var class="Fa" title="Fa">dev</var> supports U2F (CTAP1) and the user
+  verification methods supported by the authenticator do not allow protection of
+  U2F credentials, the U2F subsystem will be disabled by the authenticator. The
+  <var class="Fa" title="Fa">pin</var> parameter may be NULL if
+  <var class="Fa" title="Fa">dev</var> does not have a PIN set.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_dev_force_pin_change</code>() instructs
+  <var class="Fa" title="Fa">dev</var> to require a PIN change. Subsequent PIN
+  authentication attempts against <var class="Fa" title="Fa">dev</var> will fail
+  until its PIN is changed.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_dev_set_pin_minlen</code>() function sets
+  the minimum PIN length of <var class="Fa" title="Fa">dev</var> to
+  <var class="Fa" title="Fa">len</var>. Minimum PIN lengths may only be
+  increased.
+<div class="Pp"></div>
+Configuration settings are reflected in the payload returned by the
+  authenticator in response to a
+  <a class="Xr" title="Xr" href="fido_dev_get_cbor_info.html">fido_dev_get_cbor_info(3)</a>
+  call.
+<h1 class="Sh" title="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
+  ALSO</a></h1>
+<a class="Xr" title="Xr" href="fido_dev_get_cbor_info.html">fido_dev_get_cbor_info(3)</a>,
+  <a class="Xr" title="Xr" href="fido_dev_reset.html">fido_dev_reset(3)</a>
+<h1 class="Sh" title="Sh" id="CAVEATS"><a class="permalink" href="#CAVEATS">CAVEATS</a></h1>
+Authenticator configuration is a tentative feature of FIDO 2.1. Applications
+  willing to strictly abide by FIDO 2.0 should refrain from using authenticator
+  configuration. Applications using authenticator configuration should ensure
+  the feature is supported by the authenticator prior to using the corresponding
+  API. Since FIDO 2.1 hasn't been finalised, there is a chance the functionality
+  and associated data structures may change.</div>
+<table class="foot">
+  <tr>
+    <td class="foot-date">September 22, 2020</td>
+    <td class="foot-os">Debian</td>
+  </tr>
+</table>

--- a/content/projects/libfido2/Manuals/fido_dev_force_pin_change.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_force_pin_change.partial
@@ -1,0 +1,1 @@
+fido_dev_enable_entattest.partial

--- a/content/projects/libfido2/Manuals/fido_dev_has_uv.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_has_uv.partial
@@ -1,0 +1,1 @@
+fido_dev_open.partial

--- a/content/projects/libfido2/Manuals/fido_dev_largeblob_get.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_largeblob_get.partial
@@ -1,0 +1,192 @@
+<style>
+    table.head, table.foot { width: 100%; }
+    td.head-rtitle, td.foot-os { text-align: right; }
+    td.head-vol { text-align: center; }
+    div.Pp { margin: 1ex 0ex; }
+    div.Nd, div.Bf, div.Op { display: inline; }
+    span.Pa, span.Ad { font-style: italic; }
+    span.Ms { font-weight: bold; }
+    dl.Bl-diag > dt { font-weight: bold; }
+    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
+    code.Cd { font-weight: bold; font-family: monospace; }
+    var { font-family: monospace; }
+    .Sh { font-size: 1.5em; padding-top: 1em; padding-bottom: 1em; }
+</style>
+<table class="head">
+  <tr>
+    <td class="head-ltitle">FIDO_LARGEBLOB_GET(3)</td>
+    <td class="head-vol">Library Functions Manual</td>
+    <td class="head-rtitle">FIDO_LARGEBLOB_GET(3)</td>
+  </tr>
+</table>
+<div class="manual-text">
+<h1 class="Sh" title="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
+<code class="Nm" title="Nm">fido_dev_largeblob_get</code>,
+  <code class="Nm" title="Nm">fido_dev_largeblob_set</code>,
+  <code class="Nm" title="Nm">fido_dev_largeblob_remove</code>,
+  <code class="Nm" title="Nm">fido_dev_largeblob_get_array</code>,
+  <code class="Nm" title="Nm">fido_dev_largeblob_set_array</code> &#x2014;
+<div class="Nd" title="Nd">FIDO 2 large blob API</div>
+<h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
+<code class="In" title="In">#include
+  &lt;<a class="In" title="In">fido.h</a>&gt;</code>
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
+<code class="Fn" title="Fn">fido_dev_largeblob_get</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_dev_t
+  *dev</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
+  unsigned char *key_ptr</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">size_t key_len</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">unsigned char
+  **blob_ptr</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">size_t
+  *blob_len</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
+<code class="Fn" title="Fn">fido_dev_largeblob_set</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_dev_t
+  *dev</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
+  unsigned char *key_ptr</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">size_t key_len</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">const unsigned char
+  *blob_ptr</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">size_t blob_len</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">const char
+  *pin</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
+<code class="Fn" title="Fn">fido_dev_largeblob_remove</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_dev_t
+  *dev</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
+  unsigned char *key_ptr</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">size_t key_len</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">const char
+  *pin</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
+<code class="Fn" title="Fn">fido_dev_largeblob_get_array</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_dev_t
+  *dev</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">unsigned
+  char **cbor_ptr</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">size_t
+  *cbor_len</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
+<code class="Fn" title="Fn">fido_dev_largeblob_set_array</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_dev_t
+  *dev</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
+  unsigned char *cbor_ptr</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">size_t cbor_len</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">const char
+  *pin</var>);
+<h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
+The &#x201C;largeBlobs&#x201D; API of <i class="Em" title="Em">libfido2</i>
+  allows binary blobs residing on a FIDO 2.1 authenticator to be read, written,
+  and inspected. &#x201C;largeBlobs&#x201D; is a FIDO 2.1 extension.
+<div class="Pp"></div>
+&#x201C;largeBlobs&#x201D; are stored as elements of a CBOR array.
+  Confidentiality is ensured by encrypting each element with a distinct,
+  credential-bound 256-bit AES-GCM key. The array is otherwise shared between
+  different credentials and FIDO2 relying parties.
+<div class="Pp"></div>
+Retrieval of a credential's encryption key is possible during enrollment with
+  <a class="Xr" title="Xr" href="fido_cred_set_extensions.html">fido_cred_set_extensions(3)</a>
+  and
+  <a class="Xr" title="Xr" href="fido_cred_largeblob_key_ptr.html">fido_cred_largeblob_key_ptr(3)</a>,
+  during assertion with
+  <a class="Xr" title="Xr" href="fido_assert_set_extensions.html">fido_assert_set_extensions(3)</a>
+  and
+  <a class="Xr" title="Xr" href="fido_assert_largeblob_key_ptr.html">fido_assert_largeblob_key_ptr(3)</a>,
+  or, in the case of a resident credential, via
+  <i class="Em" title="Em">libfido2's</i> credential management API.
+<div class="Pp"></div>
+The &#x201C;largeBlobs&#x201D; CBOR array is opaque to the authenticator.
+  Management of the array is left at the discretion of FIDO2 clients. For
+  further details on FIDO 2.1's &#x201C;largeBlobs&#x201D; extension, please
+  refer to the FIDO 2.1 spec.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_dev_largeblob_get</code>() function
+  retrieves the authenticator's &#x201C;largeBlobs&#x201D; CBOR array and, on
+  success, returns the first blob (iterating from array index zero) that can be
+  decrypted by <var class="Fa" title="Fa">key_ptr</var>, where
+  <var class="Fa" title="Fa">key_ptr</var> points to
+  <var class="Fa" title="Fa">key_len</var> bytes. On success,
+  <code class="Fn" title="Fn">fido_dev_largeblob_get</code>() sets
+  <var class="Fa" title="Fa">blob_ptr</var> to the body of the decrypted blob,
+  and <var class="Fa" title="Fa">blob_len</var> to the length of the decrypted
+  blob in bytes. It is the caller's responsibility to free
+  <var class="Fa" title="Fa">blob_ptr</var>.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_dev_largeblob_set</code>() function uses
+  <var class="Fa" title="Fa">key_ptr</var> to encrypt
+  <var class="Fa" title="Fa">blob_ptr</var> and inserts the result in the
+  authenticator's &#x201C;largeBlobs&#x201D; CBOR array. Insertion happens at
+  the end of the array if no existing element can be decrypted by
+  <var class="Fa" title="Fa">key_ptr</var>, or at the position of the first
+  element (iterating from array index zero) that can be decrypted by
+  <var class="Fa" title="Fa">key_ptr</var>.
+  <var class="Fa" title="Fa">key_len</var> holds the length of
+  <var class="Fa" title="Fa">key_ptr</var> in bytes, and
+  <var class="Fa" title="Fa">blob_len</var> the length of
+  <var class="Fa" title="Fa">blob_ptr</var> in bytes. A
+  <var class="Fa" title="Fa">pin</var> or equivalent user-verification gesture
+  is required.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_dev_largeblob_remove</code>() function
+  retrieves the authenticator's &#x201C;largeBlobs&#x201D; CBOR array and, on
+  success, drops the first blob (iterating from array index zero) that can be
+  decrypted by <var class="Fa" title="Fa">key_ptr</var>, where
+  <var class="Fa" title="Fa">key_ptr</var> points to
+  <var class="Fa" title="Fa">key_len</var> bytes. A
+  <var class="Fa" title="Fa">pin</var> or equivalent user-verification gesture
+  is required.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_dev_largeblob_get_array</code>() function
+  retrieves the authenticator's &#x201C;largeBlobs&#x201D; CBOR array and, on
+  success, sets <var class="Fa" title="Fa">cbor_ptr</var> to the body of the
+  CBOR array, and <var class="Fa" title="Fa">cbor_len</var> to its corresponding
+  length in bytes. It is the caller's responsibility to free
+  <var class="Fa" title="Fa">cbor_ptr</var>.
+<div class="Pp"></div>
+Finally, the <code class="Fn" title="Fn">fido_dev_largeblob_set_array</code>()
+  function sets the authenticator's &#x201C;largeBlobs&#x201D; CBOR array to the
+  data pointed to by <var class="Fa" title="Fa">cbor_ptr</var>, where
+  <var class="Fa" title="Fa">cbor_ptr</var> points to
+  <var class="Fa" title="Fa">cbor_len</var> bytes. A
+  <var class="Fa" title="Fa">pin</var> or equivalent user-verification gesture
+  is required.
+<h1 class="Sh" title="Sh" id="RETURN_VALUES"><a class="permalink" href="#RETURN_VALUES">RETURN
+  VALUES</a></h1>
+The functions <code class="Fn" title="Fn">fido_dev_largeblob_set</code>(),
+  <code class="Fn" title="Fn">fido_dev_largeblob_get</code>(),
+  <code class="Fn" title="Fn">fido_dev_largeblob_remove</code>(),
+  <code class="Fn" title="Fn">fido_dev_largeblob_get_array</code>(), and
+  <code class="Fn" title="Fn">fido_dev_largeblob_set_array</code>() return
+  <code class="Dv" title="Dv">FIDO_OK</code> on success. On error, an error code
+  defined in
+  <code class="In" title="In">&lt;<a class="In" title="In">fido/err.h</a>&gt;</code>
+  is returned.
+<h1 class="Sh" title="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
+  ALSO</a></h1>
+<a class="Xr" title="Xr" href="fido_assert_largeblob_key_len.html">fido_assert_largeblob_key_len(3)</a>,
+  <a class="Xr" title="Xr" href="fido_assert_largeblob_key_ptr.html">fido_assert_largeblob_key_ptr(3)</a>,
+  <a class="Xr" title="Xr" href="fido_assert_set_extensions.html">fido_assert_set_extensions(3)</a>,
+  <a class="Xr" title="Xr" href="fido_cred_largeblob_key_len.html">fido_cred_largeblob_key_len(3)</a>,
+  <a class="Xr" title="Xr" href="fido_cred_largeblob_key_ptr.html">fido_cred_largeblob_key_ptr(3)</a>,
+  <a class="Xr" title="Xr" href="fido_cred_set_extensions.html">fido_cred_set_extensions(3)</a>,
+  <a class="Xr" title="Xr" href="fido_credman_dev_get_rk.html">fido_credman_dev_get_rk(3)</a>,
+  <a class="Xr" title="Xr" href="fido_credman_dev_get_rp.html">fido_credman_dev_get_rp(3)</a>,
+  <a class="Xr" title="Xr" href="fido_dev_get_assert.html">fido_dev_get_assert(3)</a>,
+  <a class="Xr" title="Xr" href="fido_dev_make_cred.html">fido_dev_make_cred(3)</a>
+<h1 class="Sh" title="Sh" id="CAVEATS"><a class="permalink" href="#CAVEATS">CAVEATS</a></h1>
+The &#x201C;largeBlobs&#x201D; extension is not meant to be used to store
+  sensitive data. When retrieved, a credential's &#x201C;largeBlobs&#x201D;
+  encryption key is transmitted in the clear, and an authenticator's
+  &#x201C;largeBlobs&#x201D; CBOR array can be read without user interaction or
+  verification.</div>
+<table class="foot">
+  <tr>
+    <td class="foot-date">October 26, 2020</td>
+    <td class="foot-os">Debian</td>
+  </tr>
+</table>

--- a/content/projects/libfido2/Manuals/fido_dev_largeblob_get_array.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_largeblob_get_array.partial
@@ -1,0 +1,1 @@
+fido_dev_largeblob_get.partial

--- a/content/projects/libfido2/Manuals/fido_dev_largeblob_remove.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_largeblob_remove.partial
@@ -1,0 +1,1 @@
+fido_dev_largeblob_get.partial

--- a/content/projects/libfido2/Manuals/fido_dev_largeblob_set.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_largeblob_set.partial
@@ -1,0 +1,1 @@
+fido_dev_largeblob_get.partial

--- a/content/projects/libfido2/Manuals/fido_dev_largeblob_set_array.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_largeblob_set_array.partial
@@ -1,0 +1,1 @@
+fido_dev_largeblob_get.partial

--- a/content/projects/libfido2/Manuals/fido_dev_open.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_open.partial
@@ -33,6 +33,8 @@
   <code class="Nm" title="Nm">fido_dev_supports_cred_prot</code>,
   <code class="Nm" title="Nm">fido_dev_supports_pin</code>,
   <code class="Nm" title="Nm">fido_dev_has_pin</code>,
+  <code class="Nm" title="Nm">fido_dev_supports_uv</code>,
+  <code class="Nm" title="Nm">fido_dev_has_uv</code>,
   <code class="Nm" title="Nm">fido_dev_protocol</code>,
   <code class="Nm" title="Nm">fido_dev_build</code>,
   <code class="Nm" title="Nm">fido_dev_flags</code>,
@@ -103,6 +105,16 @@
 <code class="Fn" title="Fn">fido_dev_has_pin</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_dev_t *dev</var>);
 <div class="Pp"></div>
+<var class="Ft" title="Ft">bool</var>
+<br/>
+<code class="Fn" title="Fn">fido_dev_supports_uv</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_dev_t *dev</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">bool</var>
+<br/>
+<code class="Fn" title="Fn">fido_dev_has_uv</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_dev_t *dev</var>);
+<div class="Pp"></div>
 <var class="Ft" title="Ft">uint8_t</var>
 <br/>
 <code class="Fn" title="Fn">fido_dev_protocol</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
@@ -131,7 +143,13 @@
 The <code class="Fn" title="Fn">fido_dev_open</code>() function opens the device
   pointed to by <var class="Fa" title="Fa">path</var>, where
   <var class="Fa" title="Fa">dev</var> is a freshly allocated or otherwise
-  closed <var class="Vt" title="Vt">fido_dev_t</var>.
+  closed <var class="Vt" title="Vt">fido_dev_t</var>. If
+  <var class="Fa" title="Fa">dev</var> claims to be FIDO2,
+  <i class="Em" title="Em">libfido2</i> will attempt to speak FIDO2 to
+  <var class="Fa" title="Fa">dev</var>. If that fails,
+  <i class="Em" title="Em">libfido2</i> will fallback to U2F unless the
+  <code class="Dv" title="Dv">FIDO_DISABLE_U2F_FALLBACK</code> flag was set in
+  <a class="Xr" title="Xr" href="fido_init.html">fido_init(3)</a>.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_dev_close</code>() function closes the
   device represented by <var class="Fa" title="Fa">dev</var>. If
@@ -180,6 +198,16 @@ The <code class="Fn" title="Fn">fido_dev_has_pin</code>() function returns
   <code class="Dv" title="Dv">true</code> if
   <var class="Fa" title="Fa">dev</var> has a FIDO 2.0 Client PIN set.
 <div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_dev_supports_uv</code>() function returns
+  <code class="Dv" title="Dv">true</code> if
+  <var class="Fa" title="Fa">dev</var> supports a built-in user verification
+  method.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_dev_has_uv</code>() function returns
+  <code class="Dv" title="Dv">true</code> if
+  <var class="Fa" title="Fa">dev</var> supports built-in user verification and
+  its user verification feature is configured.
+<div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_dev_protocol</code>() function returns the
   CTAPHID protocol version identifier of <var class="Fa" title="Fa">dev</var>.
 <div class="Pp"></div>
@@ -209,7 +237,8 @@ On success, <code class="Fn" title="Fn">fido_dev_open</code>() and
 <h1 class="Sh" title="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
 <a class="Xr" title="Xr" href="fido_dev_info_manifest.html">fido_dev_info_manifest(3)</a>,
-  <a class="Xr" title="Xr" href="fido_dev_set_io_functions.html">fido_dev_set_io_functions(3)</a></div>
+  <a class="Xr" title="Xr" href="fido_dev_set_io_functions.html">fido_dev_set_io_functions(3)</a>,
+  <a class="Xr" title="Xr" href="fido_init.html">fido_init(3)</a></div>
 <table class="foot">
   <tr>
     <td class="foot-date">May 25, 2018</td>

--- a/content/projects/libfido2/Manuals/fido_dev_set_io_functions.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_set_io_functions.partial
@@ -21,7 +21,8 @@
 </table>
 <div class="manual-text">
 <h1 class="Sh" title="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
-<code class="Nm" title="Nm">fido_dev_set_io_functions</code> &#x2014;
+<code class="Nm" title="Nm">fido_dev_set_io_functions</code>,
+  <code class="Nm" title="Nm">fido_dev_set_sigmask</code> &#x2014;
 <div class="Nd" title="Nd">FIDO 2 device I/O interface</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
@@ -33,17 +34,19 @@ typedef void *fido_dev_io_open_t(const char *);
 typedef void  fido_dev_io_close_t(void *); 
 typedef int   fido_dev_io_read_t(void *, unsigned char *, size_t, int); 
 typedef int   fido_dev_io_write_t(void *, const unsigned char *, size_t); 
-typedef int   fido_dev_io_rx_t(struct fido_dev *, uint8_t, unsigned char *, size_t, int); 
-typedef int   fido_dev_io_tx_t(struct fido_dev *, uint8_t, const unsigned char *, size_t); 
  
 typedef struct fido_dev_io { 
 	fido_dev_io_open_t  *open; 
 	fido_dev_io_close_t *close; 
 	fido_dev_io_read_t  *read; 
 	fido_dev_io_write_t *write; 
-	fido_dev_io_rx_t    *rx; 
-	fido_dev_io_tx_t    *tx; 
-} fido_dev_io_t;
+} fido_dev_io_t; 
+ 
+#ifdef _WIN32 
+typedef int fido_sigset_t; 
+#else 
+typedef sigset_t fido_sigset_t; 
+#endif
 </pre>
 </div>
 <br/>
@@ -52,77 +55,75 @@ typedef struct fido_dev_io {
 <code class="Fn" title="Fn">fido_dev_set_io_functions</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_dev_t
   *dev</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_dev_io_t *io</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
+<code class="Fn" title="Fn">fido_dev_set_sigmask</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_dev_t
+  *dev</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_sigset_t *sigmask</var>);
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
-The <code class="Nm" title="Nm">fido_dev_set_io_functions</code> interface
-  defines the I/O and transmission handlers used to talk to
-  <var class="Fa" title="Fa">dev</var>. Its usage is optional. By default,
-  <i class="Em" title="Em">libfido2</i> will use the operating system's native
-  HID interface to talk CTAP2 to a FIDO device.
-<div class="Pp"></div>
-A <var class="Vt" title="Vt">fido_dev_io_open_t</var> function is expected to
-  return a non-NULL opaque pointer on success, and NULL on error. The returned
-  opaque pointer is never dereferenced by <i class="Em" title="Em">libfido2</i>.
-<div class="Pp"></div>
-A <var class="Vt" title="Vt">fido_dev_io_close_t</var> function receives the
-  opaque handle obtained from
-  <var class="Vt" title="Vt">fido_dev_io_open_t</var>. It is not expected to be
-  idempotent.
-<div class="Pp"></div>
-A <var class="Vt" title="Vt">fido_dev_io_read_t</var> function reads a single
-  HID report from <var class="Fa" title="Fa">dev</var>. The first parameter
-  taken is the opaque handle obtained from
-  <var class="Vt" title="Vt">fido_dev_io_open_t</var>. The read buffer is
-  pointed to by the second parameter, and the third parameter holds its size.
-  The last argument passed to
-  <var class="Vt" title="Vt">fido_dev_io_read_t</var> is the number of
-  milliseconds the caller is willing to sleep, should the call need to block. If
-  this value holds -1, <var class="Vt" title="Vt">fido_dev_io_read_t</var> may
-  block indefinitely. The number of bytes read is returned. On error, -1 is
-  returned.
-<div class="Pp"></div>
-A <var class="Vt" title="Vt">fido_dev_io_write_t</var> function writes a single
-  HID report to <var class="Fa" title="Fa">dev</var>. The first parameter taken
-  is the opaque handle returned by
-  <var class="Vt" title="Vt">fido_dev_io_open_t</var>. The write buffer is
-  pointed to by the second parameter, and the third parameter holds its size. A
-  <var class="Vt" title="Vt">fido_dev_io_write_t</var> function may block. The
-  number of bytes written is returned. On error, -1 is returned.
-<div class="Pp"></div>
-A <var class="Vt" title="Vt">fido_dev_io_rx_t</var> function receives a complete
-  CTAP2 message from <var class="Fa" title="Fa">dev</var>. The first parameter
-  taken is a pointer to <var class="Fa" title="Fa">dev</var>. The second
-  parameter holds the expected CTAP2 command byte. The read buffer is pointed to
-  by the third parameter, and the fourth parameter holds its size. The last
-  argument passed to <var class="Vt" title="Vt">fido_dev_io_rx_t</var> is the
-  number of milliseconds the caller is willing to sleep, should the call need to
-  block. If this value holds -1,
-  <var class="Vt" title="Vt">fido_dev_io_rx_t</var> may block indefinitely. The
-  number of bytes read is returned. On error, -1 is returned.
-<div class="Pp"></div>
-A <var class="Vt" title="Vt">fido_dev_io_tx_t</var> function transmits a
-  complete CTAP2 message to <var class="Fa" title="Fa">dev</var>. The first
-  parameter taken is a pointer to <var class="Fa" title="Fa">dev</var>. The
-  second parameter holds the CTAP2 command byte. The write buffer is pointed to
-  by the third parameter, and the fourth parameter holds its size. A
-  <var class="Vt" title="Vt">fido_dev_io_tx_t</var> function may block. On
-  success, 0 is returned. On error, -1 is returned.
+The <code class="Fn" title="Fn">fido_dev_set_io_functions</code>() function sets
+  the I/O handlers used by <i class="Em" title="Em">libfido2</i> to talk to
+  <var class="Fa" title="Fa">dev</var>. By default, these handlers are set to
+  the operating system's native HID or NFC interfaces. They are defined as
+  follows:
+<dl class="Bl-tag">
+  <dt><var class="Vt" title="Vt">fido_dev_open_t</var></dt>
+  <dd>Receives a <var class="Vt" title="Vt">const char *</var> holding a path
+      and opens the corresponding device, returning a non-NULL opaque pointer on
+      success and NULL on error.</dd>
+  <dt><var class="Vt" title="Vt">fido_dev_close_t</var></dt>
+  <dd>Receives the opaque pointer returned by
+      <var class="Vt" title="Vt">fido_dev_open_t</var> and closes the
+    device.</dd>
+  <dt><var class="Vt" title="Vt">fido_dev_read_t</var></dt>
+  <dd>Reads a single transmission unit (HID report, APDU) from a device. The
+      first parameter is the opaque pointer returned by
+      <var class="Vt" title="Vt">fido_dev_open_t</var>. The second parameter is
+      the read buffer, and the third parameter is the read buffer size. The
+      fourth parameter is the number of milliseconds the caller is willing to
+      sleep, should the call need to block. If this value holds -1,
+      <var class="Vt" title="Vt">fido_dev_read_t</var> may block indefinitely.
+      On success, the number of bytes read is returned. On error, -1 is
+      returned.</dd>
+  <dt><var class="Vt" title="Vt">fido_dev_write_t</var></dt>
+  <dd>Writes a single transmission unit (HID report, APDU) to
+      <var class="Fa" title="Fa">dev</var>. The first parameter is the opaque
+      pointer returned by <var class="Vt" title="Vt">fido_dev_open_t</var>. The
+      second parameter is the write buffer, and the third parameter is the
+      number of bytes to be written. A
+      <var class="Vt" title="Vt">fido_dev_write_t</var> may block. On success,
+      the number of bytes written is returned. On error, -1 is returned.</dd>
+</dl>
 <div class="Pp"></div>
 When calling <code class="Fn" title="Fn">fido_dev_set_io_functions</code>(), the
   <var class="Fa" title="Fa">open</var>, <var class="Fa" title="Fa">close</var>,
-  <var class="Fa" title="Fa">read</var> and
+  <var class="Fa" title="Fa">read</var>, and
   <var class="Fa" title="Fa">write</var> fields of
-  <var class="Fa" title="Fa">io</var> may not be NULL. Either
-  <var class="Fa" title="Fa">rx</var> or <var class="Fa" title="Fa">tx</var> may
-  be NULL, in which case <i class="Em" title="Em">libfido2</i> uses its
-  corresponding CTAP2 HID transport method.
+  <var class="Fa" title="Fa">io</var> may not be NULL.
 <div class="Pp"></div>
 No references to <var class="Fa" title="Fa">io</var> are held by
   <code class="Fn" title="Fn">fido_dev_set_io_functions</code>().
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_dev_set_sigmask</code>() function may be
+  used to specify a non-NULL signal mask
+  <var class="Fa" title="Fa">sigmask</var> to be used while
+  <i class="Em" title="Em">libfido2's</i> default I/O handlers wait on
+  <var class="Fa" title="Fa">dev</var>. On UNIX-like operating systems,
+  <var class="Vt" title="Vt">fido_sigset_t</var> is defined as
+  <var class="Vt" title="Vt">sigset_t</var>. On Windows,
+  <var class="Vt" title="Vt">fido_sigset_t</var> is defined as
+  <var class="Vt" title="Vt">int</var> and
+  <code class="Fn" title="Fn">fido_dev_set_sigmask</code>() is a no-op.
+<div class="Pp"></div>
+No references to <var class="Fa" title="Fa">sigmask</var> are held by
+  <code class="Fn" title="Fn">fido_dev_set_sigmask</code>().
 <h1 class="Sh" title="Sh" id="RETURN_VALUES"><a class="permalink" href="#RETURN_VALUES">RETURN
   VALUES</a></h1>
-On success, <code class="Fn" title="Fn">fido_dev_set_io_functions</code>()
-  returns <code class="Dv" title="Dv">FIDO_OK</code>. On error, a different
-  error code defined in
+On success, <code class="Fn" title="Fn">fido_dev_set_io_functions</code>() and
+  <code class="Fn" title="Fn">fido_dev_set_sigmask</code>() return
+  <code class="Dv" title="Dv">FIDO_OK</code>. On error, a different error code
+  defined in
   <code class="In" title="In">&lt;<a class="In" title="In">fido/err.h</a>&gt;</code>
   is returned.</div>
 <table class="foot">

--- a/content/projects/libfido2/Manuals/fido_dev_set_pin_minlen.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_set_pin_minlen.partial
@@ -1,0 +1,1 @@
+fido_dev_enable_entattest.partial

--- a/content/projects/libfido2/Manuals/fido_dev_set_sigmask.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_set_sigmask.partial
@@ -1,0 +1,1 @@
+fido_dev_set_io_functions.partial

--- a/content/projects/libfido2/Manuals/fido_dev_supports_uv.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_supports_uv.partial
@@ -1,0 +1,1 @@
+fido_dev_open.partial

--- a/content/projects/libfido2/Manuals/fido_dev_toggle_always_uv.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_toggle_always_uv.partial
@@ -1,0 +1,1 @@
+fido_dev_enable_entattest.partial

--- a/content/projects/libfido2/Manuals/fido_init.partial
+++ b/content/projects/libfido2/Manuals/fido_init.partial
@@ -34,12 +34,20 @@
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
 The <code class="Fn" title="Fn">fido_init</code>() function initialises the
   <i class="Em" title="Em">libfido2</i> library. Its invocation must precede
-  that of any other <i class="Em" title="Em">libfido2</i> function. If
-  <code class="Dv" title="Dv">FIDO_DEBUG</code> is set in
+  that of any other <i class="Em" title="Em">libfido2</i> function in the
+  context of the executing thread.
+<div class="Pp"></div>
+If <code class="Dv" title="Dv">FIDO_DEBUG</code> is set in
   <var class="Fa" title="Fa">flags</var>, then debug output will be emitted by
   <i class="Em" title="Em">libfido2</i> on <i class="Em" title="Em">stderr</i>.
   Alternatively, the <code class="Ev" title="Ev">FIDO_DEBUG</code> environment
   variable may be set.
+<div class="Pp"></div>
+If <code class="Dv" title="Dv">FIDO_DISABLE_U2F_FALLBACK</code> is set in
+  <var class="Fa" title="Fa">flags</var>, then
+  <i class="Em" title="Em">libfido2</i> will not fallback to U2F in
+  <a class="Xr" title="Xr" href="fido_dev_open.html">fido_dev_open(3)</a> if a
+  device claims to be FIDO2 but fails to respond to a FIDO2 command.
 <h1 class="Sh" title="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
 <a class="Xr" title="Xr" href="fido_assert_new.html">fido_assert_new(3)</a>,


### PR DESCRIPTION
- new -b (largeblob) option to fido2-cred(1) and fido2-assert(1);
- break out and expand usage options in fido2-token(1);
- new largeblob functionality in fido2-token(1):
  * list blobs: -Lb;
  * get a blob: -Gb;
  * set a blob: -Sb.
- new API calls:
  * fido_assert_blob_len(3);
  * fido_assert_blob_ptr(3);
  * fido_assert_largeblob_key_len(3);
  * fido_assert_largeblob_key_ptr(3);
  * fido_assert_set_hmac_secret(3);
  * fido_cbor_info_maxcredbloblen(3);
  * fido_cred_set_blob(3);
  * fido_dev_enable_entattest(3);
  * fido_dev_force_pin_change(3);
  * fido_dev_has_uv(3);
  * fido_dev_largeblob_get(3);
  * fido_dev_largeblob_get_array(3);
  * fido_dev_largeblob_remove(3);
  * fido_dev_largeblob_set(3);
  * fido_dev_largeblob_set_array(3);
  * fido_dev_set_pin_minlen(3);
  * fido_dev_set_sigmask(3);
  * fido_dev_supports_uv(3);
  * fido_dev_toggle_always_uv(3).
- new FIDO_DISABLE_U2F_FALLBACK flag in fido_init(3).