### PR TITLE
libfido2: sync docs with 1.8.0

### DIFF
--- a/content/projects/libfido2/Manuals/fido2-assert.partial
+++ b/content/projects/libfido2/Manuals/fido2-assert.partial
@@ -115,8 +115,8 @@ The options are as follows:
       <code class="Fl" title="Fl">-r</code> is specified,
       <code class="Nm" title="Nm">fido2-assert</code> will not expect a
       credential id in its input, and may output multiple assertions. Resident
-      credentials are called &#x201C;discoverable credentials&#x201D; in
-      FIDO2.1.</dd>
+      credentials are called &#x201C;discoverable credentials&#x201D; in FIDO
+      2.1.</dd>
   <dt><a class="permalink" href="#t"><code class="Fl" title="Fl" id="t">-t</code></a>
     <var class="Ar" title="Ar">option</var></dt>
   <dd>Toggles a key/value <var class="Ar" title="Ar">option</var>, where

--- a/content/projects/libfido2/Manuals/fido2-cred.partial
+++ b/content/projects/libfido2/Manuals/fido2-cred.partial
@@ -130,7 +130,7 @@ The options are as follows:
       <code class="Nm" title="Nm">fido2-cred</code> will fail.</dd>
   <dt><a class="permalink" href="#r"><code class="Fl" title="Fl" id="r">-r</code></a></dt>
   <dd>Create a resident credential. Resident credentials are called
-      &#x201C;discoverable credentials&#x201D; in FIDO2.1.</dd>
+      &#x201C;discoverable credentials&#x201D; in FIDO 2.1.</dd>
   <dt><a class="permalink" href="#u"><code class="Fl" title="Fl" id="u">-u</code></a></dt>
   <dd>Create a U2F credential. By default,
       <code class="Nm" title="Nm">fido2-cred</code> will use FIDO2 if supported

--- a/content/projects/libfido2/Manuals/fido2-token.partial
+++ b/content/projects/libfido2/Manuals/fido2-token.partial
@@ -85,6 +85,16 @@
 <table class="Nm">
   <tr>
     <td><code class="Nm" title="Nm">fido2-token</code></td>
+    <td><code class="Fl" title="Fl">-D</code>
+      <code class="Fl" title="Fl">-u</code>
+      [<div class="Op"><code class="Fl" title="Fl">-d</code></div>]
+      <var class="Ar" title="Ar">device</var></td>
+  </tr>
+</table>
+<br/>
+<table class="Nm">
+  <tr>
+    <td><code class="Nm" title="Nm">fido2-token</code></td>
     <td><code class="Fl" title="Fl">-G</code>
       <code class="Fl" title="Fl">-b</code>
       [<div class="Op"><code class="Fl" title="Fl">-d</code></div>]
@@ -147,7 +157,7 @@
   <tr>
     <td><code class="Nm" title="Nm">fido2-token</code></td>
     <td><code class="Fl" title="Fl">-S</code>
-      [<div class="Op"><code class="Fl" title="Fl">-adeu</code></div>]
+      [<div class="Op"><code class="Fl" title="Fl">-adefu</code></div>]
       <var class="Ar" title="Ar">device</var></td>
   </tr>
 </table>
@@ -199,6 +209,24 @@
       [<div class="Op"><code class="Fl" title="Fl">-i</code>
       <var class="Ar" title="Ar">cred_id</var></div>]
       <var class="Ar" title="Ar">blob_path</var>
+      <var class="Ar" title="Ar">device</var></td>
+  </tr>
+</table>
+<br/>
+<table class="Nm">
+  <tr>
+    <td><code class="Nm" title="Nm">fido2-token</code></td>
+    <td><code class="Fl" title="Fl">-S</code>
+      <code class="Fl" title="Fl">-c</code>
+      [<div class="Op"><code class="Fl" title="Fl">-d</code></div>]
+      <code class="Fl" title="Fl">-i</code>
+      <var class="Ar" title="Ar">cred_id</var>
+      <code class="Fl" title="Fl">-k</code>
+      <var class="Ar" title="Ar">user_id</var>
+      <code class="Fl" title="Fl">-n</code>
+      <var class="Ar" title="Ar">name</var>
+      <code class="Fl" title="Fl">-p</code>
+      <var class="Ar" title="Ar">display_name</var>
       <var class="Ar" title="Ar">device</var></td>
   </tr>
 </table>
@@ -385,12 +413,30 @@ The options are as follows:
       <var class="Ar" title="Ar">cred_id</var> is a base64-encoded blob. A PIN
       or equivalent user-verification gesture is required.</dd>
   <dt><a class="permalink" href="#S_5"><code class="Fl" title="Fl" id="S_5">-S</code></a>
