### PR TITLE
Simplify tr(1) example

### DIFF
--- a/content/OTP/OTPs_Explained.adoc
+++ b/content/OTP/OTPs_Explained.adoc
@@ -35,9 +35,7 @@ The outputed OTP of the YubiKey OTP is provided in the Modhex characterset. The 
 
 This substitution can easily be scripted. For example, in Linux, converting a random 6 hex character string to modhex can be accompished with the command:
 
-`openssl rand -hex 6 | tr a l | tr b n | tr c r | tr d t | tr e u | tr f v | tr 0 c | tr 1 b | tr 2 d | tr 3 e | tr 4 f | tr 5 g | tr 6 h | tr 7 i | tr 8 j | tr 9 k`
-
-*NOTE:* It is essential to perform the letter translations before the number translations to prevent double encoding some of the characters.
+`openssl rand -hex 6 | tr abcdef0123456789 lnrtuvcbdefghijk`
 
 == The Yubico OTP generation algorithm
 The YubiKey OTP generation is made up of the following fields, encrypted with a unique AES-128 bit key. The result is the 32 character modhex string included after the 12 character public ID.


### PR DESCRIPTION
`tr abcdef0123456789 lnrtuvcbdefghijk` worked for GNU tr(1) just as well,
but, for another implementation, it might not. Two tr's seem safe enough.