### PR TITLE
Changes to WebAuthn Starter Kit Pages

### DIFF
--- a/content/Developer_Program/WebAuthn_Starter_Kit/Back-end_System_Design.adoc
+++ b/content/Developer_Program/WebAuthn_Starter_Kit/Back-end_System_Design.adoc
@@ -151,7 +151,7 @@ Cognito, after receiving the registration request from the client, triggers the 
 
 ===== DefineChallenge: ***Returned*** from DefineChallenge
 
-image:back3-define-auth-challenge-v1.png[]
+image:Images/back3-define-auth-challenge-v1.png[]
 
 *Figure 6 - Define Auth Challenge Returned*
 
@@ -176,13 +176,7 @@ The CreateChallenge Lambda function receives the details from the DefineChalleng
 
     ... 
        "challengeName": "CUSTOM_CHALLENGE", 
-       "session": [
-         { 
-           "challengeName": "SRP_A", 
-           "challengeResult": true, 
-           "challengeMetadata": null
-         }
-       ] 
+       "session": [] 
       }, 
       "response": {
         "publicChallengeParameters": null, 
@@ -200,13 +194,7 @@ CreateChallenge returns to Cognito the challenge with the WebAuthn Registration 
 
     ... 
         "challengeName": "CUSTOM_CHALLENGE", 
-        "session": [
-          { 
-              "challengeName": "SRP_A", 
-              "challengeResult": true, 
-              "challengeMetadata": null
-          }
-         ] 
+        "session": [] 
         }, 
         "response": {
           "publicChallengeParameters": { 
@@ -354,11 +342,6 @@ The DefineChallenge, upon receiving the response from the VerifyAuthChallenge, w
     ...
         "session": [
           {
-            "challengeName": "SRP_A",
-            "challengeResult": true,
-            "challengeMetadata": null
-          },
-          {
             "challengeName": "CUSTOM_CHALLENGE",
             "challengeResult": true,
             "challengeMetadata": null
@@ -381,11 +364,6 @@ Finally, DefineChallenge returns a success response and token approval to Cognit
 
     ... 
           "session": [
-            { 
-                "challengeName": "SRP_A", 
-                "challengeResult": true, 
-                "challengeMetadata": null
-             },
              { 
                 "challengeName": "CUSTOM_CHALLENGE", 
                 "challengeResult": true, 
@@ -475,13 +453,7 @@ The CreateChallenge Lambda function receives the details from the DefineChalleng
 
     ... 
         "challengeName": "CUSTOM_CHALLENGE", 
-        "session": [
-              { 
-                "challengeName": "SRP_A", 
-                "challengeResult": true, 
-                "challengeMetadata": null
-               }
-           ] 
+        "session": [] 
         }, 
         "response": {
                "publicChallengeParameters": null, 
@@ -499,13 +471,7 @@ CreateChallenge returns to Cognito the challenge with the WebAuthn Authenticatio
 
     ... 
          "challengeName": "CUSTOM_CHALLENGE", 
-         "session": [
-           { 
-               "challengeName": "SRP_A", 
-               "challengeResult": true, 
-               "challengeMetadata": null
-           }
-        ] 
+         "session": [] 
       }, 
       "response": {
          "publicChallengeParameters": { 
@@ -608,11 +574,6 @@ The DefineChallenge, upon receiving the response from the VerifyAuthChallenge, w
     ...
         "session": [
              { 
-                "challengeName": "SRP_A", 
-                "challengeResult": true, 
-                "challengeMetadata": null
-             },
-             { 
                 "challengeName": "CUSTOM_CHALLENGE", 
                 "challengeResult": true, 
                 "challengeMetadata": null
@@ -635,11 +596,6 @@ Finally, DefineChallenge returns a success response and token approval to Cognit
 
     ... 
         "session": [
-             { 
-                "challengeName": "SRP_A", 
-                "challengeResult": true, 
-                "challengeMetadata": null
-             },
              { 
                 "challengeName": "CUSTOM_CHALLENGE", 
                 "challengeResult": true, 

--- a/content/Developer_Program/WebAuthn_Starter_Kit/WebAuthn_High_Level_Architecture_Overview.adoc
+++ b/content/Developer_Program/WebAuthn_Starter_Kit/WebAuthn_High_Level_Architecture_Overview.adoc
@@ -81,7 +81,7 @@ There are two clients that are used for this architecture: a React component tha
 
 *Note:* The same Lambda functions handle both registration and authentication
 
-image::arch2-registration-flow-v1.png[]
+image::Images/arch2-registration-flow-v1.png[]
 *Figure 2 - Registration Component Flow*
 
 ==== Custom Authentication Flow Component Diagram


### PR DESCRIPTION
Image links contained incomplete URLs (missing "Images/" at the start of their route) - Change has fixed missing images on Back End System Design and High Level Architecture

Changes also made to the JSON example to remove unnecessary mentions of SPR_A in the Back End System Design page - Testing shows that some of these session items don't appear at some stages indicated in the current docs