+    <code class="Fl" title="Fl">-c</code> <code class="Fl" title="Fl">-i</code>
+    <var class="Ar" title="Ar">cred_id</var>
+    <code class="Fl" title="Fl">-k</code>
+    <var class="Ar" title="Ar">user_id</var>
+    <code class="Fl" title="Fl">-n</code> <var class="Ar" title="Ar">name</var>
+    <code class="Fl" title="Fl">-p</code>
+    <var class="Ar" title="Ar">display_name</var>
+    <var class="Ar" title="Ar">device</var></dt>
+  <dd>Sets the <var class="Ar" title="Ar">name</var> and
+      <var class="Ar" title="Ar">display_name</var> attributes of the resident
+      credential identified by <var class="Ar" title="Ar">cred_id</var> and
+      <var class="Ar" title="Ar">user_id</var>, where
+      <var class="Ar" title="Ar">name</var> and
+      <var class="Ar" title="Ar">display_name</var> are UTF-8 strings and
+      <var class="Ar" title="Ar">cred_id</var> and
+      <var class="Ar" title="Ar">user_id</var> are base64-encoded blobs. A PIN
+      or equivalent user-verification gesture is required.</dd>
+  <dt><a class="permalink" href="#S_6"><code class="Fl" title="Fl" id="S_6">-S</code></a>
     <code class="Fl" title="Fl">-e</code>
     <var class="Ar" title="Ar">device</var></dt>
   <dd>Performs a new biometric enrollment on
       <var class="Ar" title="Ar">device</var>. The user will be prompted for the
       PIN.</dd>
-  <dt><a class="permalink" href="#S_6"><code class="Fl" title="Fl" id="S_6">-S</code></a>
+  <dt><a class="permalink" href="#S_7"><code class="Fl" title="Fl" id="S_7">-S</code></a>
     <code class="Fl" title="Fl">-e</code> <code class="Fl" title="Fl">-i</code>
     <var class="Ar" title="Ar">template_id</var>
     <code class="Fl" title="Fl">-n</code>
@@ -403,19 +449,19 @@ The options are as follows:
       <var class="Ar" title="Ar">template_id</var> is base64-encoded and
       <var class="Ar" title="Ar">template_name</var> is a UTF-8 string. The user
       will be prompted for the PIN.</dd>
-  <dt><a class="permalink" href="#S_7"><code class="Fl" title="Fl" id="S_7">-S</code></a>
+  <dt><a class="permalink" href="#S_8"><code class="Fl" title="Fl" id="S_8">-S</code></a>
     <code class="Fl" title="Fl">-f</code>
     <var class="Ar" title="Ar">device</var></dt>
   <dd>Forces a PIN change on <var class="Ar" title="Ar">device</var>. The user
       will be prompted for the PIN.</dd>
-  <dt><a class="permalink" href="#S_8"><code class="Fl" title="Fl" id="S_8">-S</code></a>
+  <dt><a class="permalink" href="#S_9"><code class="Fl" title="Fl" id="S_9">-S</code></a>
     <code class="Fl" title="Fl">-l</code>
     <var class="Ar" title="Ar">pin_length</var>
     <var class="Ar" title="Ar">device</var></dt>
   <dd>Sets the minimum PIN length of <var class="Ar" title="Ar">device</var> to
       <var class="Ar" title="Ar">pin_length</var>. The user will be prompted for
       the PIN.</dd>
-  <dt><a class="permalink" href="#S_9"><code class="Fl" title="Fl" id="S_9">-S</code></a>
+  <dt><a class="permalink" href="#S_10"><code class="Fl" title="Fl" id="S_10">-S</code></a>
     <code class="Fl" title="Fl">-u</code>
     <var class="Ar" title="Ar">device</var></dt>
   <dd>Enables the FIDO 2.1 &#x201C;user verification always&#x201D; feature on
@@ -445,8 +491,8 @@ The actual user-flow to perform a reset is outside the scope of the FIDO2
 <div class="Pp"></div>
 An authenticator's path may contain spaces.
 <div class="Pp"></div>
-Resident credentials are called &#x201C;discoverable credentials&#x201D; in
-  FIDO2.1.
+Resident credentials are called &#x201C;discoverable credentials&#x201D; in FIDO
+  2.1.
 <div class="Pp"></div>
 Whether the FIDO 2.1 &#x201C;user verification always&#x201D; feature is
   activated or deactivated after an authenticator reset is

--- a/content/projects/libfido2/Manuals/fido_assert_new.partial
+++ b/content/projects/libfido2/Manuals/fido_assert_new.partial
@@ -102,7 +102,8 @@
 <var class="Ft" title="Ft">const unsigned char *</var>
 <br/>
 <code class="Fn" title="Fn">fido_assert_blob_ptr</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
-  fido_assert_t *assert</var>);
+  fido_assert_t *assert</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">size_t idx</var>);
 <div class="Pp"></div>
 <var class="Ft" title="Ft">const unsigned char *</var>
 <br/>
@@ -148,7 +149,8 @@
 <var class="Ft" title="Ft">size_t</var>
 <br/>
 <code class="Fn" title="Fn">fido_assert_blob_len</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
-  fido_assert_t *assert</var>);
+  fido_assert_t *assert</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">size_t idx</var>);
 <div class="Pp"></div>
 <var class="Ft" title="Ft">size_t</var>
 <br/>

--- a/content/projects/libfido2/Manuals/fido_assert_set_authdata.partial
+++ b/content/projects/libfido2/Manuals/fido_assert_set_authdata.partial
@@ -23,6 +23,7 @@
 <h1 class="Sh" title="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
 <code class="Nm" title="Nm">fido_assert_set_authdata</code>,
   <code class="Nm" title="Nm">fido_assert_set_authdata_raw</code>,
