### PR TITLE
libfido2: sync docs with 1.9.0

### DIFF
--- a/content/projects/libfido2/Manuals/es256_pk_from_EVP_PKEY.partial
+++ b/content/projects/libfido2/Manuals/es256_pk_from_EVP_PKEY.partial
@@ -1,0 +1,1 @@
+es256_pk_new.partial

--- a/content/projects/libfido2/Manuals/es256_pk_new.partial
+++ b/content/projects/libfido2/Manuals/es256_pk_new.partial
@@ -24,6 +24,7 @@
 <code class="Nm" title="Nm">es256_pk_new</code>,
   <code class="Nm" title="Nm">es256_pk_free</code>,
   <code class="Nm" title="Nm">es256_pk_from_EC_KEY</code>,
+  <code class="Nm" title="Nm">es256_pk_from_EVP_KEY</code>,
   <code class="Nm" title="Nm">es256_pk_from_ptr</code>,
   <code class="Nm" title="Nm">es256_pk_to_EVP_PKEY</code> &#x2014;
 <div class="Nd" title="Nd">FIDO 2 COSE ES256 API</div>
@@ -48,6 +49,12 @@
 <code class="Fn" title="Fn">es256_pk_from_EC_KEY</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">es256_pk_t
   *pk</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
   EC_KEY *ec</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
+<code class="Fn" title="Fn">es256_pk_from_EVP_PKEY</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">es256_pk_t
+  *pk</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
+  EVP_PKEY *pkey</var>);
 <div class="Pp"></div>
 <var class="Ft" title="Ft">int</var>
 <br/>
@@ -89,6 +96,11 @@ The <code class="Fn" title="Fn">es256_pk_from_EC_KEY</code>() function fills
   <var class="Fa" title="Fa">ec</var>. No references to
   <var class="Fa" title="Fa">ec</var> are kept.
 <div class="Pp"></div>
+The <code class="Fn" title="Fn">es256_pk_from_EVP_KEY</code>() function fills
+  <var class="Fa" title="Fa">pk</var> with the contents of
+  <var class="Fa" title="Fa">pkey</var>. No references to
+  <var class="Fa" title="Fa">pkey</var> are kept.
+<div class="Pp"></div>
 The <code class="Fn" title="Fn">es256_pk_from_ptr</code>() function fills
   <var class="Fa" title="Fa">pk</var> with the contents of
   <var class="Fa" title="Fa">ptr</var>, where
@@ -105,7 +117,8 @@ The <code class="Fn" title="Fn">es256_pk_to_EVP_PKEY</code>() function converts
   <code class="Fn" title="Fn">es256_pk_to_EVP_PKEY</code>() returns NULL.
 <h1 class="Sh" title="Sh" id="RETURN_VALUES"><a class="permalink" href="#RETURN_VALUES">RETURN
   VALUES</a></h1>
-The <code class="Fn" title="Fn">es256_pk_from_EC_KEY</code>() and
+The <code class="Fn" title="Fn">es256_pk_from_EC_KEY</code>(),
+  <code class="Fn" title="Fn">es256_pk_from_EVP_KEY</code>(), and
   <code class="Fn" title="Fn">es256_pk_from_ptr</code>() functions return
   <code class="Dv" title="Dv">FIDO_OK</code> on success. On error, a different
   error code defined in

--- a/content/projects/libfido2/Manuals/fido2-token.partial
+++ b/content/projects/libfido2/Manuals/fido2-token.partial
@@ -170,7 +170,8 @@
       <code class="Fl" title="Fl">-i</code>
       <var class="Ar" title="Ar">template_id</var>
       <code class="Fl" title="Fl">-n</code>
-      <var class="Ar" title="Ar">template_name</var></td>
+      <var class="Ar" title="Ar">template_name</var>
+      <var class="Ar" title="Ar">device</var></td>
   </tr>
 </table>
 <br/>
@@ -227,6 +228,16 @@
       <var class="Ar" title="Ar">name</var>
       <code class="Fl" title="Fl">-p</code>
       <var class="Ar" title="Ar">display_name</var>
+      <var class="Ar" title="Ar">device</var></td>
+  </tr>
+</table>
+<br/>
+<table class="Nm">
+  <tr>
+    <td><code class="Nm" title="Nm">fido2-token</code></td>
+    <td><code class="Fl" title="Fl">-S</code>
+      <code class="Fl" title="Fl">-m</code>
+      <var class="Ar" title="Ar">rp_id</var>
       <var class="Ar" title="Ar">device</var></td>
   </tr>
 </table>
