### PR TITLE
Make javadoc module support changing sets of module names

### DIFF
--- a/content/projects/java-webauthn-server/.conf.json
+++ b/content/projects/java-webauthn-server/.conf.json
@@ -23,7 +23,11 @@
   "javadoc": {
     "groupId": "com.yubico",
     "artifactId": "webauthn-server-core",
-    "artifactIds": ["webauthn-server-attestation", "webauthn-server-core"],
+    "artifactIds": ["webauthn-server-attestation", "webauthn-server-core", "webauthn-server-core-minimal"],
+    "artifactIdVersions": {
+      "<1.8.0": ["webauthn-server-attestation", "webauthn-server-core"],
+      ">=1.8.0": ["webauthn-server-attestation", "webauthn-server-core-minimal"]
+    },
     "all_versions": true
   }
 }

--- a/content/projects/yubikit-android/.conf.json
+++ b/content/projects/yubikit-android/.conf.json
@@ -28,7 +28,7 @@
   "javadoc": {
     "groupId": "com.yubico.yubikit",
     "artifactId": "android",
-    "artifactIds": ["core", "android", "management", "oath", "piv", "yubiotp"],
+    "artifactIds": ["core", "android", "management", "oath", "piv", "yubiotp", "yubikit", "mgmt", "otp", "fido"],
     "all_versions": true
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 jinja2 == 2.11.3
 beautifulsoup4 == 4.9.3
 pygments == 2.5.2
+semver == 2.13.0
 pyfeed-0.7.4.tar.gz
 xe-0.7.4.tar.gz


### PR DESCRIPTION
Some of the JavaDoc links at https://developers.yubico.com/java-webauthn-server/JavaDoc/ are broken since version 1.8.0, because we split the `webauthn-server-core` module and moved the JavaDocs to `webauthn-server-core-minimal`. A simple solution to this would be to just add the new module name to the list of `artifactIds`, but that would leave broken links to the nonexistent JavaDocs for `webauthn-server-core`. These changes add the option to specify different module names per version. `yubikit-android` had a similar issue and can also benefit from this.