+  <code class="Nm" title="Nm">fido_assert_set_clientdata</code>,
   <code class="Nm" title="Nm">fido_assert_set_clientdata_hash</code>,
   <code class="Nm" title="Nm">fido_assert_set_count</code>,
   <code class="Nm" title="Nm">fido_assert_set_extensions</code>,
@@ -60,6 +61,13 @@ typedef enum {
 <code class="Fn" title="Fn">fido_assert_set_authdata_raw</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_assert_t
   *assert</var>, <var class="Fa" title="Fa" style="white-space: nowrap;"> size_t
   idx</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
+  unsigned char *ptr</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">size_t len</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
+<code class="Fn" title="Fn">fido_assert_set_clientdata</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_assert_t
+  *assert</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
   unsigned char *ptr</var>,
   <var class="Fa" title="Fa" style="white-space: nowrap;">size_t len</var>);
 <div class="Pp"></div>
@@ -165,6 +173,15 @@ The <code class="Fn" title="Fn">fido_assert_set_clientdata_hash</code>(),
   <var class="Fa" title="Fa">len</var> bytes. A copy of
   <var class="Fa" title="Fa">ptr</var> is made, and no references to the passed
   pointer are kept.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_assert_set_clientdata</code>() function
+  allows an application to set the client data hash of
+  <var class="Fa" title="Fa">assert</var> by specifying the assertion's unhashed
+  client data. This is required by Windows Hello, which calculates the client
+  data hash internally. For compatibility with Windows Hello, applications
+  should use <code class="Fn" title="Fn">fido_assert_set_clientdata</code>()
+  instead of
+  <code class="Fn" title="Fn">fido_assert_set_clientdata_hash</code>().
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_assert_set_rp</code>() function sets the
   relying party <var class="Fa" title="Fa">id</var> of

--- a/content/projects/libfido2/Manuals/fido_assert_set_clientdata.partial
+++ b/content/projects/libfido2/Manuals/fido_assert_set_clientdata.partial
@@ -1,0 +1,1 @@
+fido_assert_set_authdata.partial

--- a/content/projects/libfido2/Manuals/fido_bio_dev_get_info.partial
+++ b/content/projects/libfido2/Manuals/fido_bio_dev_get_info.partial
@@ -138,7 +138,8 @@ The <code class="Fn" title="Fn">fido_bio_dev_get_template_array</code>()
 The <code class="Fn" title="Fn">fido_bio_dev_set_template_name</code>() function
   sets the friendly name of <var class="Fa" title="Fa">template</var> on
   <var class="Fa" title="Fa">dev</var>.
-<div class="Pp"></div>
+<h1 class="Sh" title="Sh" id="RETURN_VALUES"><a class="permalink" href="#RETURN_VALUES">RETURN
+  VALUES</a></h1>
 The error codes returned by
   <code class="Fn" title="Fn">fido_bio_dev_get_info</code>(),
   <code class="Fn" title="Fn">fido_bio_dev_enroll_begin</code>(),
@@ -154,14 +155,7 @@ The error codes returned by
   ALSO</a></h1>
 <a class="Xr" title="Xr" href="fido_bio_enroll_new.html">fido_bio_enroll_new(3)</a>,
   <a class="Xr" title="Xr" href="fido_bio_info_new.html">fido_bio_info_new(3)</a>,
-  <a class="Xr" title="Xr" href="fido_bio_template.html">fido_bio_template(3)</a>
-<h1 class="Sh" title="Sh" id="CAVEATS"><a class="permalink" href="#CAVEATS">CAVEATS</a></h1>
-Biometric enrollment is a tentative feature of FIDO 2.1. Applications willing to
-  strictly abide by FIDO 2.0 should refrain from using biometric enrollment.
-  Applications using biometric enrollment should ensure it is supported by the
-  authenticator prior to using the API. Since FIDO 2.1 hasn't been finalised,
-  there is a chance the functionality and associated data structures may
-  change.</div>
+  <a class="Xr" title="Xr" href="fido_bio_template.html">fido_bio_template(3)</a></div>
 <table class="foot">
   <tr>
     <td class="foot-date">September 13, 2019</td>

--- a/content/projects/libfido2/Manuals/fido_bio_template.partial
+++ b/content/projects/libfido2/Manuals/fido_bio_template.partial
@@ -165,6 +165,13 @@ The <code class="Fn" title="Fn">fido_bio_template</code>() function returns a
   <var class="Fa" title="Fa">array</var>. Please note that the first template in
   <var class="Fa" title="Fa">array</var> has an
   <var class="Fa" title="Fa">idx</var> (index) value of 0.
+<h1 class="Sh" title="Sh" id="RETURN_VALUES"><a class="permalink" href="#RETURN_VALUES">RETURN
+  VALUES</a></h1>
+The error codes returned by
+  <code class="Fn" title="Fn">fido_bio_template_set_id</code>() and
+  <code class="Fn" title="Fn">fido_bio_template_set_name</code>() are defined in
+  <code class="In" title="In">&lt;<a class="In" title="In">fido/err.h</a>&gt;</code>.
+  On success, <code class="Dv" title="Dv">FIDO_OK</code> is returned.
 <h1 class="Sh" title="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
 <a class="Xr" title="Xr" href="fido_bio_dev_get_info.html">fido_bio_dev_get_info(3)</a>,