@@ -462,6 +473,13 @@ The options are as follows:
       <var class="Ar" title="Ar">pin_length</var>. The user will be prompted for
       the PIN.</dd>
   <dt><a class="permalink" href="#S_10"><code class="Fl" title="Fl" id="S_10">-S</code></a>
+    <code class="Fl" title="Fl">-m</code> <var class="Ar" title="Ar">rp_id</var>
+    <var class="Ar" title="Ar">device</var></dt>
+  <dd>Sets the list of relying party IDs that are allowed to retrieve the
+      minimum PIN length of <var class="Ar" title="Ar">device</var>. Multiple
+      IDs may be specified, separated by commas. The user will be prompted for
+      the PIN.</dd>
+  <dt><a class="permalink" href="#S_11"><code class="Fl" title="Fl" id="S_11">-S</code></a>
     <code class="Fl" title="Fl">-u</code>
     <var class="Ar" title="Ar">device</var></dt>
   <dd>Enables the FIDO 2.1 &#x201C;user verification always&#x201D; feature on

--- a/content/projects/libfido2/Manuals/fido_cred_attstmt_len.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_attstmt_len.partial
@@ -1,0 +1,1 @@
+fido_cred_new.partial

--- a/content/projects/libfido2/Manuals/fido_cred_attstmt_ptr.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_attstmt_ptr.partial
@@ -1,0 +1,1 @@
+fido_cred_new.partial

--- a/content/projects/libfido2/Manuals/fido_cred_new.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_new.partial
@@ -23,6 +23,7 @@
 <h1 class="Sh" title="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
 <code class="Nm" title="Nm">fido_cred_new</code>,
   <code class="Nm" title="Nm">fido_cred_free</code>,
+  <code class="Nm" title="Nm">fido_cred_pin_minlen</code>,
   <code class="Nm" title="Nm">fido_cred_prot</code>,
   <code class="Nm" title="Nm">fido_cred_fmt</code>,
   <code class="Nm" title="Nm">fido_cred_rp_id</code>,
@@ -39,6 +40,7 @@
   <code class="Nm" title="Nm">fido_cred_sig_ptr</code>,
   <code class="Nm" title="Nm">fido_cred_user_id_ptr</code>,
   <code class="Nm" title="Nm">fido_cred_x5c_ptr</code>,
+  <code class="Nm" title="Nm">fido_cred_attstmt_ptr</code>,
   <code class="Nm" title="Nm">fido_cred_authdata_len</code>,
   <code class="Nm" title="Nm">fido_cred_authdata_raw_len</code>,
   <code class="Nm" title="Nm">fido_cred_clientdata_hash_len</code>,
@@ -49,6 +51,7 @@
   <code class="Nm" title="Nm">fido_cred_sig_len</code>,
   <code class="Nm" title="Nm">fido_cred_user_id_len</code>,
   <code class="Nm" title="Nm">fido_cred_x5c_len</code>,
+  <code class="Nm" title="Nm">fido_cred_attstmt_len</code>,
   <code class="Nm" title="Nm">fido_cred_type</code>,
   <code class="Nm" title="Nm">fido_cred_flags</code>,
   <code class="Nm" title="Nm">fido_cred_sigcount</code> &#x2014;
@@ -66,10 +69,15 @@
 <code class="Fn" title="Fn">fido_cred_free</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_cred_t
   **cred_p</var>);
 <div class="Pp"></div>
+<var class="Ft" title="Ft">size_t</var>
+<br/>
+<code class="Fn" title="Fn">fido_cred_pin_minlen</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cred_t *cred</var>);
+<div class="Pp"></div>
 <var class="Ft" title="Ft">int</var>
 <br/>
-<code class="Fn" title="Fn">fido_cred_prot</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_cred_t
-  *cred</var>);
+<code class="Fn" title="Fn">fido_cred_prot</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cred_t *cred</var>);
 <div class="Pp"></div>
 <var class="Ft" title="Ft">const char *</var>
 <br/>
@@ -146,6 +154,11 @@
 <code class="Fn" title="Fn">fido_cred_x5c_ptr</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_cred_t *cred</var>);
 <div class="Pp"></div>
+<var class="Ft" title="Ft">const unsigned char *</var>
+<br/>
+<code class="Fn" title="Fn">fido_cred_attstmt_ptr</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cred_t *cred</var>);
+<div class="Pp"></div>
 <var class="Ft" title="Ft">size_t</var>
 <br/>
 <code class="Fn" title="Fn">fido_cred_authdata_len</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
@@ -196,6 +209,11 @@
 <code class="Fn" title="Fn">fido_cred_x5c_len</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_cred_t *cred</var>);
 <div class="Pp"></div>
