### PR TITLE
Updated FAQ, known-issues, and compatibility chart to reflect latest iOS version

### DIFF
--- a/content/WebAuthn/Supporting_U2F_or_FIDO2_Security_Keys_on_iOS_or_iPadOS/FAQ.adoc
+++ b/content/WebAuthn/Supporting_U2F_or_FIDO2_Security_Keys_on_iOS_or_iPadOS/FAQ.adoc
@@ -11,7 +11,7 @@
 *Answer*: The supported YubiKeys for native apps using the Yubico iOS SDK are:
 
 * YubiKey 5Ci for iPhones/iPads with Lightning connector,
-* YubiKey 5 NFC for iPhones (7 and higher with NFC support), and the
+* YubiKey 5 & 5C NFC for iPhones (7 and higher with NFC support), and the
 * Security Key NFC by Yubico for NFC-enabled iPhones.
 
 There is no YubiKey support for the iPad Pro with USB-C connector when using a native app.

--- a/content/WebAuthn/Supporting_U2F_or_FIDO2_Security_Keys_on_iOS_or_iPadOS/Known_Issues.adoc
+++ b/content/WebAuthn/Supporting_U2F_or_FIDO2_Security_Keys_on_iOS_or_iPadOS/Known_Issues.adoc
@@ -1,14 +1,12 @@
 == Known Issues
 
-This section covers known issues (as of January 2, 2020) when using 13.3+ Safari browser, SFSafariViewController, orASWebAuthenticationSession.
+This section covers known issues (as of May 11, 2021) when using 14.2+ Safari browser, SFSafariViewController, or ASWebAuthenticationSession.
 
 === 1. User Verification (PIN Support)
 
-It does not matter whether a FIDO2 PIN is set, required, or preferred: in all those cases, the Safari browser dialog does not prompt for a PIN.
-
 [NOTE]
 ======
-If the service from which the user is authenticating is a U2F flow only, then PIN on FIDO2 is a non-issue and the user will successfully authenticate. Learn more in the link:../WebAuthn_Developer_Guide/User_Presence_vs_User_Verification.adoc[User Presence vs User Verification section of our WebAuthn Developer Guide].
+If a FIDO2 PIN does not exist on the YubiKey, iOS Safari WILL NOT prompt the user to create a PIN.
 ======
 
 ==== Required, Preferred, and Discouraged Parameters for User Verification
@@ -16,38 +14,9 @@ If the service from which the user is authenticating is a U2F flow only, then PI
 |=========================================================================
 |Feature                       |Required    |Preferred   |Discouraged
 
-|User Verification (FIDO2 PIN) |Not working |Not working |Working
+|User Verification (FIDO2 PIN) |Supported | Supported |Supported
 |=========================================================================
 
 “Required”, “Preferred”, and “Discouraged” are optional parameters sent to the client browser by the WebAuthn RP during user registration.
-
-
-=== 2. Discoverable Credentials (Resident Key)
-
-When the WebAuthn RP specifies the optional parameter `RequireResidentKey=TRUE`, the registration hangs and the user is never prompted to insert or tap the YubiKey. Learn more in the link:../WebAuthn_Developer_Guide/Resident_Keys.adoc[Discoverable Credentials section of our WebAuthn Developer Guide].
-
-==== Required (TRUE)/Required(FALSE) Parameters for Discoverable Credentials (ResidentKey)
-[options="header"]
-|=====================================================================================
-|Feature                            |Required (TRUE) |Required (FALSE)
-
-|Discoverable Credentials (ResidentKey) |Not working     |Working
-|=====================================================================================
-
-`Required: TRUE|FALSE` is an optional parameter sent by the WebAuthn RP to the client.
-
-
-=== 3. Attestation
-
-If the WebAuthn RP requests any attestation parameter other than `none`, registration fails and the user is never prompted to insert or tap a YubiKey. Learn more in the link:../WebAuthn_Developer_Guide/Attestation.adoc[Attestation section of our WebAuthn Developer Guide].
-
-==== None, Indirect, and Direct Parameters for Attestation
-[options="header"]
-|=========================================================
-|Feature                       |None     |Indirect          |Direct
-
-|Attestation                   |Working  |Not working       |Not working
-|=========================================================
-
 
 link:FAQ.adoc[Next: FAQ]

--- a/content/WebAuthn/Supporting_U2F_or_FIDO2_Security_Keys_on_iOS_or_iPadOS/Security_Key_Compatibility.adoc
+++ b/content/WebAuthn/Supporting_U2F_or_FIDO2_Security_Keys_on_iOS_or_iPadOS/Security_Key_Compatibility.adoc
@@ -1,17 +1,18 @@
 == Security Key Compatibility
 
-iOS 13.3 opens up a large pool of supported security keys when using the Safari browser, SFSafariViewController orASWebAuthenticationSession:
+iOS 13.3+ opens up a large pool of supported security keys when using the Safari browser, SFSafariViewController or ASWebAuthenticationSession:
 
 
 === Table 1: Safari Browser, SFSafariViewController/ASWebAuthenticationSession + Compatible U2F/FIDO2 Security Keys
-Compatible U2F/FIDO2 Security Keys that currently work with iOS/iPadOS 13.3 devices using Safari browser and apps using SFSafariViewController or ASWebAuthenticationSession
+Compatible U2F/FIDO2 Security Keys that currently work with iOS/iPadOS 13.3+ devices using Safari browser and apps using SFSafariViewController or ASWebAuthenticationSession
 [options="header"]
 |========================