--- a/content/projects/libfido2/Manuals/fido_cbor_info_algorithm_cose.partial
+++ b/content/projects/libfido2/Manuals/fido_cbor_info_algorithm_cose.partial
@@ -1,0 +1,1 @@
+fido_cbor_info_new.partial

--- a/content/projects/libfido2/Manuals/fido_cbor_info_algorithm_count.partial
+++ b/content/projects/libfido2/Manuals/fido_cbor_info_algorithm_count.partial
@@ -1,0 +1,1 @@
+fido_cbor_info_new.partial

--- a/content/projects/libfido2/Manuals/fido_cbor_info_algorithm_type.partial
+++ b/content/projects/libfido2/Manuals/fido_cbor_info_algorithm_type.partial
@@ -1,0 +1,1 @@
+fido_cbor_info_new.partial

--- a/content/projects/libfido2/Manuals/fido_cbor_info_new.partial
+++ b/content/projects/libfido2/Manuals/fido_cbor_info_new.partial
@@ -27,12 +27,17 @@
   <code class="Nm" title="Nm">fido_cbor_info_aaguid_ptr</code>,
   <code class="Nm" title="Nm">fido_cbor_info_extensions_ptr</code>,
   <code class="Nm" title="Nm">fido_cbor_info_protocols_ptr</code>,
+  <code class="Nm" title="Nm">fido_cbor_info_transports_ptr</code>,
   <code class="Nm" title="Nm">fido_cbor_info_versions_ptr</code>,
   <code class="Nm" title="Nm">fido_cbor_info_options_name_ptr</code>,
   <code class="Nm" title="Nm">fido_cbor_info_options_value_ptr</code>,
+  <code class="Nm" title="Nm">fido_cbor_info_algorithm_type</code>,
+  <code class="Nm" title="Nm">fido_cbor_info_algorithm_cose</code>,
+  <code class="Nm" title="Nm">fido_cbor_info_algorithm_count</code>,
   <code class="Nm" title="Nm">fido_cbor_info_aaguid_len</code>,
   <code class="Nm" title="Nm">fido_cbor_info_extensions_len</code>,
   <code class="Nm" title="Nm">fido_cbor_info_protocols_len</code>,
+  <code class="Nm" title="Nm">fido_cbor_info_transports_len</code>,
   <code class="Nm" title="Nm">fido_cbor_info_versions_len</code>,
   <code class="Nm" title="Nm">fido_cbor_info_options_len</code>,
   <code class="Nm" title="Nm">fido_cbor_info_maxmsgsiz</code>,
@@ -77,6 +82,11 @@
 <div class="Pp"></div>
 <var class="Ft" title="Ft">char **</var>
 <br/>
+<code class="Fn" title="Fn">fido_cbor_info_transports_ptr</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cbor_info_t *ci</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">char **</var>
+<br/>
 <code class="Fn" title="Fn">fido_cbor_info_versions_ptr</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_cbor_info_t *ci</var>);
 <div class="Pp"></div>
@@ -88,6 +98,23 @@
 <var class="Ft" title="Ft">const bool *</var>
 <br/>
 <code class="Fn" title="Fn">fido_cbor_info_options_value_ptr</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cbor_info_t *ci</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">const char *</var>
+<br/>
+<code class="Fn" title="Fn">fido_cbor_info_algorithm_type</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cbor_info_t *ci</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">size_t idx</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
+<code class="Fn" title="Fn">fido_cbor_info_algorithm_cose</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cbor_info_t *ci</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">size_t idx</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">size_t</var>
+<br/>
+<code class="Fn" title="Fn">fido_cbor_info_algorithm_count</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_cbor_info_t *ci</var>);
 <div class="Pp"></div>
 <var class="Ft" title="Ft">size_t</var>
@@ -103,6 +130,11 @@
 <var class="Ft" title="Ft">size_t</var>
 <br/>
 <code class="Fn" title="Fn">fido_cbor_info_protocols_len</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cbor_info_t *ci</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">size_t</var>
+<br/>
+<code class="Fn" title="Fn">fido_cbor_info_transports_len</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_cbor_info_t *ci</var>);
 <div class="Pp"></div>
 <var class="Ft" title="Ft">size_t</var>
@@ -164,14 +196,17 @@ The <code class="Fn" title="Fn">fido_dev_get_cbor_info</code>() function
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_cbor_info_aaguid_ptr</code>(),
   <code class="Fn" title="Fn">fido_cbor_info_extensions_ptr</code>(),
-  <code class="Fn" title="Fn">fido_cbor_info_protocols_ptr</code>(), and
+  <code class="Fn" title="Fn">fido_cbor_info_protocols_ptr</code>(),
+  <code class="Fn" title="Fn">fido_cbor_info_transports_ptr</code>(), and
   <code class="Fn" title="Fn">fido_cbor_info_versions_ptr</code>() functions
   return pointers to the authenticator attestation GUID, supported extensions,
-  PIN protocol and CTAP version strings of <var class="Fa" title="Fa">ci</var>.
-  The corresponding length of a given attribute can be obtained by
+  PIN protocol, transports, and CTAP version strings of
+  <var class="Fa" title="Fa">ci</var>. The corresponding length of a given
+  attribute can be obtained by
   <code class="Fn" title="Fn">fido_cbor_info_aaguid_len</code>(),
   <code class="Fn" title="Fn">fido_cbor_info_extensions_len</code>(),