+<var class="Ft" title="Ft">size_t</var>
+<br/>
+<code class="Fn" title="Fn">fido_cred_attstmt_len</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cred_t *cred</var>);
+<div class="Pp"></div>
 <var class="Ft" title="Ft">int</var>
 <br/>
 <code class="Fn" title="Fn">fido_cred_type</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
@@ -236,10 +254,22 @@ The <code class="Fn" title="Fn">fido_cred_free</code>() function releases the
   <var class="Fa" title="Fa">*cred_p</var> may be NULL, in which case
   <code class="Fn" title="Fn">fido_cred_free</code>() is a NOP.
 <div class="Pp"></div>
-The <code class="Fn" title="Fn">fido_cred_prot</code>() function returns the
-  protection of <var class="Fa" title="Fa">cred</var>. See
+If the FIDO 2.1 <code class="Dv" title="Dv">FIDO_EXT_MINPINLEN</code> extension
+  is enabled on <var class="Fa" title="Fa">cred</var>, then the
+  <code class="Fn" title="Fn">fido_cred_pin_minlen</code>() function returns the
+  minimum PIN length of <var class="Fa" title="Fa">cred</var>. Otherwise,
+  <code class="Fn" title="Fn">fido_cred_pin_minlen</code>() returns zero. See
+  <a class="Xr" title="Xr" href="fido_cred_set_pin_minlen.html">fido_cred_set_pin_minlen(3)</a>
+  on how to enable this extension.
+<div class="Pp"></div>
+If the FIDO 2.1 <code class="Dv" title="Dv">FIDO_EXT_CRED_PROTECT</code>
+  extension is enabled on <var class="Fa" title="Fa">cred</var>, then the
+  <code class="Fn" title="Fn">fido_cred_prot</code>() function returns the
+  protection of <var class="Fa" title="Fa">cred</var>. Otherwise,
+  <code class="Fn" title="Fn">fido_cred_prot</code>() returns zero. See
   <a class="Xr" title="Xr" href="fido_cred_set_prot.html">fido_cred_set_prot(3)</a>
-  for the values understood by <i class="Em" title="Em">libfido2</i>.
+  for the protection policies understood by
+  <i class="Em" title="Em">libfido2</i>.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_cred_fmt</code>() function returns a
   pointer to a NUL-terminated string containing the format of
@@ -263,11 +293,12 @@ The <code class="Fn" title="Fn">fido_cred_authdata_ptr</code>(),
   <code class="Fn" title="Fn">fido_cred_largeblob_key_ptr</code>(),
   <code class="Fn" title="Fn">fido_cred_pubkey_ptr</code>(),
   <code class="Fn" title="Fn">fido_cred_sig_ptr</code>(),
-  <code class="Fn" title="Fn">fido_cred_user_id_ptr</code>(), and
-  <code class="Fn" title="Fn">fido_cred_x5c_ptr</code>() functions return
+  <code class="Fn" title="Fn">fido_cred_user_id_ptr</code>(),
+  <code class="Fn" title="Fn">fido_cred_x5c_ptr</code>(), and
+  <code class="Fn" title="Fn">fido_cred_attstmt_ptr</code>() functions return
   pointers to the CBOR-encoded and raw authenticator data, client data hash, ID,
   authenticator attestation GUID, &#x201C;largeBlobKey&#x201D;, public key,
-  signature, user ID, and x509 certificate parts of
+  signature, user ID, x509 certificate, and attestation statement parts of
   <var class="Fa" title="Fa">cred</var>, or NULL if the respective entry is not
   set.
 <div class="Pp"></div>
@@ -280,8 +311,9 @@ The corresponding length can be obtained by
   <code class="Fn" title="Fn">fido_cred_largeblob_key_len</code>(),
   <code class="Fn" title="Fn">fido_cred_pubkey_len</code>(),
   <code class="Fn" title="Fn">fido_cred_sig_len</code>(),
-  <code class="Fn" title="Fn">fido_cred_user_id_len</code>(), and
-  <code class="Fn" title="Fn">fido_cred_x5c_len</code>().
+  <code class="Fn" title="Fn">fido_cred_user_id_len</code>(),
+  <code class="Fn" title="Fn">fido_cred_x5c_len</code>(), and
+  <code class="Fn" title="Fn">fido_cred_attstmt_len</code>().
 <div class="Pp"></div>
 The authenticator data, x509 certificate, and signature parts of a credential
   are typically passed to a FIDO 2 server for verification.
@@ -317,6 +349,8 @@ If not NULL, pointers returned by
   ALSO</a></h1>
 <a class="Xr" title="Xr" href="fido_cred_exclude.html">fido_cred_exclude(3)</a>,
   <a class="Xr" title="Xr" href="fido_cred_set_authdata.html">fido_cred_set_authdata(3)</a>,
