### PR TITLE
Update attestation link

### DIFF
--- a/content/PIV/Introduction/PIV_attestation.adoc
+++ b/content/PIV/Introduction/PIV_attestation.adoc
@@ -1,7 +1,7 @@
 == PIV Attestation
 
 === Introduction
-This document describes the attestation feature added to the PIV module in YubiKey 4.3 and 5. For actual commands to work with the attestation feature, please see the yubico-piv-tool link:../../yubico-piv-tool/doc/Attestation.adoc[documentation].
+This document describes the attestation feature added to the PIV module in YubiKey 4.3 and 5. For actual commands to work with the attestation feature, please see the yubico-piv-tool link:../../yubico-piv-tool/Attestation.adoc[documentation].
 
 === Purpose
 The concept of attestation is used to show that a certain asymmetric key has been generated on device and not imported. Typically this would be used before creating a certificate.


### PR DESCRIPTION
Link seems broken, pointing to `.../doc/Attestation.html`: https://developers.yubico.com/PIV/Introduction/PIV_attestation.html