-  <code class="Fn" title="Fn">fido_cbor_info_protocols_len</code>(), or
+  <code class="Fn" title="Fn">fido_cbor_info_protocols_len</code>(),
+  <code class="Fn" title="Fn">fido_cbor_info_transports_len</code>(), or
   <code class="Fn" title="Fn">fido_cbor_info_versions_len</code>().
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_cbor_info_options_name_ptr</code>() and
@@ -180,6 +215,19 @@ The <code class="Fn" title="Fn">fido_cbor_info_options_name_ptr</code>() and
   values in <var class="Fa" title="Fa">ci</var>. The length of the options array
   is returned by
   <code class="Fn" title="Fn">fido_cbor_info_options_len</code>().
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_cbor_info_algorithm_count</code>() function
+  returns the number of supported algorithms in
+  <var class="Fa" title="Fa">ci</var>. The
+  <code class="Fn" title="Fn">fido_cbor_info_algorithm_cose</code>() function
+  returns the COSE identifier of algorithm <var class="Fa" title="Fa">idx</var>
+  in <var class="Fa" title="Fa">ci</var>, or 0 if the COSE identifier is unknown
+  or unset. The
+  <code class="Fn" title="Fn">fido_cbor_info_algorithm_type</code>() function
+  returns the type of algorithm <var class="Fa" title="Fa">idx</var> in
+  <var class="Fa" title="Fa">ci</var>, or NULL if the type is unset. Please note
+  that the first algorithm in <var class="Fa" title="Fa">ci</var> has an
+  <var class="Fa" title="Fa">idx</var> (index) value of 0.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_cbor_info_maxmsgsiz</code>() function
   returns the maximum message size attribute of
@@ -208,6 +256,7 @@ A complete example of how to use these functions can be found in the
 The <code class="Fn" title="Fn">fido_cbor_info_aaguid_ptr</code>(),
   <code class="Fn" title="Fn">fido_cbor_info_extensions_ptr</code>(),
   <code class="Fn" title="Fn">fido_cbor_info_protocols_ptr</code>(),
+  <code class="Fn" title="Fn">fido_cbor_info_transports_ptr</code>(),
   <code class="Fn" title="Fn">fido_cbor_info_versions_ptr</code>(),
   <code class="Fn" title="Fn">fido_cbor_info_options_name_ptr</code>(), and
   <code class="Fn" title="Fn">fido_cbor_info_options_value_ptr</code>()

--- a/content/projects/libfido2/Manuals/fido_cbor_info_transports_len.partial
+++ b/content/projects/libfido2/Manuals/fido_cbor_info_transports_len.partial
@@ -1,0 +1,1 @@
+fido_cbor_info_new.partial

--- a/content/projects/libfido2/Manuals/fido_cbor_info_transports_ptr.partial
+++ b/content/projects/libfido2/Manuals/fido_cbor_info_transports_ptr.partial
@@ -1,0 +1,1 @@
+fido_cbor_info_new.partial

--- a/content/projects/libfido2/Manuals/fido_cred_set_authdata.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_set_authdata.partial
@@ -25,6 +25,8 @@
   <code class="Nm" title="Nm">fido_cred_set_authdata_raw</code>,
   <code class="Nm" title="Nm">fido_cred_set_x509</code>,
   <code class="Nm" title="Nm">fido_cred_set_sig</code>,
+  <code class="Nm" title="Nm">fido_cred_set_id</code>,
+  <code class="Nm" title="Nm">fido_cred_set_clientdata</code>,
   <code class="Nm" title="Nm">fido_cred_set_clientdata_hash</code>,
   <code class="Nm" title="Nm">fido_cred_set_rp</code>,
   <code class="Nm" title="Nm">fido_cred_set_user</code>,
@@ -74,6 +76,20 @@ typedef enum {
 <var class="Ft" title="Ft">int</var>
 <br/>
 <code class="Fn" title="Fn">fido_cred_set_sig</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_cred_t
+  *cred</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
+  unsigned char *ptr</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">size_t len</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
+<code class="Fn" title="Fn">fido_cred_set_id</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_cred_t
+  *cred</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
+  unsigned char *ptr</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">size_t len</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
+<code class="Fn" title="Fn">fido_cred_set_clientdata</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_cred_t
   *cred</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
   unsigned char *ptr</var>,
   <var class="Fa" title="Fa" style="white-space: nowrap;">size_t len</var>);
@@ -160,10 +176,11 @@ The <code class="Nm" title="Nm">fido_cred_set_authdata</code> set of functions
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_cred_set_authdata</code>(),
   <code class="Fn" title="Fn">fido_cred_set_x509</code>(),
-  <code class="Fn" title="Fn">fido_cred_set_sig</code>(), and
+  <code class="Fn" title="Fn">fido_cred_set_sig</code>(),
+  <code class="Fn" title="Fn">fido_cred_set_id</code>(), and
   <code class="Fn" title="Fn">fido_cred_set_clientdata_hash</code>() functions
-  set the authenticator data, attestation certificate, signature and client data
-  hash parts of <var class="Fa" title="Fa">cred</var> to
+  set the authenticator data, attestation certificate, signature, id, and client
+  data hash parts of <var class="Fa" title="Fa">cred</var> to
   <var class="Fa" title="Fa">ptr</var>, where
   <var class="Fa" title="Fa">ptr</var> points to
   <var class="Fa" title="Fa">len</var> bytes. A copy of
