### PR TITLE
Fix WebAuthn .conf.json syntax

### DIFF
--- a/content/WebAuthn/.conf.json
+++ b/content/WebAuthn/.conf.json
@@ -5,7 +5,7 @@
     "WebAuthn_Browser_Support",
     "Supporting_U2F_or_FIDO2_Security_Keys_on_iOS_or_iPadOS",
     "Concepts",
-    "Libraries",
+    "Libraries"
   ],
   "suggest-edits": {}
 }


### PR DESCRIPTION
https://github.com/Yubico/developers.yubico.com/commit/e122841b0c97d16519d445c1d6d70f28253c5460 broke the [build](https://github.com/Yubico/developers-gitops/runs/4181957488?check_suite_focus=true#step:5:1066)