+  <a class="Xr" title="Xr" href="fido_cred_set_pin_minlen.html">fido_cred_set_pin_minlen(3)</a>,
+  <a class="Xr" title="Xr" href="fido_cred_set_prot.html">fido_cred_set_prot(3)</a>,
   <a class="Xr" title="Xr" href="fido_cred_verify.html">fido_cred_verify(3)</a>,
   <a class="Xr" title="Xr" href="fido_credman_metadata_new.html">fido_credman_metadata_new(3)</a>,
   <a class="Xr" title="Xr" href="fido_dev_largeblob_get.html">fido_dev_largeblob_get(3)</a>,

--- a/content/projects/libfido2/Manuals/fido_cred_pin_minlen.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_pin_minlen.partial
@@ -1,0 +1,1 @@
+fido_cred_new.partial

--- a/content/projects/libfido2/Manuals/fido_cred_set_attstmt.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_set_attstmt.partial
@@ -1,0 +1,1 @@
+fido_cred_set_authdata.partial

--- a/content/projects/libfido2/Manuals/fido_cred_set_authdata.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_set_authdata.partial
@@ -23,6 +23,7 @@
 <h1 class="Sh" title="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
 <code class="Nm" title="Nm">fido_cred_set_authdata</code>,
   <code class="Nm" title="Nm">fido_cred_set_authdata_raw</code>,
+  <code class="Nm" title="Nm">fido_cred_set_attstmt</code>,
   <code class="Nm" title="Nm">fido_cred_set_x509</code>,
   <code class="Nm" title="Nm">fido_cred_set_sig</code>,
   <code class="Nm" title="Nm">fido_cred_set_id</code>,
@@ -32,6 +33,7 @@
   <code class="Nm" title="Nm">fido_cred_set_user</code>,
   <code class="Nm" title="Nm">fido_cred_set_extensions</code>,
   <code class="Nm" title="Nm">fido_cred_set_blob</code>,
+  <code class="Nm" title="Nm">fido_cred_set_pin_minlen</code>,
   <code class="Nm" title="Nm">fido_cred_set_prot</code>,
   <code class="Nm" title="Nm">fido_cred_set_rk</code>,
   <code class="Nm" title="Nm">fido_cred_set_uv</code>,
@@ -62,6 +64,13 @@ typedef enum {
 <var class="Ft" title="Ft">int</var>
 <br/>
 <code class="Fn" title="Fn">fido_cred_set_authdata_raw</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_cred_t
+  *cred</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
+  unsigned char *ptr</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">size_t len</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
+<code class="Fn" title="Fn">fido_cred_set_attstmt</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_cred_t
   *cred</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
   unsigned char *ptr</var>,
   <var class="Fa" title="Fa" style="white-space: nowrap;">size_t len</var>);
@@ -136,6 +145,12 @@ typedef enum {
 <div class="Pp"></div>
 <var class="Ft" title="Ft">int</var>
 <br/>
+<code class="Fn" title="Fn">fido_cred_set_pin_minlen</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_cred_t
+  *cred</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">size_t
+  len</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
 <code class="Fn" title="Fn">fido_cred_set_prot</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_cred_t
   *cred</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">int
   prot</var>);
@@ -175,28 +190,40 @@ The <code class="Nm" title="Nm">fido_cred_set_authdata</code> set of functions
   constituent parts, please refer to the Web Authentication (webauthn) standard.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_cred_set_authdata</code>(),
+  <code class="Fn" title="Fn">fido_cred_set_attstmt</code>(),
   <code class="Fn" title="Fn">fido_cred_set_x509</code>(),
   <code class="Fn" title="Fn">fido_cred_set_sig</code>(),
   <code class="Fn" title="Fn">fido_cred_set_id</code>(), and
   <code class="Fn" title="Fn">fido_cred_set_clientdata_hash</code>() functions
-  set the authenticator data, attestation certificate, signature, id, and client
-  data hash parts of <var class="Fa" title="Fa">cred</var> to
-  <var class="Fa" title="Fa">ptr</var>, where
-  <var class="Fa" title="Fa">ptr</var> points to
+  set the authenticator data, attestation statement, attestation certificate,
+  attestation signature, id, and client data hash parts of
+  <var class="Fa" title="Fa">cred</var> to <var class="Fa" title="Fa">ptr</var>,
+  where <var class="Fa" title="Fa">ptr</var> points to
   <var class="Fa" title="Fa">len</var> bytes. A copy of
   <var class="Fa" title="Fa">ptr</var> is made, and no references to the passed