@@ -174,6 +191,20 @@ The <code class="Fn" title="Fn">fido_cred_set_authdata</code>(),
   <code class="Fn" title="Fn">fido_cred_authdata_ptr</code>(). Alternatively, a
   raw binary blob may be passed to
   <code class="Fn" title="Fn">fido_cred_set_authdata_raw</code>().
+<div class="Pp"></div>
+An application calling
+  <code class="Fn" title="Fn">fido_cred_set_authdata</code>() does not need to
+  call <code class="Fn" title="Fn">fido_cred_set_id</code>(). The latter is
+  meant to be used in contexts where the credential's authenticator data is not
+  available.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_cred_set_clientdata</code>() function
+  allows an application to set the client data hash of
+  <var class="Fa" title="Fa">cred</var> by specifying the credential's unhashed
+  client data. This is required by Windows Hello, which calculates the client
+  data hash internally. For compatibility with Windows Hello, applications
+  should use <code class="Fn" title="Fn">fido_cred_set_clientdata</code>()
+  instead of <code class="Fn" title="Fn">fido_cred_set_clientdata_hash</code>().
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_cred_set_rp</code>() function sets the
   relying party <var class="Fa" title="Fa">id</var> and
@@ -235,11 +266,12 @@ The <code class="Fn" title="Fn">fido_cred_set_rk</code>() and
   authenticator to use its default settings.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_cred_set_fmt</code>() function sets the
-  format of <var class="Fa" title="Fa">cred</var> to
+  attestation format of <var class="Fa" title="Fa">cred</var> to
   <var class="Fa" title="Fa">fmt</var>, where
-  <var class="Fa" title="Fa">fmt</var> must be either
-  <var class="Vt" title="Vt">packed</var> (the format used in FIDO2) or
-  <var class="Vt" title="Vt">fido-u2f</var> (the format used by U2F). A copy of
+  <var class="Fa" title="Fa">fmt</var> must be
+  <var class="Vt" title="Vt">packed</var> (the format used in FIDO2),
+  <var class="Vt" title="Vt">fido-u2f</var> (the format used by U2F), or
+  <var class="Vt" title="Vt">none</var>. A copy of
   <var class="Fa" title="Fa">fmt</var> is made, and no references to the passed
   pointer are kept. Note that not all authenticators support FIDO2 and therefore
   may not be able to generate <var class="Vt" title="Vt">packed</var>.

--- a/content/projects/libfido2/Manuals/fido_cred_set_clientdata.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_set_clientdata.partial
@@ -1,0 +1,1 @@
+fido_cred_set_authdata.partial

--- a/content/projects/libfido2/Manuals/fido_cred_set_id.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_set_id.partial
@@ -1,0 +1,1 @@
+fido_cred_set_authdata.partial

--- a/content/projects/libfido2/Manuals/fido_cred_verify.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_verify.partial
@@ -22,7 +22,8 @@
 <div class="manual-text">
 <h1 class="Sh" title="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
 <code class="Nm" title="Nm">fido_cred_verify</code> &#x2014;
-<div class="Nd" title="Nd">verifies the signature of a FIDO 2 credential</div>
+<div class="Nd" title="Nd">verifies the attestation signature of a FIDO 2
+  credential</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
   &lt;<a class="In" title="In">fido.h</a>&gt;</code>
@@ -33,12 +34,12 @@
   fido_cred_t *cred</var>);
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
 The <code class="Fn" title="Fn">fido_cred_verify</code>() function verifies
-  whether the signature contained in <var class="Fa" title="Fa">cred</var>
-  matches the attributes of the credential. Before using
-  <code class="Fn" title="Fn">fido_cred_verify</code>() in a sensitive context,
-  the reader is strongly encouraged to make herself familiar with the FIDO 2
-  credential attestation process as defined in the Web Authentication (webauthn)
-  standard.
+  whether the attestation signature contained in
+  <var class="Fa" title="Fa">cred</var> matches the attributes of the
+  credential. Before using <code class="Fn" title="Fn">fido_cred_verify</code>()
+  in a sensitive context, the reader is strongly encouraged to make herself
+  familiar with the FIDO 2 credential attestation process as defined in the Web
+  Authentication (webauthn) standard.
 <div class="Pp"></div>
 A brief description follows:
 <div class="Pp"></div>
@@ -64,6 +65,8 @@ The attestation statement formats supported by
 The error codes returned by
   <code class="Fn" title="Fn">fido_cred_verify</code>() are defined in
   <code class="In" title="In">&lt;<a class="In" title="In">fido/err.h</a>&gt;</code>.
+  If <var class="Fa" title="Fa">cred</var> does not contain attestation data,
+  then <code class="Dv" title="Dv">FIDO_ERR_INVALID_ARGUMENT</code> is returned.
   If <var class="Fa" title="Fa">cred</var> passes verification, then
   <code class="Dv" title="Dv">FIDO_OK</code> is returned.
 <h1 class="Sh" title="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE

--- a/content/projects/libfido2/Manuals/fido_credman_metadata_new.partial
+++ b/content/projects/libfido2/Manuals/fido_credman_metadata_new.partial
@@ -38,6 +38,7 @@
   <code class="Nm" title="Nm">fido_credman_rp_id_hash_len</code>,
   <code class="Nm" title="Nm">fido_credman_get_dev_metadata</code>,
   <code class="Nm" title="Nm">fido_credman_get_dev_rk</code>,
