### PR TITLE
Update python dependencies to newer versions.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-jinja2 == 2.10.1
-beautifulsoup4 == 4.3.2
-pygments == 2.2.0
+jinja2 == 2.11.3
+beautifulsoup4 == 4.9.3
+pygments == 2.5.2
 pyfeed-0.7.4.tar.gz
 xe-0.7.4.tar.gz


### PR DESCRIPTION
Some of these have newer versions available, but they are not compatible with Python 2.7