### PR TITLE
Revert "Bump pygments from 2.2.0 to 2.7.4"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 jinja2 == 2.11.3
 beautifulsoup4 == 4.9.3
-pygments == 2.7.4
+pygments == 2.5.2
 pyfeed-0.7.4.tar.gz
 xe-0.7.4.tar.gz


### PR DESCRIPTION
Reverts Yubico/developers.yubico.com#362

Change to 2.7.4 version is breaking some project page workflows.