+  <code class="Nm" title="Nm">fido_credman_set_dev_rk</code>,
   <code class="Nm" title="Nm">fido_credman_del_dev_rk</code>,
   <code class="Nm" title="Nm">fido_credman_get_dev_rp</code> &#x2014;
 <div class="Nd" title="Nd">FIDO 2 credential management API</div>
@@ -144,12 +145,17 @@
 <div class="Pp"></div>
 <var class="Ft" title="Ft">int</var>
 <br/>
-<code class="Fn" title="Fn">fido_credman_del_dev_rk</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_dev_t
+<code class="Fn" title="Fn">fido_credman_set_dev_rk</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_dev_t
   *dev</var>,
-  <var class="Fa" title="Fa" style="white-space: nowrap;">const</var>,
-  <var class="Fa" title="Fa" style="white-space: nowrap;">unsigned</var>,
-  <var class="Fa" title="Fa" style="white-space: nowrap;">char</var>,
-  <var class="Fa" title="Fa" style="white-space: nowrap;">*cred_id&quot;</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">fido_cred_t
+  *cred</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
+  char *pin</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
+<code class="Fn" title="Fn">fido_credman_del_dev_rk</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_dev_t
+  *dev</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
+  unsigned char *cred_id</var>,
   <var class="Fa" title="Fa" style="white-space: nowrap;">size_t
   cred_id_len</var>,
   <var class="Fa" title="Fa" style="white-space: nowrap;">const char
@@ -164,10 +170,10 @@
   *pin</var>);
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
 The credential management API of <i class="Em" title="Em">libfido2</i> allows
-  resident credentials on a FIDO2 authenticator to be listed, inspected, and
-  removed. Please note that not all FIDO2 authenticators support credential
-  management. To obtain information on what an authenticator supports, please
-  refer to
+  resident credentials on a FIDO2 authenticator to be listed, inspected,
+  modified, and removed. Please note that not all FIDO2 authenticators support
+  credential management. To obtain information on what an authenticator
+  supports, please refer to
   <a class="Xr" title="Xr" href="fido_cbor_info_new.html">fido_cbor_info_new(3)</a>.
 <div class="Pp"></div>
 The <var class="Vt" title="Vt">fido_credman_metadata_t</var> type abstracts
@@ -230,6 +236,16 @@ The <code class="Fn" title="Fn">fido_credman_rk_count</code>() function returns
   <var class="Fa" title="Fa">rk</var> has an
   <var class="Fa" title="Fa">idx</var> (index) value of 0.
 <div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_credman_set_dev_rk</code>() function
+  updates the credential pointed to by <var class="Fa" title="Fa">cred</var> in
+  <var class="Fa" title="Fa">dev</var>. The credential id and user id attributes
+  of <var class="Fa" title="Fa">cred</var> must be set. See
+  <a class="Xr" title="Xr" href="fido_cred_set_id.html">fido_cred_set_id(3)</a>
+  and
+  <a class="Xr" title="Xr" href="fido_cred_set_user.html">fido_cred_set_user(3)</a>
+  for details. Only a credential's user attributes (name, display name) may be
+  updated at this time.
+<div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_credman_del_dev_rk</code>() function
   deletes the resident credential identified by
   <var class="Fa" title="Fa">cred_id</var> from
@@ -283,6 +299,7 @@ The <code class="Fn" title="Fn">fido_credman_rp_id_hash_ptr</code>() function
   VALUES</a></h1>
 The <code class="Fn" title="Fn">fido_credman_get_dev_metadata</code>(),
   <code class="Fn" title="Fn">fido_credman_get_dev_rk</code>(),
+  <code class="Fn" title="Fn">fido_credman_set_dev_rk</code>(),
   <code class="Fn" title="Fn">fido_credman_del_dev_rk</code>(), and
   <code class="Fn" title="Fn">fido_credman_get_dev_rp</code>() functions return
   <code class="Dv" title="Dv">FIDO_OK</code> on success. On error, a different
@@ -293,16 +310,11 @@ The <code class="Fn" title="Fn">fido_credman_get_dev_metadata</code>(),
 <h1 class="Sh" title="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
 <a class="Xr" title="Xr" href="fido_cbor_info_new.html">fido_cbor_info_new(3)</a>,
-  <a class="Xr" title="Xr" href="fido_cred_new.html">fido_cred_new(3)</a>
+  <a class="Xr" title="Xr" href="fido_cred_new.html">fido_cred_new(3)</a>,
+  <a class="Xr" title="Xr" href="fido_dev_supports_credman.html">fido_dev_supports_credman(3)</a>
 <h1 class="Sh" title="Sh" id="CAVEATS"><a class="permalink" href="#CAVEATS">CAVEATS</a></h1>
-Credential management is a tentative feature of FIDO 2.1. Applications willing
-  to strictly abide by FIDO 2.0 should refrain from using credential management.
-  Applications using credential management should ensure it is supported by the
-  authenticator prior to using the API. Since FIDO 2.1 hasn't been finalised,
-  there is a chance the functionality and associated data structures may change.
-<div class="Pp"></div>
-Resident credentials are called &#x201C;discoverable credentials&#x201D; in
-  FIDO2.1.</div>
+Resident credentials are called &#x201C;discoverable credentials&#x201D; in FIDO
+  2.1.</div>
 <table class="foot">
   <tr>
     <td class="foot-date">June 28, 2019</td>

