### PR TITLE
Update YubiKey_and_PIV.adoc

### DIFF
--- a/content/PIV/Introduction/YubiKey_and_PIV.adoc
+++ b/content/PIV/Introduction/YubiKey_and_PIV.adoc
@@ -30,7 +30,7 @@ The following key slots exist:
 
 * 9B: Triple-DES key (algorithm 3) for PIV management.
 
-The maximum size of stored objects is 2025/3049 bytes for current versions of
+The maximum size of stored objects is 2025/3052 bytes for current versions of
 YubiKey NEO and YubiKey 4 & 5, respectively.
 
 Currently all functionality are available over both contact and contactless


### PR DESCRIPTION
Changed max size of stored objects to 3052 bytes to match KB.