-|                             |iPhone (7 and newer) running iOS 13.3 (with Lightning and NFC)  |iPad running iPadOS 13.3 (with Lightning)  |iPad running iPadOS 13.3 (with USB-C)
+|                             |iPhone (7 and newer) running iOS 13.3+ (with Lightning and NFC)  |iPad running iPadOS 13.3+ (with Lightning)  |iPad running iPadOS 13.3+ (with USB-C)
 
 |YubiKey 5Ci                  |Lightning                                                       |Lightning                                  |USB-C
 |YubiKey 5 NFC                |USB-A, NFC                                                      |USB-A                                      |USB-A
 |YubiKey 5C                   |-                                                               |-                                          |USB-C
+|YubiKey 5C NFC               |NFC                                                               |-                                          |USB-C
 |Security Key by Yubico       |USB-A                                                           |USB-A                                      |USB-A
 |Security Key by Yubico (NFC) |USB-A, NFC                                                      |USB-A                                      |USB-A
 |YubiKey 5 Nano               |USB-A                                                           |USB-A                                      |USB-A
@@ -34,6 +35,7 @@ Compatible U2F/FIDO2 Security Keys that currently work with iOS/iPadOS apps usin
 
 |YubiKey 5Ci                  |Lightning                                                       |Lightning                                |-
 |YubiKey 5 NFC                |NFC                                                             |-                                        |-
+|YubiKey 5C NFC                |NFC                                                             |-                                        |-
 |Security Key by Yubico (NFC) |NFC                                                             |-                                        |-
 |========================
 

--- a/content/WebAuthn/WebAuthn_Browser_Support/index.adoc
+++ b/content/WebAuthn/WebAuthn_Browser_Support/index.adoc
@@ -46,7 +46,7 @@ https://bugs.webkit.org/show_bug.cgi?id=191516
 |===
 2+|Browser |User Presence (touch) |Resident Key / Discoverable Credential |User Verification (PIN / Biometric) |CTAP 1 /
 U2F Legacy Support
-.2+|*Safari 14** |USB a|image::group-4.png[] a|image::group-4.png[] a|image::group-copy-5.png[] a|image::group-4.png[]
+.2+|*Safari 14** |USB a|image::group-4.png[] a|image::group-4.png[] a|image::group-4.png[] a|image::group-4.png[]
 ^.^|NFC a|N/A a|N/A a|N/A a|N/A
 .2+|*Chrome 85* |USB a|image::group-4.png[] a|image::group-4.png[] a|image::group-4.png[] a|image::group-4.png[]
 ^.^|NFC a|N/A a|N/A a|N/A a|N/A
@@ -59,14 +59,14 @@ U2F Legacy Support
 https://bugzilla.mozilla.org/show_bug.cgi?id=1530370
 
 === iOS 14 ===
-Verified with iPhone XS and iPhone8
+Verified with iPhone 12, 11, XR, XS and iPhone8
 
 [%header,cols="^.^,^.,^.,^.,^.,^."]
 |===
 2+|Browser |User Presence (touch) |Resident Key / Discoverable Credential |User Verification (PIN / Biometric) |CTAP 1 /
 U2F Legacy Support
-.2+|*Safari 14* |Lightning  a|image::group-4.png[] a|image::group-4.png[] a|image::group-copy-5.png[] a|image::group-4.png[]
-^.^|NFC a|image::group-4.png[] a|image::group-4.png[] a|image::group-copy-5.png[] a|image::group-4.png[]
+.2+|*Safari 14* |Lightning  a|image::group-4.png[] a|image::group-4.png[] a|image::group-4.png[] a|image::group-4.png[]
+^.^|NFC a|image::group-4.png[] a|image::group-4.png[] a|image::group-4.png[] a|image::group-4.png[]
 .2+|*Chrome 85* |Lightning  a|image::group-copy-5.png[] a|image::group-copy-5.png[] a|image::group-copy-5.png[] a|image::group-copy-5.png[]
 ^.^|NFC a|image::group-copy-5.png[] a|image::group-copy-5.png[] a|image::group-copy-5.png[] a|image::group-copy-5.png[]
 .2+|*Firefox 81* |Lightning  a|image::group-copy-5.png[] a|image::group-copy-5.png[] a|image::group-copy-5.png[] a|image::group-copy-5.png[]
@@ -82,7 +82,7 @@ NFC tests have been excluded since NFC is not supported on iPadOS browsers.
 |===
 2+|Browser |User Presence (touch) |Resident Key / Discoverable Credential |User Verification (PIN / Biometric) |CTAP 1 /
 U2F Legacy Support
-.2+|*Safari 14* |Lightning  a|image::group-4.png[] a|image::group-4.png[] a|image::group-copy-5.png[] a|image::group-4.png[]
+.2+|*Safari 14* |Lightning  a|image::group-4.png[] a|image::group-4.png[] a|image::group-4.png[] a|image::group-4.png[]
 ^.^|NFC a|N/A a|N/A a|N/A a|N/A
 .2+|*Chrome 85* |Lightning  a|image::group-copy-5.png[] a|image::group-copy-5.png[] a|image::group-copy-5.png[] a|image::group-copy-5.png[]
 ^.^|NFC a|N/A a|N/A a|N/A a|N/A


### PR DESCRIPTION
1. Updated Security Key Compatibility to reflect iOS 14 and YubiKey 5C NFC - ([public doc](https://developers.yubico.com/WebAuthn/Supporting_U2F_or_FIDO2_Security_Keys_on_iOS_or_iPadOS/Security_Key_Compatibility.html))

2. Updated the Known Issues to reflect latest supporting features on iOS 14.x ([Public doc](https://developers.yubico.com/WebAuthn/Supporting_U2F_or_FIDO2_Security_Keys_on_iOS_or_iPadOS/Known_Issues.html))

3. Updated WebAuthn Browser Compatibility to reflect supporting iOS 14.x features ([Public doc](https://developers.yubico.com/WebAuthn/WebAuthn_Browser_Support/))