-  pointer are kept. The authenticator data passed to
+  pointer are kept.
+<div class="Pp"></div>
+The authenticator data passed to
   <code class="Fn" title="Fn">fido_cred_set_authdata</code>() must be a
   CBOR-encoded byte string, as obtained from
   <code class="Fn" title="Fn">fido_cred_authdata_ptr</code>(). Alternatively, a
   raw binary blob may be passed to
-  <code class="Fn" title="Fn">fido_cred_set_authdata_raw</code>().
-<div class="Pp"></div>
-An application calling
+  <code class="Fn" title="Fn">fido_cred_set_authdata_raw</code>(). An
+  application calling
   <code class="Fn" title="Fn">fido_cred_set_authdata</code>() does not need to
   call <code class="Fn" title="Fn">fido_cred_set_id</code>(). The latter is
   meant to be used in contexts where the credential's authenticator data is not
   available.
+<div class="Pp"></div>
+The attestation statement passed to
+  <code class="Fn" title="Fn">fido_cred_set_attstmt</code>() must be a
+  CBOR-encoded map, as obtained from
+  <code class="Fn" title="Fn">fido_cred_attstmt_ptr</code>(). An application
+  calling <code class="Fn" title="Fn">fido_cred_set_attstmt</code>() does not
+  need to call <code class="Fn" title="Fn">fido_cred_set_x509</code>() or
+  <code class="Fn" title="Fn">fido_cred_set_sig</code>(). The latter two are
+  meant to be used in contexts where the credential's complete attestation
+  statement is not available or required.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_cred_set_clientdata</code>() function
   allows an application to set the client data hash of
@@ -237,7 +264,8 @@ The <code class="Fn" title="Fn">fido_cred_set_extensions</code>() function sets
   <var class="Fa" title="Fa">flags</var>. At the moment, only the
   <code class="Dv" title="Dv">FIDO_EXT_CRED_BLOB</code>,
   <code class="Dv" title="Dv">FIDO_EXT_CRED_PROTECT</code>,
-  <code class="Dv" title="Dv">FIDO_EXT_HMAC_SECRET</code>, and
+  <code class="Dv" title="Dv">FIDO_EXT_HMAC_SECRET</code>,
+  <code class="Dv" title="Dv">FIDO_EXT_MINPINLEN</code>, and
   <code class="Dv" title="Dv">FIDO_EXT_LARGEBLOB_KEY</code> extensions are
   supported. If <var class="Fa" title="Fa">flags</var> is zero, the extensions
   of <var class="Fa" title="Fa">cred</var> are cleared.
@@ -248,8 +276,20 @@ The <code class="Fn" title="Fn">fido_cred_set_blob</code>() function sets the
   <var class="Fa" title="Fa">ptr</var>, which must be
   <var class="Fa" title="Fa">len</var> bytes long.
 <div class="Pp"></div>
-The <code class="Fn" title="Fn">fido_cred_set_prot</code>() function sets the
-  protection of <var class="Fa" title="Fa">cred</var> to the scalar
+The <code class="Fn" title="Fn">fido_cred_set_pin_minlen</code>() function
+  enables the FIDO 2.1 <code class="Dv" title="Dv">FIDO_EXT_MINPINLEN</code>
+  extension on <var class="Fa" title="Fa">cred</var> and sets the expected
+  minimum PIN length of <var class="Fa" title="Fa">cred</var> to
+  <var class="Fa" title="Fa">len</var>, where
+  <var class="Fa" title="Fa">len</var> is greater than zero. If
+  <var class="Fa" title="Fa">len</var> is zero, the
+  <code class="Dv" title="Dv">FIDO_EXT_MINPINLEN</code> extension is disabled on
+  <var class="Fa" title="Fa">cred</var>.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_cred_set_prot</code>() function enables the
+  FIDO 2.1 <code class="Dv" title="Dv">FIDO_EXT_CRED_PROTECT</code> extension on
+  <var class="Fa" title="Fa">cred</var> and sets the protection of
+  <var class="Fa" title="Fa">cred</var> to the scalar
   <var class="Fa" title="Fa">prot</var>. At the moment, only the
   <code class="Dv" title="Dv">FIDO_CRED_PROT_UV_OPTIONAL</code>,
   <code class="Dv" title="Dv">FIDO_CRED_PROT_UV_OPTIONAL_WITH_ID</code>, and

--- a/content/projects/libfido2/Manuals/fido_cred_set_pin_minlen.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_set_pin_minlen.partial
@@ -1,0 +1,1 @@
+fido_cred_set_authdata.partial