--- a/content/projects/libfido2/Manuals/fido_credman_set_dev_rk.partial
+++ b/content/projects/libfido2/Manuals/fido_credman_set_dev_rk.partial
@@ -1,0 +1,1 @@
+fido_credman_metadata_new.partial

--- a/content/projects/libfido2/Manuals/fido_dev_enable_entattest.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_enable_entattest.partial
@@ -93,17 +93,19 @@ Configuration settings are reflected in the payload returned by the
   authenticator in response to a
   <a class="Xr" title="Xr" href="fido_dev_get_cbor_info.html">fido_dev_get_cbor_info(3)</a>
   call.
+<h1 class="Sh" title="Sh" id="RETURN_VALUES"><a class="permalink" href="#RETURN_VALUES">RETURN
+  VALUES</a></h1>
+The error codes returned by
+  <code class="Fn" title="Fn">fido_dev_enable_entattest</code>(),
+  <code class="Fn" title="Fn">fido_dev_toggle_always_uv</code>(),
+  <code class="Fn" title="Fn">fido_dev_force_pin_change</code>(), and
+  <code class="Fn" title="Fn">fido_dev_set_pin_minlen</code>() are defined in
+  <code class="In" title="In">&lt;<a class="In" title="In">fido/err.h</a>&gt;</code>.
+  On success, <code class="Dv" title="Dv">FIDO_OK</code> is returned.
 <h1 class="Sh" title="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
 <a class="Xr" title="Xr" href="fido_dev_get_cbor_info.html">fido_dev_get_cbor_info(3)</a>,
-  <a class="Xr" title="Xr" href="fido_dev_reset.html">fido_dev_reset(3)</a>
-<h1 class="Sh" title="Sh" id="CAVEATS"><a class="permalink" href="#CAVEATS">CAVEATS</a></h1>
-Authenticator configuration is a tentative feature of FIDO 2.1. Applications
-  willing to strictly abide by FIDO 2.0 should refrain from using authenticator
-  configuration. Applications using authenticator configuration should ensure
-  the feature is supported by the authenticator prior to using the corresponding
-  API. Since FIDO 2.1 hasn't been finalised, there is a chance the functionality
-  and associated data structures may change.</div>
+  <a class="Xr" title="Xr" href="fido_dev_reset.html">fido_dev_reset(3)</a></div>
 <table class="foot">
   <tr>
     <td class="foot-date">September 22, 2020</td>

--- a/content/projects/libfido2/Manuals/fido_dev_is_winhello.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_is_winhello.partial
@@ -1,0 +1,1 @@
+fido_dev_open.partial

--- a/content/projects/libfido2/Manuals/fido_dev_open.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_open.partial
@@ -29,6 +29,7 @@
   <code class="Nm" title="Nm">fido_dev_force_fido2</code>,
   <code class="Nm" title="Nm">fido_dev_force_u2f</code>,
   <code class="Nm" title="Nm">fido_dev_is_fido2</code>,
+  <code class="Nm" title="Nm">fido_dev_is_winhello</code>,
   <code class="Nm" title="Nm">fido_dev_supports_credman</code>,
   <code class="Nm" title="Nm">fido_dev_supports_cred_prot</code>,
   <code class="Nm" title="Nm">fido_dev_supports_pin</code>,
@@ -83,6 +84,11 @@
 <var class="Ft" title="Ft">bool</var>
 <br/>
 <code class="Fn" title="Fn">fido_dev_is_fido2</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_dev_t *dev</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">bool</var>
+<br/>
+<code class="Fn" title="Fn">fido_dev_is_winhello</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_dev_t *dev</var>);
 <div class="Pp"></div>
 <var class="Ft" title="Ft">bool</var>
@@ -181,6 +187,10 @@ The <code class="Fn" title="Fn">fido_dev_force_u2f</code>() function can be used
 The <code class="Fn" title="Fn">fido_dev_is_fido2</code>() function returns
   <code class="Dv" title="Dv">true</code> if
   <var class="Fa" title="Fa">dev</var> is a FIDO 2 device.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_dev_is_winhello</code>() function returns
+  <code class="Dv" title="Dv">true</code> if
+  <var class="Fa" title="Fa">dev</var> is a Windows Hello device.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_dev_supports_credman</code>() function
   returns <code class="Dv" title="Dv">true</code> if


### PR DESCRIPTION
- new -Sc (set/update credential) option to fido2-token;
- add fido2-token -Du (disable always uv) to synopsis;
- new API calls:
  * fido_assert_set_clientdata(3);
  * fido_cbor_info_algorithm_cose(3);
  * fido_cbor_info_algorithm_count(3);
  * fido_cbor_info_algorithm_type(3);
  * fido_cbor_info_transports_len(3);
  * fido_cbor_info_transports_ptr(3);
  * fido_cred_set_clientdata(3);
  * fido_cred_set_id(3);
  * fido_credman_set_dev_rk(3);
  * fido_dev_is_winhello(3).
- mention support of attestation format 'none';
- consistency fixes;
- drop fido 2.1 blurb.