### PR TITLE
Use mod_rewrite to add trailing slash for dirs

### DIFF
--- a/httpd.conf
+++ b/httpd.conf
@@ -29,6 +29,10 @@ LoadModule setenvif_module modules/mod_setenvif.so
 SetEnvIf Request_URI "^.*" REQUEST_PROTO=https
 SetEnvIf X-Forwarded-Proto "^http$" REQUEST_PROTO=http
 
+RewriteEngine On
+RewriteCond %{LA-U:REQUEST_FILENAME} -d
+RewriteRule ^/(.*[^/])$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/$1/ [R=301,L,QSA]
+
 ErrorLog /dev/stderr
 LogLevel warn
 


### PR DESCRIPTION
This is needed since mod_rewrite is executed before mod_dir

If we leave this to mod_dir's DirectorySlash-directive (default on) the
redirect will use the protocol the request came in on, which will be
http since we terminate SSL in the layer above.

By doing the redirect with a RewriteRule we can include our HTTP/HTTPS
handling logic in these redirects aswell.