--- a/content/projects/libfido2/Manuals/fido_cred_verify.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_verify.partial
@@ -44,22 +44,21 @@ The <code class="Fn" title="Fn">fido_cred_verify</code>() function verifies
 A brief description follows:
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_cred_verify</code>() function verifies
-  whether the client data hash, relying party ID, credential ID, type, and
-  resident/discoverable key and user verification attributes of
-  <var class="Fa" title="Fa">cred</var> have been attested by the holder of the
-  private counterpart of the public key contained in the credential's x509
-  certificate.
+  whether the client data hash, relying party ID, credential ID, type,
+  protection policy, minimum PIN length, and resident/discoverable key and user
+  verification attributes of <var class="Fa" title="Fa">cred</var> have been
+  attested by the holder of the private counterpart of the public key contained
+  in the credential's x509 certificate.
 <div class="Pp"></div>
 Please note that the x509 certificate itself is not verified.
 <div class="Pp"></div>
 The attestation statement formats supported by
   <code class="Fn" title="Fn">fido_cred_verify</code>() are
-  <i class="Em" title="Em">packed</i> and <i class="Em" title="Em">fido-u2f</i>.
-  The attestation type implemented by
+  <i class="Em" title="Em">packed</i>, <i class="Em" title="Em">fido-u2f</i>,
+  and <i class="Em" title="Em">tpm</i>. The attestation type implemented by
   <code class="Fn" title="Fn">fido_cred_verify</code>() is
-  <i class="Em" title="Em">Basic Attestation</i>. The attestation key pair is
-  assumed to be of the type ES256. Other attestation formats and types are not
-  supported.
+  <i class="Em" title="Em">Basic Attestation</i>. Other attestation formats and
+  types are not supported.
 <h1 class="Sh" title="Sh" id="RETURN_VALUES"><a class="permalink" href="#RETURN_VALUES">RETURN
   VALUES</a></h1>
 The error codes returned by

--- a/content/projects/libfido2/Manuals/fido_dev_enable_entattest.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_enable_entattest.partial
@@ -24,7 +24,8 @@
 <code class="Nm" title="Nm">fido_dev_enable_entattest</code>,
   <code class="Nm" title="Nm">fido_dev_toggle_always_uv</code>,
   <code class="Nm" title="Nm">fido_dev_force_pin_change</code>,
-  <code class="Nm" title="Nm">fido_dev_set_pin_minlen</code> &#x2014;
+  <code class="Nm" title="Nm">fido_dev_set_pin_minlen</code>,
+  <code class="Nm" title="Nm">fido_dev_set_pin_minlen_rpid</code> &#x2014;
 <div class="Nd" title="Nd">FIDO 2.1 configuration authenticator API</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
@@ -56,6 +57,15 @@
 <code class="Fn" title="Fn">fido_dev_set_pin_minlen</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_dev_t
   *dev</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">size_t
   len</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const char
+  *pin</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
+<code class="Fn" title="Fn">fido_dev_set_pin_minlen_rpid</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_dev_t
+  *dev</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const char
+  * const *rpid</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">size_t n</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">const char
   *pin</var>);
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
 The functions described in this page allow configuration of a FIDO 2.1
@@ -89,6 +99,15 @@ The <code class="Fn" title="Fn">fido_dev_set_pin_minlen</code>() function sets
   <var class="Fa" title="Fa">len</var>. Minimum PIN lengths may only be
   increased.
 <div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_dev_set_pin_minlen_rpid</code>() function
+  sets the list of relying party identifiers (RP IDs) that are allowed to obtain
+  the minimum PIN length of <var class="Fa" title="Fa">dev</var> through the
+  FIDO 2.1 <code class="Dv" title="Dv">FIDO_EXT_MINPINLEN</code> extension. The
+  list of RP identifiers is denoted by <var class="Fa" title="Fa">rpid</var>, a
+  vector of <var class="Fa" title="Fa">n</var> NUL-terminated UTF-8 strings. A
+  copy of <var class="Fa" title="Fa">rpid</var> is made, and no reference to it
+  or its contents is kept.
+<div class="Pp"></div>
 Configuration settings are reflected in the payload returned by the
   authenticator in response to a
   <a class="Xr" title="Xr" href="fido_dev_get_cbor_info.html">fido_dev_get_cbor_info(3)</a>
@@ -98,13 +117,16 @@ Configuration settings are reflected in the payload returned by the
 The error codes returned by
   <code class="Fn" title="Fn">fido_dev_enable_entattest</code>(),
   <code class="Fn" title="Fn">fido_dev_toggle_always_uv</code>(),
-  <code class="Fn" title="Fn">fido_dev_force_pin_change</code>(), and
-  <code class="Fn" title="Fn">fido_dev_set_pin_minlen</code>() are defined in
+  <code class="Fn" title="Fn">fido_dev_force_pin_change</code>(),
+  <code class="Fn" title="Fn">fido_dev_set_pin_minlen</code>(), and
+  <code class="Fn" title="Fn">fido_dev_set_pin_minlen_rpid</code>() are defined
+  in
   <code class="In" title="In">&lt;<a class="In" title="In">fido/err.h</a>&gt;</code>.
   On success, <code class="Dv" title="Dv">FIDO_OK</code> is returned.
 <h1 class="Sh" title="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
