### PR TITLE
Fix redirects for renamed yubico-piv-tool binaries

### DIFF
--- a/content/projects/yubico-piv-tool/.htaccess
+++ b/content/projects/yubico-piv-tool/.htaccess
@@ -10,5 +10,5 @@ RewriteRule ^OS_X_code_signing.html$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/PIV/Gui
 RewriteRule ^SSH_User_certificates.html$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/PIV/Guides/SSH_user_certificates.html [L,R=301]
 RewriteRule ^SSH_with_PIV_and_PKCS11.html$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/PIV/Guides/SSH_with_PIV_and_PKCS11.html [L,R=301]
 RewriteRule ^Android_code_signing.html$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/PIV/Guides/Android_code_signing.html [L,R=301]
-RewriteRule ^yubico-piv-tool-2.2.0-mac.pkg$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/yubico-piv-tool/Releases/yubico-piv-tool-2.2.0-mac-amd64.pkg [L,R=301]
-RewriteRule ^yubico-piv-tool-2.2.0-mac.pkg.sig$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/yubico-piv-tool/Releases/yubico-piv-tool-2.2.0-mac-amd64.pkg.sig [L,R=301]
+RewriteRule ^Releases/yubico-piv-tool-2.2.0-mac.pkg$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/yubico-piv-tool/Releases/yubico-piv-tool-2.2.0-mac-amd64.pkg [L,R=301]
+RewriteRule ^Releases/yubico-piv-tool-2.2.0-mac.pkg.sig$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/yubico-piv-tool/Releases/yubico-piv-tool-2.2.0-mac-amd64.pkg.sig [L,R=301]


### PR DESCRIPTION
Add missing Releases/ directory.