-<a class="Xr" title="Xr" href="fido_dev_get_cbor_info.html">fido_dev_get_cbor_info(3)</a>,
+<a class="Xr" title="Xr" href="fido_cred_pin_minlen.html">fido_cred_pin_minlen(3)</a>,
+  <a class="Xr" title="Xr" href="fido_dev_get_cbor_info.html">fido_dev_get_cbor_info(3)</a>,
   <a class="Xr" title="Xr" href="fido_dev_reset.html">fido_dev_reset(3)</a></div>
 <table class="foot">
   <tr>

--- a/content/projects/libfido2/Manuals/fido_dev_info_manifest.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_info_manifest.partial
@@ -124,10 +124,16 @@ The <code class="Fn" title="Fn">fido_dev_info_vendor</code>() function returns
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_dev_info_manufacturer_string</code>()
   function returns the manufacturer string of
-  <var class="Fa" title="Fa">di</var>.
+  <var class="Fa" title="Fa">di</var>. If <var class="Fa" title="Fa">di</var>
+  does not have an associated manufacturer string,
+  <code class="Fn" title="Fn">fido_dev_info_manufacturer_string</code>() returns
+  an empty string.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_dev_info_product_string</code>() function
-  returns the product string of <var class="Fa" title="Fa">di</var>.
+  returns the product string of <var class="Fa" title="Fa">di</var>. If
+  <var class="Fa" title="Fa">di</var> does not have an associated product
+  string, <code class="Fn" title="Fn">fido_dev_info_product_string</code>()
+  returns an empty string.
 <div class="Pp"></div>
 An example of how to use the functions described in this document can be found
   in the <span class="Pa" title="Pa">examples/manifest.c</span> file shipped

--- a/content/projects/libfido2/Manuals/fido_dev_set_io_functions.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_set_io_functions.partial
@@ -22,7 +22,8 @@
 <div class="manual-text">
 <h1 class="Sh" title="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
 <code class="Nm" title="Nm">fido_dev_set_io_functions</code>,
-  <code class="Nm" title="Nm">fido_dev_set_sigmask</code> &#x2014;
+  <code class="Nm" title="Nm">fido_dev_set_sigmask</code>,
+  <code class="Nm" title="Nm">fido_dev_set_timeout</code> &#x2014;
 <div class="Nd" title="Nd">FIDO 2 device I/O interface</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
@@ -61,6 +62,12 @@ typedef sigset_t fido_sigset_t;
 <code class="Fn" title="Fn">fido_dev_set_sigmask</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_dev_t
   *dev</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_sigset_t *sigmask</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
+<code class="Fn" title="Fn">fido_dev_set_timeout</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_dev_t
+  *dev</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">int
+  ms</var>);
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
 The <code class="Fn" title="Fn">fido_dev_set_io_functions</code>() function sets
   the I/O handlers used by <i class="Em" title="Em">libfido2</i> to talk to
@@ -118,10 +125,23 @@ The <code class="Fn" title="Fn">fido_dev_set_sigmask</code>() function may be
 <div class="Pp"></div>
 No references to <var class="Fa" title="Fa">sigmask</var> are held by
   <code class="Fn" title="Fn">fido_dev_set_sigmask</code>().
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_dev_set_timeout</code>() function informs
+  <i class="Em" title="Em">libfido2</i> not to block for more than
+  <var class="Fa" title="Fa">ms</var> milliseconds while communicating with
+  <var class="Fa" title="Fa">dev</var>. If a timeout occurs, the corresponding
+  <i class="Em" title="Em">fido_dev_*</i> function will fail with
+  <code class="Dv" title="Dv">FIDO_ERR_RX</code>. If
+  <var class="Fa" title="Fa">ms</var> is -1, then
+  <i class="Em" title="Em">libfido2</i> may block indefinitely. This is the
+  default behaviour. When using the Windows Hello backend,
+  <var class="Fa" title="Fa">ms</var> is used as a guidance and may be
+  overwritten by the platform.
 <h1 class="Sh" title="Sh" id="RETURN_VALUES"><a class="permalink" href="#RETURN_VALUES">RETURN
   VALUES</a></h1>
-On success, <code class="Fn" title="Fn">fido_dev_set_io_functions</code>() and
-  <code class="Fn" title="Fn">fido_dev_set_sigmask</code>() return
+On success, <code class="Fn" title="Fn">fido_dev_set_io_functions</code>(),
+  <code class="Fn" title="Fn">fido_dev_set_sigmask</code>(), and
+  <code class="Fn" title="Fn">fido_dev_set_timeout</code>() return
   <code class="Dv" title="Dv">FIDO_OK</code>. On error, a different error code
   defined in
   <code class="In" title="In">&lt;<a class="In" title="In">fido/err.h</a>&gt;</code>

--- a/content/projects/libfido2/Manuals/fido_dev_set_pin_minlen_rpid.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_set_pin_minlen_rpid.partial
@@ -1,0 +1,1 @@
+fido_dev_enable_entattest.partial

--- a/content/projects/libfido2/Manuals/fido_dev_set_timeout.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_set_timeout.partial
@@ -1,0 +1,1 @@
+fido_dev_set_io_functions.partial

--- a/content/projects/libfido2/Manuals/rs256_pk_from_EVP_PKEY.partial
+++ b/content/projects/libfido2/Manuals/rs256_pk_from_EVP_PKEY.partial
@@ -1,0 +1,1 @@
+rs256_pk_new.partial

--- a/content/projects/libfido2/Manuals/rs256_pk_new.partial
+++ b/content/projects/libfido2/Manuals/rs256_pk_new.partial
@@ -23,6 +23,7 @@
 <h1 class="Sh" title="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
 <code class="Nm" title="Nm">rs256_pk_new</code>,
   <code class="Nm" title="Nm">rs256_pk_free</code>,
+  <code class="Nm" title="Nm">rs256_pk_from_EVP_PKEY</code>,
   <code class="Nm" title="Nm">rs256_pk_from_RSA</code>,
   <code class="Nm" title="Nm">rs256_pk_from_ptr</code>,
   <code class="Nm" title="Nm">rs256_pk_to_EVP_PKEY</code> &#x2014;
@@ -42,6 +43,12 @@
 <br/>
 <code class="Fn" title="Fn">rs256_pk_free</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">rs256_pk_t
   **pkp</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
+<code class="Fn" title="Fn">rs256_pk_from_EVP_PKEY</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">rs256_pk_t
+  *pk</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
+  EVP_PKEY *pkey</var>);
 <div class="Pp"></div>
 <var class="Ft" title="Ft">int</var>
 <br/>
@@ -84,6 +91,11 @@ The <code class="Fn" title="Fn">rs256_pk_free</code>() function releases the
   may be NULL, in which case <code class="Fn" title="Fn">rs256_pk_free</code>()
   is a NOP.
 <div class="Pp"></div>
+The <code class="Fn" title="Fn">rs256_pk_from_EVP_PKEY</code>() function fills
+  <var class="Fa" title="Fa">pk</var> with the contents of
+  <var class="Fa" title="Fa">pkey</var>. No references to
+  <var class="Fa" title="Fa">pkey</var> are kept.
+<div class="Pp"></div>
 The <code class="Fn" title="Fn">rs256_pk_from_RSA</code>() function fills
   <var class="Fa" title="Fa">pk</var> with the contents of
   <var class="Fa" title="Fa">rsa</var>. No references to
@@ -103,7 +115,8 @@ The <code class="Fn" title="Fn">rs256_pk_to_EVP_PKEY</code>() function converts
   <code class="Fn" title="Fn">rs256_pk_to_EVP_PKEY</code>() returns NULL.
 <h1 class="Sh" title="Sh" id="RETURN_VALUES"><a class="permalink" href="#RETURN_VALUES">RETURN
   VALUES</a></h1>
-The <code class="Fn" title="Fn">rs256_pk_from_RSA</code>() and
+The <code class="Fn" title="Fn">rs256_pk_from_EVP_PKEY</code>(),
+  <code class="Fn" title="Fn">rs256_pk_from_RSA</code>(), and
   <code class="Fn" title="Fn">rs256_pk_from_ptr</code>() functions return
   <code class="Dv" title="Dv">FIDO_OK</code> on success. On error, a different
   error code defined in


### PR DESCRIPTION
- new -Sm (set minPinLength RP list) option to fido2-token;
- new API calls:
  * es256_pk_from_EVP_KEY(3);
  * fido_cred_attstmt_len(3);
  * fido_cred_attstmt_ptr(3);
  * fido_cred_pin_minlen(3);
  * fido_cred_set_attstmt(3);
  * fido_cred_set_pin_minlen(3);
  * fido_dev_set_pin_minlen_rpid(3);
  * fido_dev_set_timeout(3);
  * rs256_pk_from_EVP_PKEY(3).
- mention support of attestation format 'tpm';
- mention 'minPinLength' support;
- consistency fixes.