### PR TITLE
libfido2: sync docs with 1.10.0

### DIFF
--- a/content/projects/libfido2/Manuals/eddsa_pk_from_EVP_PKEY.partial
+++ b/content/projects/libfido2/Manuals/eddsa_pk_from_EVP_PKEY.partial
@@ -1,0 +1,1 @@
+eddsa_pk_new.partial

--- a/content/projects/libfido2/Manuals/eddsa_pk_new.partial
+++ b/content/projects/libfido2/Manuals/eddsa_pk_new.partial
@@ -26,7 +26,7 @@
   <code class="Nm" title="Nm">eddsa_pk_from_EVP_PKEY</code>,
   <code class="Nm" title="Nm">eddsa_pk_from_ptr</code>,
   <code class="Nm" title="Nm">eddsa_pk_to_EVP_PKEY</code> &#x2014;
-<div class="Nd" title="Nd">FIDO 2 COSE EDDSA API</div>
+<div class="Nd" title="Nd">FIDO2 COSE EDDSA API</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
   &lt;<a class="In" title="In">openssl/evp.h</a>&gt;</code>
@@ -103,7 +103,7 @@ The <code class="Fn" title="Fn">eddsa_pk_to_EVP_PKEY</code>() function converts
   <code class="Fn" title="Fn">eddsa_pk_to_EVP_PKEY</code>() returns NULL.
 <h1 class="Sh" title="Sh" id="RETURN_VALUES"><a class="permalink" href="#RETURN_VALUES">RETURN
   VALUES</a></h1>
-The <code class="Fn" title="Fn">eddsa_pk_from_EC_KEY</code>() and
+The <code class="Fn" title="Fn">eddsa_pk_from_EVP_PKEY</code>() and
   <code class="Fn" title="Fn">eddsa_pk_from_ptr</code>() functions return
   <code class="Dv" title="Dv">FIDO_OK</code> on success. On error, a different
   error code defined in

--- a/content/projects/libfido2/Manuals/es256_pk_new.partial
+++ b/content/projects/libfido2/Manuals/es256_pk_new.partial
@@ -24,10 +24,10 @@
 <code class="Nm" title="Nm">es256_pk_new</code>,
   <code class="Nm" title="Nm">es256_pk_free</code>,
   <code class="Nm" title="Nm">es256_pk_from_EC_KEY</code>,
-  <code class="Nm" title="Nm">es256_pk_from_EVP_KEY</code>,
+  <code class="Nm" title="Nm">es256_pk_from_EVP_PKEY</code>,
   <code class="Nm" title="Nm">es256_pk_from_ptr</code>,
   <code class="Nm" title="Nm">es256_pk_to_EVP_PKEY</code> &#x2014;
-<div class="Nd" title="Nd">FIDO 2 COSE ES256 API</div>
+<div class="Nd" title="Nd">FIDO2 COSE ES256 API</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
   &lt;<a class="In" title="In">openssl/ec.h</a>&gt;</code>
@@ -96,7 +96,7 @@ The <code class="Fn" title="Fn">es256_pk_from_EC_KEY</code>() function fills
   <var class="Fa" title="Fa">ec</var>. No references to
   <var class="Fa" title="Fa">ec</var> are kept.
 <div class="Pp"></div>
-The <code class="Fn" title="Fn">es256_pk_from_EVP_KEY</code>() function fills
+The <code class="Fn" title="Fn">es256_pk_from_EVP_PKEY</code>() function fills
   <var class="Fa" title="Fa">pk</var> with the contents of
   <var class="Fa" title="Fa">pkey</var>. No references to
   <var class="Fa" title="Fa">pkey</var> are kept.
@@ -118,7 +118,7 @@ The <code class="Fn" title="Fn">es256_pk_to_EVP_PKEY</code>() function converts
 <h1 class="Sh" title="Sh" id="RETURN_VALUES"><a class="permalink" href="#RETURN_VALUES">RETURN
   VALUES</a></h1>
 The <code class="Fn" title="Fn">es256_pk_from_EC_KEY</code>(),
-  <code class="Fn" title="Fn">es256_pk_from_EVP_KEY</code>(), and
+  <code class="Fn" title="Fn">es256_pk_from_EVP_PKEY</code>(), and
   <code class="Fn" title="Fn">es256_pk_from_ptr</code>() functions return
   <code class="Dv" title="Dv">FIDO_OK</code> on success. On error, a different
   error code defined in

--- a/content/projects/libfido2/Manuals/fido2-assert.partial
+++ b/content/projects/libfido2/Manuals/fido2-assert.partial
@@ -22,7 +22,7 @@
 <div class="manual-text">
 <h1 class="Sh" title="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
 <code class="Nm" title="Nm">fido2-assert</code> &#x2014;
-<div class="Nd" title="Nd">get/verify a FIDO 2 assertion</div>
+<div class="Nd" title="Nd">get/verify a FIDO2 assertion</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <table class="Nm">
   <tr>
@@ -51,7 +51,7 @@
   </tr>
 </table>
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
-<code class="Nm" title="Nm">fido2-assert</code> gets or verifies a FIDO 2
+<code class="Nm" title="Nm">fido2-assert</code> gets or verifies a FIDO2
   assertion.
 <div class="Pp"></div>
 The input of <code class="Nm" title="Nm">fido2-assert</code> is defined by the
@@ -115,7 +115,7 @@ The options are as follows:
       <code class="Fl" title="Fl">-r</code> is specified,
       <code class="Nm" title="Nm">fido2-assert</code> will not expect a
       credential id in its input, and may output multiple assertions. Resident
-      credentials are called &#x201C;discoverable credentials&#x201D; in FIDO
+      credentials are called &#x201C;discoverable credentials&#x201D; in CTAP
       2.1.</dd>
   <dt><a class="permalink" href="#t"><code class="Fl" title="Fl" id="t">-t</code></a>
     <var class="Ar" title="Ar">option</var></dt>

--- a/content/projects/libfido2/Manuals/fido2-cred.partial
+++ b/content/projects/libfido2/Manuals/fido2-cred.partial
@@ -22,7 +22,7 @@
 <div class="manual-text">
 <h1 class="Sh" title="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
 <code class="Nm" title="Nm">fido2-cred</code> &#x2014;
-<div class="Nd" title="Nd">make/verify a FIDO 2 credential</div>
+<div class="Nd" title="Nd">make/verify a FIDO2 credential</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <table class="Nm">
   <tr>
@@ -55,7 +55,7 @@
   </tr>
 </table>
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
-<code class="Nm" title="Nm">fido2-cred</code> makes or verifies a FIDO 2
+<code class="Nm" title="Nm">fido2-cred</code> makes or verifies a FIDO2
   credential.
 <div class="Pp"></div>
 A credential <var class="Ar" title="Ar">type</var> may be
@@ -130,7 +130,7 @@ The options are as follows:
       <code class="Nm" title="Nm">fido2-cred</code> will fail.</dd>
   <dt><a class="permalink" href="#r"><code class="Fl" title="Fl" id="r">-r</code></a></dt>
   <dd>Create a resident credential. Resident credentials are called
-      &#x201C;discoverable credentials&#x201D; in FIDO 2.1.</dd>
+      &#x201C;discoverable credentials&#x201D; in CTAP 2.1.</dd>
   <dt><a class="permalink" href="#u"><code class="Fl" title="Fl" id="u">-u</code></a></dt>
   <dd>Create a U2F credential. By default,
       <code class="Nm" title="Nm">fido2-cred</code> will use FIDO2 if supported

--- a/content/projects/libfido2/Manuals/fido2-token.partial
+++ b/content/projects/libfido2/Manuals/fido2-token.partial
@@ -22,7 +22,7 @@
 <div class="manual-text">
 <h1 class="Sh" title="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
 <code class="Nm" title="Nm">fido2-token</code> &#x2014;
-<div class="Nd" title="Nd">find and manage a FIDO 2 authenticator</div>
+<div class="Nd" title="Nd">find and manage a FIDO2 authenticator</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <table class="Nm">
   <tr>
@@ -249,7 +249,7 @@
   </tr>
 </table>
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
-<code class="Nm" title="Nm">fido2-token</code> manages a FIDO 2 authenticator.
+<code class="Nm" title="Nm">fido2-token</code> manages a FIDO2 authenticator.
 <div class="Pp"></div>
 The options are as follows:
 <dl class="Bl-tag">
@@ -302,14 +302,14 @@ The options are as follows:
   <dt><a class="permalink" href="#D_5"><code class="Fl" title="Fl" id="D_5">-D</code></a>
     <code class="Fl" title="Fl">-u</code>
     <var class="Ar" title="Ar">device</var></dt>
-  <dd>Disables the FIDO 2.1 &#x201C;user verification always&#x201D; feature on
+  <dd>Disables the CTAP 2.1 &#x201C;user verification always&#x201D; feature on
       <var class="Ar" title="Ar">device</var>.</dd>
   <dt><a class="permalink" href="#G"><code class="Fl" title="Fl" id="G">-G</code></a>
     <code class="Fl" title="Fl">-b</code> <code class="Fl" title="Fl">-k</code>
     <var class="Ar" title="Ar">key_path</var>
     <var class="Ar" title="Ar">blob_path</var>
     <var class="Ar" title="Ar">device</var></dt>
-  <dd>Gets a FIDO 2.1 &#x201C;largeBlob&#x201D; encrypted with
+  <dd>Gets a CTAP 2.1 &#x201C;largeBlob&#x201D; encrypted with
       <var class="Ar" title="Ar">key_path</var> from
       <var class="Ar" title="Ar">device</var>, where
       <var class="Ar" title="Ar">key_path</var> must hold the blob's
@@ -323,7 +323,7 @@ The options are as follows:
     <var class="Ar" title="Ar">cred_id</var></div>]
     <var class="Ar" title="Ar">blob_path</var>
     <var class="Ar" title="Ar">device</var></dt>
-  <dd>Gets a FIDO 2.1 &#x201C;largeBlob&#x201D; associated with
+  <dd>Gets a CTAP 2.1 &#x201C;largeBlob&#x201D; associated with
       <var class="Ar" title="Ar">rp_id</var> from
       <var class="Ar" title="Ar">device</var>. If
       <var class="Ar" title="Ar">rp_id</var> has multiple credentials enrolled
@@ -359,7 +359,7 @@ The options are as follows:
   <dt><a class="permalink" href="#L_2"><code class="Fl" title="Fl" id="L_2">-L</code></a>
     <code class="Fl" title="Fl">-b</code>
     <var class="Ar" title="Ar">device</var></dt>
-  <dd>Produces a list of FIDO 2.1 &#x201C;largeBlobs&#x201D; on
+  <dd>Produces a list of CTAP 2.1 &#x201C;largeBlobs&#x201D; on
       <var class="Ar" title="Ar">device</var>. A PIN or equivalent
       user-verification gesture is required.</dd>
   <dt><a class="permalink" href="#L_3"><code class="Fl" title="Fl" id="L_3">-L</code></a>
@@ -391,14 +391,14 @@ The options are as follows:
   <dt><a class="permalink" href="#S_2"><code class="Fl" title="Fl" id="S_2">-S</code></a>
     <code class="Fl" title="Fl">-a</code>
     <var class="Ar" title="Ar">device</var></dt>
-  <dd>Enables FIDO 2.1 Enterprise Attestation on
+  <dd>Enables CTAP 2.1 Enterprise Attestation on
       <var class="Ar" title="Ar">device</var>.</dd>
   <dt><a class="permalink" href="#S_3"><code class="Fl" title="Fl" id="S_3">-S</code></a>
     <code class="Fl" title="Fl">-b</code> <code class="Fl" title="Fl">-k</code>
     <var class="Ar" title="Ar">key_path</var>
     <var class="Ar" title="Ar">blob_path</var>
     <var class="Ar" title="Ar">device</var></dt>
-  <dd>Sets <var class="Ar" title="Ar">blob_path</var> as a FIDO 2.1
+  <dd>Sets <var class="Ar" title="Ar">blob_path</var> as a CTAP 2.1
       &#x201C;largeBlob&#x201D; encrypted with
       <var class="Ar" title="Ar">key_path</var> on
       <var class="Ar" title="Ar">device</var>, where
@@ -413,7 +413,7 @@ The options are as follows:
     <var class="Ar" title="Ar">cred_id</var></div>]
     <var class="Ar" title="Ar">blob_path</var>
     <var class="Ar" title="Ar">device</var></dt>
-  <dd>Sets <var class="Ar" title="Ar">blob_path</var> as a FIDO 2.1
+  <dd>Sets <var class="Ar" title="Ar">blob_path</var> as a CTAP 2.1
       &#x201C;largeBlob&#x201D; associated with
       <var class="Ar" title="Ar">rp_id</var> on
       <var class="Ar" title="Ar">device</var>. If
@@ -482,7 +482,7 @@ The options are as follows:
   <dt><a class="permalink" href="#S_11"><code class="Fl" title="Fl" id="S_11">-S</code></a>
     <code class="Fl" title="Fl">-u</code>
     <var class="Ar" title="Ar">device</var></dt>
-  <dd>Enables the FIDO 2.1 &#x201C;user verification always&#x201D; feature on
+  <dd>Enables the CTAP 2.1 &#x201C;user verification always&#x201D; feature on
       <var class="Ar" title="Ar">device</var>.</dd>
   <dt><a class="permalink" href="#V"><code class="Fl" title="Fl" id="V">-V</code></a></dt>
   <dd>Prints version information.</dd>
@@ -509,10 +509,10 @@ The actual user-flow to perform a reset is outside the scope of the FIDO2
 <div class="Pp"></div>
 An authenticator's path may contain spaces.
 <div class="Pp"></div>
-Resident credentials are called &#x201C;discoverable credentials&#x201D; in FIDO
+Resident credentials are called &#x201C;discoverable credentials&#x201D; in CTAP
   2.1.
 <div class="Pp"></div>
-Whether the FIDO 2.1 &#x201C;user verification always&#x201D; feature is
+Whether the CTAP 2.1 &#x201C;user verification always&#x201D; feature is
   activated or deactivated after an authenticator reset is
   vendor-specific.</div>
 <table class="foot">

--- a/content/projects/libfido2/Manuals/fido_assert_allow_cred.partial
+++ b/content/projects/libfido2/Manuals/fido_assert_allow_cred.partial
@@ -22,8 +22,7 @@
 <div class="manual-text">
 <h1 class="Sh" title="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
 <code class="Nm" title="Nm">fido_assert_allow_cred</code> &#x2014;
-<div class="Nd" title="Nd">appends a credential ID to the list of credentials
-  allowed in an assertion</div>
+<div class="Nd" title="Nd">allow a credential in a FIDO2 assertion</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
   &lt;<a class="In" title="In">fido.h</a>&gt;</code>
@@ -45,7 +44,7 @@ The <code class="Fn" title="Fn">fido_assert_allow_cred</code>() function adds
   <code class="Fn" title="Fn">fido_assert_allow_cred</code>() fails, the
   existing list of allowed credentials is preserved.
 <div class="Pp"></div>
-For the format of a FIDO 2 credential ID, please refer to the Web Authentication
+For the format of a FIDO2 credential ID, please refer to the Web Authentication
   (webauthn) standard.
 <h1 class="Sh" title="Sh" id="RETURN_VALUES"><a class="permalink" href="#RETURN_VALUES">RETURN
   VALUES</a></h1>

--- a/content/projects/libfido2/Manuals/fido_assert_new.partial
+++ b/content/projects/libfido2/Manuals/fido_assert_new.partial
@@ -46,7 +46,7 @@
   <code class="Nm" title="Nm">fido_assert_id_len</code>,
   <code class="Nm" title="Nm">fido_assert_sigcount</code>,
   <code class="Nm" title="Nm">fido_assert_flags</code> &#x2014;
-<div class="Nd" title="Nd">FIDO 2 assertion API</div>
+<div class="Nd" title="Nd">FIDO2 assertion API</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
   &lt;<a class="In" title="In">fido.h</a>&gt;</code>
@@ -194,7 +194,9 @@
   fido_assert_t *assert</var>,
   <var class="Fa" title="Fa" style="white-space: nowrap;">size_t idx</var>);
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
-FIDO 2 assertions are abstracted in <i class="Em" title="Em">libfido2</i> by the
+A FIDO2 assertion is a collection of statements, each statement a map between a
+  challenge, a credential, a signature, and ancillary attributes. In
+  <i class="Em" title="Em">libfido2</i>, a FIDO2 assertion is abstracted by the
   <var class="Vt" title="Vt">fido_assert_t</var> type. The functions described
   in this page allow a <var class="Vt" title="Vt">fido_assert_t</var> type to be
   allocated, deallocated, and inspected. For other operations on
@@ -234,65 +236,69 @@ The <code class="Fn" title="Fn">fido_assert_user_display_name</code>(),
   <var class="Fa" title="Fa">assert</var>. If not NULL, the values returned by
   these functions point to NUL-terminated UTF-8 strings.
 <div class="Pp"></div>
-The <code class="Fn" title="Fn">fido_assert_user_id_ptr</code>(),
-  <code class="Fn" title="Fn">fido_assert_authdata_ptr</code>(),
-  <code class="Fn" title="Fn">fido_assert_blob_ptr</code>(),
-  <code class="Fn" title="Fn">fido_assert_hmac_secret_ptr</code>(),
-  <code class="Fn" title="Fn">fido_assert_largeblob_key_ptr</code>(),
-  <code class="Fn" title="Fn">fido_assert_sig_ptr</code>(), and
-  <code class="Fn" title="Fn">fido_assert_id_ptr</code>() functions return
-  pointers to the user ID, CBOR-encoded authenticator data, cred blob,
-  hmac-secret, &#x201C;largeBlobKey&#x201D;, signature, and credential ID
-  attributes of statement <var class="Fa" title="Fa">idx</var> in
+The <code class="Fn" title="Fn">fido_assert_authdata_ptr</code>(),
+  <code class="Fn" title="Fn">fido_assert_clientdata_hash_ptr</code>(),
+  <code class="Fn" title="Fn">fido_assert_id_ptr</code>(),
+  <code class="Fn" title="Fn">fido_assert_user_id_ptr</code>(),
+  <code class="Fn" title="Fn">fido_assert_sig_ptr</code>(),
+  <code class="Fn" title="Fn">fido_assert_sigcount</code>(), and
+  <code class="Fn" title="Fn">fido_assert_flags</code>() functions return
+  pointers to the CBOR-encoded authenticator data, client data hash, credential
+  ID, user ID, signature, signature count, and authenticator data flags of
+  statement <var class="Fa" title="Fa">idx</var> in
   <var class="Fa" title="Fa">assert</var>.
 <div class="Pp"></div>
-The <code class="Fn" title="Fn">fido_assert_user_id_len</code>(),
-  <code class="Fn" title="Fn">fido_assert_authdata_len</code>(),
-  <code class="Fn" title="Fn">fido_assert_blob_len</code>(),
-  <code class="Fn" title="Fn">fido_assert_hmac_secret_len</code>(),
-  <code class="Fn" title="Fn">fido_assert_largeblob_key_len</code>(),
-  <code class="Fn" title="Fn">fido_assert_sig_len</code>(), and
-  <code class="Fn" title="Fn">fido_assert_id_len</code>() functions can be used
-  to retrieve the corresponding length of a specific attribute.
-<div class="Pp"></div>
-The <code class="Fn" title="Fn">fido_assert_sigcount</code>() function can be
-  used to obtain the signature counter of statement
+The <code class="Fn" title="Fn">fido_assert_hmac_secret_ptr</code>() function
+  returns a pointer to the hmac-secret attribute of statement
   <var class="Fa" title="Fa">idx</var> in
-  <var class="Fa" title="Fa">assert</var>.
+  <var class="Fa" title="Fa">assert</var>. The HMAC Secret Extension
+  (hmac-secret) is a CTAP 2.0 extension.
 <div class="Pp"></div>
-The <code class="Fn" title="Fn">fido_assert_flags</code>() function returns the
-  authenticator data flags of statement <var class="Fa" title="Fa">idx</var> in
-  <var class="Fa" title="Fa">assert</var>.
+The <code class="Fn" title="Fn">fido_assert_blob_ptr</code>() and
+  <code class="Fn" title="Fn">fido_assert_largeblob_key_ptr</code>() functions
+  return pointers to the &#x201C;credBlob&#x201D; and
+  &#x201C;largeBlobKey&#x201D; attributes of statement
+  <var class="Fa" title="Fa">idx</var> in
+  <var class="Fa" title="Fa">assert</var>. Credential Blob (credBlob) and Large
+  Blob Key (largeBlobKey) are CTAP 2.1 extensions.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_assert_authdata_len</code>(),
+  <code class="Fn" title="Fn">fido_assert_clientdata_hash_len</code>(),
+  <code class="Fn" title="Fn">fido_assert_id_len</code>(),
+  <code class="Fn" title="Fn">fido_assert_user_id_len</code>(),
+  <code class="Fn" title="Fn">fido_assert_sig_len</code>(),
+  <code class="Fn" title="Fn">fido_assert_hmac_secret_len</code>(),
+  <code class="Fn" title="Fn">fido_assert_blob_len</code>(), and
+  <code class="Fn" title="Fn">fido_assert_largeblob_key_len</code>() functions
+  return the length of a given attribute.
 <div class="Pp"></div>
 Please note that the first statement in <var class="Fa" title="Fa">assert</var>
   has an <var class="Fa" title="Fa">idx</var> (index) value of 0.
 <div class="Pp"></div>
 The authenticator data and signature parts of an assertion statement are
-  typically passed to a FIDO 2 server for verification.
-<div class="Pp"></div>
-The <code class="Fn" title="Fn">fido_assert_clientdata_hash_ptr</code>()
-  function returns a pointer to the client data hash of
-  <var class="Fa" title="Fa">assert</var>. The corresponding length can be
-  obtained by
-  <code class="Fn" title="Fn">fido_assert_clientdata_hash_len</code>().
+  typically passed to a FIDO2 server for verification.
 <h1 class="Sh" title="Sh" id="RETURN_VALUES"><a class="permalink" href="#RETURN_VALUES">RETURN
   VALUES</a></h1>
 The authenticator data returned by
   <code class="Fn" title="Fn">fido_assert_authdata_ptr</code>() is a
   CBOR-encoded byte string, as obtained from the authenticator.
 <div class="Pp"></div>
-The <code class="Fn" title="Fn">fido_assert_user_display_name</code>(),
+The <code class="Fn" title="Fn">fido_assert_rp_id</code>(),
+  <code class="Fn" title="Fn">fido_assert_user_display_name</code>(),
   <code class="Fn" title="Fn">fido_assert_user_icon</code>(),
   <code class="Fn" title="Fn">fido_assert_user_name</code>(),
   <code class="Fn" title="Fn">fido_assert_authdata_ptr</code>(),
   <code class="Fn" title="Fn">fido_assert_clientdata_hash_ptr</code>(),
+  <code class="Fn" title="Fn">fido_assert_id_ptr</code>(),
+  <code class="Fn" title="Fn">fido_assert_user_id_ptr</code>(),
+  <code class="Fn" title="Fn">fido_assert_sig_ptr</code>(),
   <code class="Fn" title="Fn">fido_assert_hmac_secret_ptr</code>(),
-  <code class="Fn" title="Fn">fido_assert_largeblob_key_ptr</code>(),
-  <code class="Fn" title="Fn">fido_assert_user_id_ptr</code>(), and
-  <code class="Fn" title="Fn">fido_assert_sig_ptr</code>() functions return NULL
-  if the respective field in <var class="Fa" title="Fa">assert</var> is not set.
-  If not NULL, returned pointers are guaranteed to exist until any API function
-  that takes <var class="Fa" title="Fa">assert</var> without the
+  <code class="Fn" title="Fn">fido_assert_blob_ptr</code>(), and
+  <code class="Fn" title="Fn">fido_assert_largeblob_key_ptr</code>() functions
+  may return NULL if the respective field in
+  <var class="Fa" title="Fa">assert</var> is not set. If not NULL, returned
+  pointers are guaranteed to exist until any API function that takes
+  <var class="Fa" title="Fa">assert</var> without the
   <i class="Em" title="Em">const</i> qualifier is invoked.
 <h1 class="Sh" title="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>

--- a/content/projects/libfido2/Manuals/fido_assert_set_authdata.partial
+++ b/content/projects/libfido2/Manuals/fido_assert_set_authdata.partial
@@ -33,7 +33,7 @@
   <code class="Nm" title="Nm">fido_assert_set_uv</code>,
   <code class="Nm" title="Nm">fido_assert_set_rp</code>,
   <code class="Nm" title="Nm">fido_assert_set_sig</code> &#x2014;
-<div class="Nd" title="Nd">set parameters of a FIDO 2 assertion</div>
+<div class="Nd" title="Nd">set parameters of a FIDO2 assertion</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
   &lt;<a class="In" title="In">fido.h</a>&gt;</code>
@@ -51,7 +51,7 @@ typedef enum {
 <var class="Ft" title="Ft">int</var>
 <br/>
 <code class="Fn" title="Fn">fido_assert_set_authdata</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_assert_t
-  *assert</var>, <var class="Fa" title="Fa" style="white-space: nowrap;"> size_t
+  *assert</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">size_t
   idx</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
   unsigned char *ptr</var>,
   <var class="Fa" title="Fa" style="white-space: nowrap;">size_t len</var>);
@@ -59,7 +59,7 @@ typedef enum {
 <var class="Ft" title="Ft">int</var>
 <br/>
 <code class="Fn" title="Fn">fido_assert_set_authdata_raw</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_assert_t
-  *assert</var>, <var class="Fa" title="Fa" style="white-space: nowrap;"> size_t
+  *assert</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">size_t
   idx</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
   unsigned char *ptr</var>,
   <var class="Fa" title="Fa" style="white-space: nowrap;">size_t len</var>);
@@ -100,7 +100,8 @@ typedef enum {
 <var class="Ft" title="Ft">int</var>
 <br/>
 <code class="Fn" title="Fn">fido_assert_set_hmac_secret</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_assert_t
-  *assert</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
+  *assert</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">size_t
+  idx</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
   unsigned char *ptr</var>,
   <var class="Fa" title="Fa" style="white-space: nowrap;">size_t len</var>);
 <div class="Pp"></div>
@@ -131,13 +132,13 @@ typedef enum {
   <var class="Fa" title="Fa" style="white-space: nowrap;">size_t len</var>);
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
 The <code class="Nm" title="Nm">fido_assert_set_authdata</code> set of functions
-  define the various parameters of a FIDO 2 assertion, allowing a
+  define the various parameters of a FIDO2 assertion, allowing a
   <var class="Fa" title="Fa">fido_assert_t</var> type to be prepared for a
   subsequent call to
   <a class="Xr" title="Xr" href="fido_dev_get_assert.html">fido_dev_get_assert(3)</a>
   or
   <a class="Xr" title="Xr" href="fido_assert_verify.html">fido_assert_verify(3)</a>.
-  For the complete specification of a FIDO 2 assertion and the format of its
+  For the complete specification of a FIDO2 assertion and the format of its
   constituent parts, please refer to the Web Authentication (webauthn) standard.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_assert_set_count</code>() function sets the
@@ -163,12 +164,9 @@ The <code class="Fn" title="Fn">fido_assert_set_authdata</code>() and
   a raw binary blob may be passed to
   <code class="Fn" title="Fn">fido_assert_set_authdata_raw</code>().
 <div class="Pp"></div>
-The <code class="Fn" title="Fn">fido_assert_set_clientdata_hash</code>(),
-  <code class="Fn" title="Fn">fido_assert_set_hmac_salt</code>(), and
-  <code class="Fn" title="Fn">fido_assert_set_hmac_secret</code>() functions set
-  the client data hash and hmac-salt parts of
-  <var class="Fa" title="Fa">assert</var> to
-  <var class="Fa" title="Fa">ptr</var>, where
+The <code class="Fn" title="Fn">fido_assert_set_clientdata_hash</code>()
+  function sets the client data hash of <var class="Fa" title="Fa">assert</var>
+  to <var class="Fa" title="Fa">ptr</var>, where
   <var class="Fa" title="Fa">ptr</var> points to
   <var class="Fa" title="Fa">len</var> bytes. A copy of
   <var class="Fa" title="Fa">ptr</var> is made, and no references to the passed
@@ -199,6 +197,18 @@ The <code class="Fn" title="Fn">fido_assert_set_extensions</code>() function
   supported. If <var class="Fa" title="Fa">flags</var> is zero, the extensions
   of <var class="Fa" title="Fa">assert</var> are cleared.
 <div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_assert_set_hmac_salt</code>() and
+  <code class="Fn" title="Fn">fido_assert_set_hmac_secret</code>() functions set
+  the hmac-salt and hmac-secret parts of <var class="Fa" title="Fa">assert</var>
+  to <var class="Fa" title="Fa">ptr</var>, where
+  <var class="Fa" title="Fa">ptr</var> points to
+  <var class="Fa" title="Fa">len</var> bytes. A copy of
+  <var class="Fa" title="Fa">ptr</var> is made, and no references to the passed
+  pointer are kept. The HMAC Secret (hmac-secret) Extension is a CTAP 2.0
+  extension. The
+  <code class="Fn" title="Fn">fido_assert_set_hmac_secret</code>() function is
+  normally only useful when writing tests.
+<div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_assert_set_up</code>() and
   <code class="Fn" title="Fn">fido_assert_set_uv</code>() functions set the
   <var class="Fa" title="Fa">up</var> (user presence) and
@@ -208,25 +218,20 @@ The <code class="Fn" title="Fn">fido_assert_set_up</code>() and
   authenticator to use its default settings.
 <div class="Pp"></div>
 Use of the <code class="Nm" title="Nm">fido_assert_set_authdata</code> set of
-  functions may happen in two distinct situations: when asking a FIDO device to
+  functions may happen in two distinct situations: when asking a FIDO2 device to
   produce a series of assertion statements, prior to
   <a class="Xr" title="Xr" href="fido_dev_get_assert.html">fido_dev_get_assert(3)</a>
-  (i.e, in the context of a FIDO client), or when verifying assertion statements
-  using
+  (i.e, in the context of a FIDO2 client), or when verifying assertion
+  statements using
   <a class="Xr" title="Xr" href="fido_assert_verify.html">fido_assert_verify(3)</a>
-  (i.e, in the context of a FIDO server).
+  (i.e, in the context of a FIDO2 server).
 <div class="Pp"></div>
-For a complete description of the generation of a FIDO 2 assertion and its
-  verification, please refer to the FIDO 2 specification. An example of how to
+For a complete description of the generation of a FIDO2 assertion and its
+  verification, please refer to the FIDO2 specification. An example of how to
   use the <code class="Nm" title="Nm">fido_assert_set_authdata</code> set of
   functions can be found in the
   <span class="Pa" title="Pa">examples/assert.c</span> file shipped with
   <i class="Em" title="Em">libfido2</i>.
-<div class="Pp"></div>
-<code class="Fn" title="Fn">fido_assert_set_hmac_secret</code>() is not normally
-  useful in a FIDO client or server &#x2014; it is provided to enable testing
-  other functionality that relies on retrieving the HMAC secret from an
-  assertion obtained from an authenticator.
 <h1 class="Sh" title="Sh" id="RETURN_VALUES"><a class="permalink" href="#RETURN_VALUES">RETURN
   VALUES</a></h1>
 The <code class="Nm" title="Nm">fido_assert_set_authdata</code> functions return

--- a/content/projects/libfido2/Manuals/fido_assert_set_authdata_raw.partial
+++ b/content/projects/libfido2/Manuals/fido_assert_set_authdata_raw.partial
@@ -1,0 +1,1 @@
+fido_assert_set_authdata.partial

--- a/content/projects/libfido2/Manuals/fido_assert_verify.partial
+++ b/content/projects/libfido2/Manuals/fido_assert_verify.partial
@@ -22,7 +22,7 @@
 <div class="manual-text">
 <h1 class="Sh" title="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
 <code class="Nm" title="Nm">fido_assert_verify</code> &#x2014;
-<div class="Nd" title="Nd">verifies the signature of a FIDO 2 assertion
+<div class="Nd" title="Nd">verifies the signature of a FIDO2 assertion
   statement</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
@@ -30,11 +30,11 @@
 <div class="Pp"></div>
 <var class="Ft" title="Ft">int</var>
 <br/>
-<code class="Fn" title="Fn">fido_assert_verify</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_assert_t
-  *assert</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">size_t
-  idx</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">int
-  cose_alg</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
-  void *pk</var>);
+<code class="Fn" title="Fn">fido_assert_verify</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_assert_t *assert</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">size_t idx</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">int cose_alg</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">const void *pk</var>);
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
 The <code class="Fn" title="Fn">fido_assert_verify</code>() function verifies
   whether the signature contained in statement index
@@ -43,7 +43,7 @@ The <code class="Fn" title="Fn">fido_assert_verify</code>() function verifies
   assertion. Before using
   <code class="Fn" title="Fn">fido_assert_verify</code>() in a sensitive
   context, the reader is strongly encouraged to make herself familiar with the
-  FIDO 2 assertion statement process as defined in the Web Authentication
+  FIDO2 assertion statement process as defined in the Web Authentication
   (webauthn) standard.
 <div class="Pp"></div>
 A brief description follows:

--- a/content/projects/libfido2/Manuals/fido_bio_dev_get_info.partial
+++ b/content/projects/libfido2/Manuals/fido_bio_dev_get_info.partial
@@ -28,7 +28,7 @@
   <code class="Nm" title="Nm">fido_bio_dev_enroll_remove</code>,
   <code class="Nm" title="Nm">fido_bio_dev_get_template_array</code>,
   <code class="Nm" title="Nm">fido_bio_dev_set_template_name</code> &#x2014;
-<div class="Nd" title="Nd">FIDO 2 biometric authenticator API</div>
+<div class="Nd" title="Nd">FIDO2 biometric authenticator API</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
   &lt;<a class="In" title="In">fido.h</a>&gt;</code>

--- a/content/projects/libfido2/Manuals/fido_bio_enroll_new.partial
+++ b/content/projects/libfido2/Manuals/fido_bio_enroll_new.partial
@@ -25,7 +25,7 @@
   <code class="Nm" title="Nm">fido_bio_enroll_free</code>,
   <code class="Nm" title="Nm">fido_bio_enroll_last_status</code>,
   <code class="Nm" title="Nm">fido_bio_enroll_remaining_samples</code> &#x2014;
-<div class="Nd" title="Nd">FIDO 2 biometric enrollment API</div>
+<div class="Nd" title="Nd">FIDO2 biometric enrollment API</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
   &lt;<a class="In" title="In">fido.h</a>&gt;</code>
@@ -72,7 +72,7 @@
 <code class="Fn" title="Fn">fido_bio_enroll_remaining_samples</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_bio_enroll_t *enroll</var>);
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
-Ongoing FIDO 2 biometric enrollments are abstracted in
+Ongoing FIDO2 biometric enrollments are abstracted in
   <i class="Em" title="Em">libfido2</i> by the
   <var class="Vt" title="Vt">fido_bio_enroll_t</var> type.
 <div class="Pp"></div>

--- a/content/projects/libfido2/Manuals/fido_bio_info_new.partial
+++ b/content/projects/libfido2/Manuals/fido_bio_info_new.partial
@@ -25,7 +25,7 @@
   <code class="Nm" title="Nm">fido_bio_info_free</code>,
   <code class="Nm" title="Nm">fido_bio_info_type</code>,
   <code class="Nm" title="Nm">fido_bio_info_max_samples</code> &#x2014;
-<div class="Nd" title="Nd">FIDO 2 biometric sensor information API</div>
+<div class="Nd" title="Nd">FIDO2 biometric sensor information API</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
   &lt;<a class="In" title="In">fido.h</a>&gt;</code>

--- a/content/projects/libfido2/Manuals/fido_bio_template.partial
+++ b/content/projects/libfido2/Manuals/fido_bio_template.partial
@@ -32,7 +32,7 @@
   <code class="Nm" title="Nm">fido_bio_template_new</code>,
   <code class="Nm" title="Nm">fido_bio_template_set_id</code>,
   <code class="Nm" title="Nm">fido_bio_template_set_name</code> &#x2014;
-<div class="Nd" title="Nd">FIDO 2 biometric template API</div>
+<div class="Nd" title="Nd">FIDO2 biometric template API</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
   &lt;<a class="In" title="In">fido.h</a>&gt;</code>
@@ -97,7 +97,7 @@
   fido_bio_template_array_t *array</var>,
   <var class="Fa" title="Fa" style="white-space: nowrap;">size_t idx</var>);
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
-Existing FIDO 2 biometric enrollments are abstracted in
+Existing FIDO2 biometric enrollments are abstracted in
   <i class="Em" title="Em">libfido2</i> by the
   <var class="Vt" title="Vt">fido_bio_template_t</var> and
   <var class="Vt" title="Vt">fido_bio_template_array_t</var> types.

--- a/content/projects/libfido2/Manuals/fido_cbor_info_new.partial
+++ b/content/projects/libfido2/Manuals/fido_cbor_info_new.partial
@@ -41,10 +41,11 @@
   <code class="Nm" title="Nm">fido_cbor_info_versions_len</code>,
   <code class="Nm" title="Nm">fido_cbor_info_options_len</code>,
   <code class="Nm" title="Nm">fido_cbor_info_maxmsgsiz</code>,
+  <code class="Nm" title="Nm">fido_cbor_info_maxcredbloblen</code>,
   <code class="Nm" title="Nm">fido_cbor_info_maxcredcntlst</code>,
   <code class="Nm" title="Nm">fido_cbor_info_maxcredidlen</code>,
   <code class="Nm" title="Nm">fido_cbor_info_fwversion</code> &#x2014;
-<div class="Nd" title="Nd">FIDO 2 CBOR Info API</div>
+<div class="Nd" title="Nd">FIDO2 CBOR Info API</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
   &lt;<a class="In" title="In">fido.h</a>&gt;</code>

--- a/content/projects/libfido2/Manuals/fido_cred_exclude.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_exclude.partial
@@ -52,7 +52,7 @@ If <code class="Nm" title="Nm">fido_cred_exclude</code> returns success and
   <a class="Xr" title="Xr" href="fido_dev_make_cred.html">fido_dev_make_cred(3)</a>
   will fail.
 <div class="Pp"></div>
-For the format of a FIDO 2 credential ID, please refer to the Web Authentication
+For the format of a FIDO2 credential ID, please refer to the Web Authentication
   (webauthn) standard.
 <h1 class="Sh" title="Sh" id="RETURN_VALUES"><a class="permalink" href="#RETURN_VALUES">RETURN
   VALUES</a></h1>

--- a/content/projects/libfido2/Manuals/fido_cred_new.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_new.partial
@@ -55,7 +55,7 @@
   <code class="Nm" title="Nm">fido_cred_type</code>,
   <code class="Nm" title="Nm">fido_cred_flags</code>,
   <code class="Nm" title="Nm">fido_cred_sigcount</code> &#x2014;
-<div class="Nd" title="Nd">FIDO 2 credential API</div>
+<div class="Nd" title="Nd">FIDO2 credential API</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
   &lt;<a class="In" title="In">fido.h</a>&gt;</code>
@@ -229,9 +229,9 @@
 <code class="Fn" title="Fn">fido_cred_sigcount</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_cred_t *cred</var>);
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
-FIDO 2 credentials are abstracted in <i class="Em" title="Em">libfido2</i> by
-  the <var class="Vt" title="Vt">fido_cred_t</var> type. The functions described
-  in this page allow a <var class="Vt" title="Vt">fido_cred_t</var> type to be
+FIDO2 credentials are abstracted in <i class="Em" title="Em">libfido2</i> by the
+  <var class="Vt" title="Vt">fido_cred_t</var> type. The functions described in
+  this page allow a <var class="Vt" title="Vt">fido_cred_t</var> type to be
   allocated, deallocated, and inspected. For other operations on
   <var class="Vt" title="Vt">fido_cred_t</var>, please refer to
   <a class="Xr" title="Xr" href="fido_cred_set_authdata.html">fido_cred_set_authdata(3)</a>,
@@ -254,7 +254,7 @@ The <code class="Fn" title="Fn">fido_cred_free</code>() function releases the
   <var class="Fa" title="Fa">*cred_p</var> may be NULL, in which case
   <code class="Fn" title="Fn">fido_cred_free</code>() is a NOP.
 <div class="Pp"></div>
-If the FIDO 2.1 <code class="Dv" title="Dv">FIDO_EXT_MINPINLEN</code> extension
+If the CTAP 2.1 <code class="Dv" title="Dv">FIDO_EXT_MINPINLEN</code> extension
   is enabled on <var class="Fa" title="Fa">cred</var>, then the
   <code class="Fn" title="Fn">fido_cred_pin_minlen</code>() function returns the
   minimum PIN length of <var class="Fa" title="Fa">cred</var>. Otherwise,
@@ -262,7 +262,7 @@ If the FIDO 2.1 <code class="Dv" title="Dv">FIDO_EXT_MINPINLEN</code> extension
   <a class="Xr" title="Xr" href="fido_cred_set_pin_minlen.html">fido_cred_set_pin_minlen(3)</a>
   on how to enable this extension.
 <div class="Pp"></div>
-If the FIDO 2.1 <code class="Dv" title="Dv">FIDO_EXT_CRED_PROTECT</code>
+If the CTAP 2.1 <code class="Dv" title="Dv">FIDO_EXT_CRED_PROTECT</code>
   extension is enabled on <var class="Fa" title="Fa">cred</var>, then the
   <code class="Fn" title="Fn">fido_cred_prot</code>() function returns the
   protection of <var class="Fa" title="Fa">cred</var>. Otherwise,
@@ -316,7 +316,7 @@ The corresponding length can be obtained by
   <code class="Fn" title="Fn">fido_cred_attstmt_len</code>().
 <div class="Pp"></div>
 The authenticator data, x509 certificate, and signature parts of a credential
-  are typically passed to a FIDO 2 server for verification.
+  are typically passed to a FIDO2 server for verification.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_cred_type</code>() function returns the
   COSE algorithm of <var class="Fa" title="Fa">cred</var>.

--- a/content/projects/libfido2/Manuals/fido_cred_set_authdata.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_set_authdata.partial
@@ -39,7 +39,7 @@
   <code class="Nm" title="Nm">fido_cred_set_uv</code>,
   <code class="Nm" title="Nm">fido_cred_set_fmt</code>,
   <code class="Nm" title="Nm">fido_cred_set_type</code> &#x2014;
-<div class="Nd" title="Nd">set parameters of a FIDO 2 credential</div>
+<div class="Nd" title="Nd">set parameters of a FIDO2 credential</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
   &lt;<a class="In" title="In">fido.h</a>&gt;</code>
@@ -180,13 +180,13 @@ typedef enum {
   cose_alg</var>);
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
 The <code class="Nm" title="Nm">fido_cred_set_authdata</code> set of functions
-  define the various parameters of a FIDO 2 credential, allowing a
+  define the various parameters of a FIDO2 credential, allowing a
   <var class="Fa" title="Fa">fido_cred_t</var> type to be prepared for a
   subsequent call to
   <a class="Xr" title="Xr" href="fido_dev_make_cred.html">fido_dev_make_cred(3)</a>
   or
   <a class="Xr" title="Xr" href="fido_cred_verify.html">fido_cred_verify(3)</a>.
-  For the complete specification of a FIDO 2 credential and the format of its
+  For the complete specification of a FIDO2 credential and the format of its
   constituent parts, please refer to the Web Authentication (webauthn) standard.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_cred_set_authdata</code>(),
@@ -277,7 +277,7 @@ The <code class="Fn" title="Fn">fido_cred_set_blob</code>() function sets the
   <var class="Fa" title="Fa">len</var> bytes long.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_cred_set_pin_minlen</code>() function
-  enables the FIDO 2.1 <code class="Dv" title="Dv">FIDO_EXT_MINPINLEN</code>
+  enables the CTAP 2.1 <code class="Dv" title="Dv">FIDO_EXT_MINPINLEN</code>
   extension on <var class="Fa" title="Fa">cred</var> and sets the expected
   minimum PIN length of <var class="Fa" title="Fa">cred</var> to
   <var class="Fa" title="Fa">len</var>, where
@@ -287,7 +287,7 @@ The <code class="Fn" title="Fn">fido_cred_set_pin_minlen</code>() function
   <var class="Fa" title="Fa">cred</var>.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_cred_set_prot</code>() function enables the
-  FIDO 2.1 <code class="Dv" title="Dv">FIDO_EXT_CRED_PROTECT</code> extension on
+  CTAP 2.1 <code class="Dv" title="Dv">FIDO_EXT_CRED_PROTECT</code> extension on
   <var class="Fa" title="Fa">cred</var> and sets the protection of
   <var class="Fa" title="Fa">cred</var> to the scalar
   <var class="Fa" title="Fa">prot</var>. At the moment, only the
@@ -328,15 +328,15 @@ The <code class="Fn" title="Fn">fido_cred_set_type</code>() function sets the
 <div class="Pp"></div>
 Use of the <code class="Nm" title="Nm">fido_cred_set_authdata</code> set of
   functions may happen in two distinct situations: when generating a new
-  credential on a FIDO device, prior to
+  credential on a FIDO2 device, prior to
   <a class="Xr" title="Xr" href="fido_dev_make_cred.html">fido_dev_make_cred(3)</a>
-  (i.e, in the context of a FIDO client), or when validating a generated
+  (i.e, in the context of a FIDO2 client), or when validating a generated
   credential using
   <a class="Xr" title="Xr" href="fido_cred_verify.html">fido_cred_verify(3)</a>
-  (i.e, in the context of a FIDO server).
+  (i.e, in the context of a FIDO2 server).
 <div class="Pp"></div>
-For a complete description of the generation of a FIDO 2 credential and its
-  verification, please refer to the FIDO 2 specification. A concrete utilisation
+For a complete description of the generation of a FIDO2 credential and its
+  verification, please refer to the FIDO2 specification. A concrete utilisation
   example of the <code class="Nm" title="Nm">fido_cred_set_authdata</code> set
   of functions can be found in the <span class="Pa" title="Pa">cred.c</span>
   example shipped with <i class="Em" title="Em">libfido2</i>.

--- a/content/projects/libfido2/Manuals/fido_cred_verify.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_verify.partial
@@ -21,8 +21,9 @@
 </table>
 <div class="manual-text">
 <h1 class="Sh" title="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
-<code class="Nm" title="Nm">fido_cred_verify</code> &#x2014;
-<div class="Nd" title="Nd">verifies the attestation signature of a FIDO 2
+<code class="Nm" title="Nm">fido_cred_verify</code>,
+  <code class="Nm" title="Nm">fido_cred_verify_self</code> &#x2014;
+<div class="Nd" title="Nd">verify the attestation signature of a FIDO2
   credential</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
@@ -32,16 +33,21 @@
 <br/>
 <code class="Fn" title="Fn">fido_cred_verify</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_cred_t *cred</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
+<code class="Fn" title="Fn">fido_cred_verify_self</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cred_t *cred</var>);
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
-The <code class="Fn" title="Fn">fido_cred_verify</code>() function verifies
+The <code class="Fn" title="Fn">fido_cred_verify</code>() and
+  <code class="Fn" title="Fn">fido_cred_verify_self</code>() functions verify
   whether the attestation signature contained in
   <var class="Fa" title="Fa">cred</var> matches the attributes of the
   credential. Before using <code class="Fn" title="Fn">fido_cred_verify</code>()
-  in a sensitive context, the reader is strongly encouraged to make herself
-  familiar with the FIDO 2 credential attestation process as defined in the Web
-  Authentication (webauthn) standard.
-<div class="Pp"></div>
-A brief description follows:
+  or <code class="Fn" title="Fn">fido_cred_verify_self</code>() in a sensitive
+  context, the reader is strongly encouraged to make herself familiar with the
+  FIDO2 credential attestation process as defined in the Web Authentication
+  (webauthn) standard.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_cred_verify</code>() function verifies
   whether the client data hash, relying party ID, credential ID, type,
@@ -57,15 +63,28 @@ The attestation statement formats supported by
   <i class="Em" title="Em">packed</i>, <i class="Em" title="Em">fido-u2f</i>,
   and <i class="Em" title="Em">tpm</i>. The attestation type implemented by
   <code class="Fn" title="Fn">fido_cred_verify</code>() is
-  <i class="Em" title="Em">Basic Attestation</i>. Other attestation formats and
-  types are not supported.
+  <i class="Em" title="Em">Basic Attestation</i>.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_cred_verify_self</code>() function verifies
+  whether the client data hash, relying party ID, credential ID, type,
+  protection policy, minimum PIN length, and resident/discoverable key and user
+  verification attributes of <var class="Fa" title="Fa">cred</var> have been
+  attested by the holder of the credential's private key.
+<div class="Pp"></div>
+The attestation statement formats supported by
+  <code class="Fn" title="Fn">fido_cred_verify_self</code>() are
+  <i class="Em" title="Em">packed</i> and <i class="Em" title="Em">fido-u2f</i>.
+  The attestation type implemented by
+  <code class="Fn" title="Fn">fido_cred_verify_self</code>() is
+  <i class="Em" title="Em">Self Attestation</i>.
+<div class="Pp"></div>
+Other attestation formats and types are not supported.
 <h1 class="Sh" title="Sh" id="RETURN_VALUES"><a class="permalink" href="#RETURN_VALUES">RETURN
   VALUES</a></h1>
 The error codes returned by
-  <code class="Fn" title="Fn">fido_cred_verify</code>() are defined in
+  <code class="Fn" title="Fn">fido_cred_verify</code>() and
+  <code class="Fn" title="Fn">fido_cred_verify_self</code>() are defined in
   <code class="In" title="In">&lt;<a class="In" title="In">fido/err.h</a>&gt;</code>.
-  If <var class="Fa" title="Fa">cred</var> does not contain attestation data,
-  then <code class="Dv" title="Dv">FIDO_ERR_INVALID_ARGUMENT</code> is returned.
   If <var class="Fa" title="Fa">cred</var> passes verification, then
   <code class="Dv" title="Dv">FIDO_OK</code> is returned.
 <h1 class="Sh" title="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE

--- a/content/projects/libfido2/Manuals/fido_cred_verify_self.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_verify_self.partial
@@ -1,0 +1,1 @@
+fido_cred_verify.partial

--- a/content/projects/libfido2/Manuals/fido_credman_metadata_new.partial
+++ b/content/projects/libfido2/Manuals/fido_credman_metadata_new.partial
@@ -41,7 +41,7 @@
   <code class="Nm" title="Nm">fido_credman_set_dev_rk</code>,
   <code class="Nm" title="Nm">fido_credman_del_dev_rk</code>,
   <code class="Nm" title="Nm">fido_credman_get_dev_rp</code> &#x2014;
-<div class="Nd" title="Nd">FIDO 2 credential management API</div>
+<div class="Nd" title="Nd">FIDO2 credential management API</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
   &lt;<a class="In" title="In">fido.h</a>&gt;</code>
@@ -313,7 +313,7 @@ The <code class="Fn" title="Fn">fido_credman_get_dev_metadata</code>(),
   <a class="Xr" title="Xr" href="fido_cred_new.html">fido_cred_new(3)</a>,
   <a class="Xr" title="Xr" href="fido_dev_supports_credman.html">fido_dev_supports_credman(3)</a>
 <h1 class="Sh" title="Sh" id="CAVEATS"><a class="permalink" href="#CAVEATS">CAVEATS</a></h1>
-Resident credentials are called &#x201C;discoverable credentials&#x201D; in FIDO
+Resident credentials are called &#x201C;discoverable credentials&#x201D; in CTAP
   2.1.</div>
 <table class="foot">
   <tr>

--- a/content/projects/libfido2/Manuals/fido_dev_enable_entattest.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_enable_entattest.partial
@@ -26,7 +26,7 @@
   <code class="Nm" title="Nm">fido_dev_force_pin_change</code>,
   <code class="Nm" title="Nm">fido_dev_set_pin_minlen</code>,
   <code class="Nm" title="Nm">fido_dev_set_pin_minlen_rpid</code> &#x2014;
-<div class="Nd" title="Nd">FIDO 2.1 configuration authenticator API</div>
+<div class="Nd" title="Nd">CTAP 2.1 configuration authenticator API</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
   &lt;<a class="In" title="In">fido.h</a>&gt;</code>
@@ -68,7 +68,7 @@
   <var class="Fa" title="Fa" style="white-space: nowrap;">const char
   *pin</var>);
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
-The functions described in this page allow configuration of a FIDO 2.1
+The functions described in this page allow configuration of a CTAP 2.1
   authenticator.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_dev_enable_entattest</code>() function
@@ -102,7 +102,7 @@ The <code class="Fn" title="Fn">fido_dev_set_pin_minlen</code>() function sets
 The <code class="Fn" title="Fn">fido_dev_set_pin_minlen_rpid</code>() function
   sets the list of relying party identifiers (RP IDs) that are allowed to obtain
   the minimum PIN length of <var class="Fa" title="Fa">dev</var> through the
-  FIDO 2.1 <code class="Dv" title="Dv">FIDO_EXT_MINPINLEN</code> extension. The
+  CTAP 2.1 <code class="Dv" title="Dv">FIDO_EXT_MINPINLEN</code> extension. The
   list of RP identifiers is denoted by <var class="Fa" title="Fa">rpid</var>, a
   vector of <var class="Fa" title="Fa">n</var> NUL-terminated UTF-8 strings. A
   copy of <var class="Fa" title="Fa">rpid</var> is made, and no reference to it

--- a/content/projects/libfido2/Manuals/fido_dev_get_assert.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_get_assert.partial
@@ -22,7 +22,7 @@
 <div class="manual-text">
 <h1 class="Sh" title="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
 <code class="Nm" title="Nm">fido_dev_get_assert</code> &#x2014;
-<div class="Nd" title="Nd">obtains an assertion from a FIDO device</div>
+<div class="Nd" title="Nd">obtains an assertion from a FIDO2 device</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
   &lt;<a class="In" title="In">fido.h</a>&gt;</code>
@@ -30,13 +30,13 @@
 <var class="Ft" title="Ft">int</var>
 <br/>
 <code class="Fn" title="Fn">fido_dev_get_assert</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_dev_t
-  *dev</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">
-  fido_assert_t *assert</var>,
-  <var class="Fa" title="Fa" style="white-space: nowrap;">const char
-  *pin</var>);
+  *dev</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">fido_assert_t
+  *assert</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
+  char *pin</var>);
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
 The <code class="Fn" title="Fn">fido_dev_get_assert</code>() function asks the
-  FIDO device represented by <var class="Fa" title="Fa">dev</var> for an
+  FIDO2 device represented by <var class="Fa" title="Fa">dev</var> for an
   assertion according to the following parameters defined in
   <var class="Fa" title="Fa">assert</var>:
 <div class="Pp"></div>

--- a/content/projects/libfido2/Manuals/fido_dev_get_touch_begin.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_get_touch_begin.partial
@@ -23,7 +23,7 @@
 <h1 class="Sh" title="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
 <code class="Nm" title="Nm">fido_dev_get_touch_begin</code>,
   <code class="Nm" title="Nm">fido_dev_get_touch_status</code> &#x2014;
-<div class="Nd" title="Nd">asynchronously wait for touch on a FIDO 2
+<div class="Nd" title="Nd">asynchronously wait for touch on a FIDO2
   authenticator</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
@@ -42,8 +42,8 @@
   ms</var>);
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
 The functions described in this page allow an application to asynchronously wait
-  for touch on a FIDO authenticator. This is useful when multiple authenticators
-  are present and the application needs to know which one to use.
+  for touch on a FIDO2 authenticator. This is useful when multiple
+  authenticators are present and the application needs to know which one to use.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_dev_get_touch_begin</code>() function
   initiates a touch request on <var class="Fa" title="Fa">dev</var>.

--- a/content/projects/libfido2/Manuals/fido_dev_has_pin.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_has_pin.partial
@@ -1,0 +1,1 @@
+fido_dev_open.partial

--- a/content/projects/libfido2/Manuals/fido_dev_info_manifest.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_info_manifest.partial
@@ -29,8 +29,9 @@
   <code class="Nm" title="Nm">fido_dev_info_product</code>,
   <code class="Nm" title="Nm">fido_dev_info_vendor</code>,
   <code class="Nm" title="Nm">fido_dev_info_manufacturer_string</code>,
-  <code class="Nm" title="Nm">fido_dev_info_product_string</code> &#x2014;
-<div class="Nd" title="Nd">FIDO 2 device discovery functions</div>
+  <code class="Nm" title="Nm">fido_dev_info_product_string</code>,
+  <code class="Nm" title="Nm">fido_dev_info_set</code> &#x2014;
+<div class="Nd" title="Nd">FIDO2 device discovery functions</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
   &lt;<a class="In" title="In">fido.h</a>&gt;</code>
@@ -83,10 +84,23 @@
 <br/>
 <code class="Fn" title="Fn">fido_dev_info_product_string</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_dev_info_t *di</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
+<code class="Fn" title="Fn">fido_dev_info_set</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_dev_info_t
+  *devlist</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">size_t
+  i</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const char
+  *path</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
+  char *manufacturer</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">const char
+  *product</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_dev_io_t *io</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_dev_transport_t *transport</var>);
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
 The <code class="Fn" title="Fn">fido_dev_info_manifest</code>() function fills
   <var class="Fa" title="Fa">devlist</var> with up to
-  <var class="Fa" title="Fa">ilen</var> FIDO devices found by the underlying
+  <var class="Fa" title="Fa">ilen</var> FIDO2 devices found by the underlying
   operating system. Currently only USB HID devices are supported. The number of
   discovered devices is returned in <var class="Fa" title="Fa">olen</var>, where
   <var class="Fa" title="Fa">olen</var> is an addressable pointer.
@@ -138,11 +152,34 @@ The <code class="Fn" title="Fn">fido_dev_info_product_string</code>() function
 An example of how to use the functions described in this document can be found
   in the <span class="Pa" title="Pa">examples/manifest.c</span> file shipped
   with <i class="Em" title="Em">libfido2</i>.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_dev_info_set</code>() function initializes
+  an entry in a device list allocated by
+  <code class="Fn" title="Fn">fido_dev_info_new</code>() with the specified
+  path, manufacturer, and product strings, and with the specified I/O handlers
+  and, optionally, transport functions, as described in
+  <a class="Xr" title="Xr" href="fido_dev_set_io_functions.html">fido_dev_set_io_functions(3)</a>.
+  The <var class="Fa" title="Fa">io</var> argument must be specified; the
+  <var class="Fa" title="Fa">transport</var> argument may be
+  <code class="Dv" title="Dv">NULL</code>. The path, I/O handlers, and transport
+  functions will be used automatically by
+  <a class="Xr" title="Xr" href="fido_dev_new_with_info.html">fido_dev_new_with_info(3)</a>
+  and
+  <a class="Xr" title="Xr" href="fido_dev_open_with_info.html">fido_dev_open_with_info(3)</a>.
+  An application can use this, for example, to substitute mock FIDO2 devices in
+  testing for the real ones that
+  <code class="Fn" title="Fn">fido_dev_info_manifest</code>() would discover.
 <h1 class="Sh" title="Sh" id="RETURN_VALUES"><a class="permalink" href="#RETURN_VALUES">RETURN
   VALUES</a></h1>
 The <code class="Fn" title="Fn">fido_dev_info_manifest</code>() function always
   returns <code class="Dv" title="Dv">FIDO_OK</code>. If a discovery error
   occurs, the <var class="Fa" title="Fa">olen</var> pointer is set to 0.
+<div class="Pp"></div>
+On success, the <code class="Fn" title="Fn">fido_dev_info_set</code>() function
+  returns <code class="Dv" title="Dv">FIDO_OK</code>. On error, a different
+  error code defined in
+  <code class="In" title="In">&lt;<a class="In" title="In">fido/err.h</a>&gt;</code>
+  is returned.
 <div class="Pp"></div>
 The pointers returned by <code class="Fn" title="Fn">fido_dev_info_ptr</code>(),
   <code class="Fn" title="Fn">fido_dev_info_path</code>(),

--- a/content/projects/libfido2/Manuals/fido_dev_info_set.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_info_set.partial
@@ -1,0 +1,1 @@
+fido_dev_info_manifest.partial

--- a/content/projects/libfido2/Manuals/fido_dev_io_handle.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_io_handle.partial
@@ -1,0 +1,1 @@
+fido_dev_set_io_functions.partial

--- a/content/projects/libfido2/Manuals/fido_dev_largeblob_get.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_largeblob_get.partial
@@ -26,7 +26,7 @@
   <code class="Nm" title="Nm">fido_dev_largeblob_remove</code>,
   <code class="Nm" title="Nm">fido_dev_largeblob_get_array</code>,
   <code class="Nm" title="Nm">fido_dev_largeblob_set_array</code> &#x2014;
-<div class="Nd" title="Nd">FIDO 2 large blob API</div>
+<div class="Nd" title="Nd">FIDO2 large blob API</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
   &lt;<a class="In" title="In">fido.h</a>&gt;</code>
@@ -81,8 +81,8 @@
   *pin</var>);
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
 The &#x201C;largeBlobs&#x201D; API of <i class="Em" title="Em">libfido2</i>
-  allows binary blobs residing on a FIDO 2.1 authenticator to be read, written,
-  and inspected. &#x201C;largeBlobs&#x201D; is a FIDO 2.1 extension.
+  allows binary blobs residing on a CTAP 2.1 authenticator to be read, written,
+  and inspected. &#x201C;largeBlobs&#x201D; is a CTAP 2.1 extension.
 <div class="Pp"></div>
 &#x201C;largeBlobs&#x201D; are stored as elements of a CBOR array.
   Confidentiality is ensured by encrypting each element with a distinct,
@@ -102,8 +102,8 @@ Retrieval of a credential's encryption key is possible during enrollment with
 <div class="Pp"></div>
 The &#x201C;largeBlobs&#x201D; CBOR array is opaque to the authenticator.
   Management of the array is left at the discretion of FIDO2 clients. For
-  further details on FIDO 2.1's &#x201C;largeBlobs&#x201D; extension, please
-  refer to the FIDO 2.1 spec.
+  further details on CTAP 2.1's &#x201C;largeBlobs&#x201D; extension, please
+  refer to the CTAP 2.1 spec.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_dev_largeblob_get</code>() function
   retrieves the authenticator's &#x201C;largeBlobs&#x201D; CBOR array and, on

--- a/content/projects/libfido2/Manuals/fido_dev_make_cred.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_make_cred.partial
@@ -22,7 +22,7 @@
 <div class="manual-text">
 <h1 class="Sh" title="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
 <code class="Nm" title="Nm">fido_dev_make_cred</code> &#x2014;
-<div class="Nd" title="Nd">generates a new credential on a FIDO device</div>
+<div class="Nd" title="Nd">generates a new credential on a FIDO2 device</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
   &lt;<a class="In" title="In">fido.h</a>&gt;</code>
@@ -30,13 +30,13 @@
 <var class="Ft" title="Ft">int</var>
 <br/>
 <code class="Fn" title="Fn">fido_dev_make_cred</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_dev_t
-  *dev</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">
-  fido_cred_t *cred</var>,
-  <var class="Fa" title="Fa" style="white-space: nowrap;">const char
-  *pin</var>);
+  *dev</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">fido_cred_t
+  *cred</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
+  char *pin</var>);
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
 The <code class="Fn" title="Fn">fido_dev_make_cred</code>() function asks the
-  FIDO device represented by <var class="Fa" title="Fa">dev</var> to generate a
+  FIDO2 device represented by <var class="Fa" title="Fa">dev</var> to generate a
   new credential according to the following parameters defined in
   <var class="Fa" title="Fa">cred</var>:
 <div class="Pp"></div>

--- a/content/projects/libfido2/Manuals/fido_dev_new_with_info.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_new_with_info.partial
@@ -1,0 +1,1 @@
+fido_dev_open.partial

--- a/content/projects/libfido2/Manuals/fido_dev_open.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_open.partial
@@ -22,9 +22,11 @@
 <div class="manual-text">
 <h1 class="Sh" title="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
 <code class="Nm" title="Nm">fido_dev_open</code>,
+  <code class="Nm" title="Nm">fido_dev_open_with_info</code>,
   <code class="Nm" title="Nm">fido_dev_close</code>,
   <code class="Nm" title="Nm">fido_dev_cancel</code>,
   <code class="Nm" title="Nm">fido_dev_new</code>,
+  <code class="Nm" title="Nm">fido_dev_new_with_info</code>,
   <code class="Nm" title="Nm">fido_dev_free</code>,
   <code class="Nm" title="Nm">fido_dev_force_fido2</code>,
   <code class="Nm" title="Nm">fido_dev_force_u2f</code>,
@@ -32,16 +34,17 @@
   <code class="Nm" title="Nm">fido_dev_is_winhello</code>,
   <code class="Nm" title="Nm">fido_dev_supports_credman</code>,
   <code class="Nm" title="Nm">fido_dev_supports_cred_prot</code>,
+  <code class="Nm" title="Nm">fido_dev_supports_permissions</code>,
   <code class="Nm" title="Nm">fido_dev_supports_pin</code>,
-  <code class="Nm" title="Nm">fido_dev_has_pin</code>,
   <code class="Nm" title="Nm">fido_dev_supports_uv</code>,
+  <code class="Nm" title="Nm">fido_dev_has_pin</code>,
   <code class="Nm" title="Nm">fido_dev_has_uv</code>,
   <code class="Nm" title="Nm">fido_dev_protocol</code>,
   <code class="Nm" title="Nm">fido_dev_build</code>,
   <code class="Nm" title="Nm">fido_dev_flags</code>,
   <code class="Nm" title="Nm">fido_dev_major</code>,
   <code class="Nm" title="Nm">fido_dev_minor</code> &#x2014;
-<div class="Nd" title="Nd">FIDO 2 device open/close and related functions</div>
+<div class="Nd" title="Nd">FIDO2 device open/close and related functions</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
   &lt;<a class="In" title="In">fido.h</a>&gt;</code>
@@ -51,6 +54,11 @@
 <code class="Fn" title="Fn">fido_dev_open</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_dev_t
   *dev</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const char
   *path</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
+<code class="Fn" title="Fn">fido_dev_open_with_info</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_dev_t
+  *dev</var>);
 <div class="Pp"></div>
 <var class="Ft" title="Ft">int</var>
 <br/>
@@ -65,6 +73,11 @@
 <var class="Ft" title="Ft">fido_dev_t *</var>
 <br/>
 <code class="Fn" title="Fn">fido_dev_new</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">void</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">fido_dev_t *</var>
+<br/>
+<code class="Fn" title="Fn">fido_dev_new_with_info</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_dev_info_t *</var>);
 <div class="Pp"></div>
 <var class="Ft" title="Ft">void</var>
 <br/>
@@ -103,17 +116,22 @@
 <div class="Pp"></div>
 <var class="Ft" title="Ft">bool</var>
 <br/>
+<code class="Fn" title="Fn">fido_dev_supports_permissions</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_dev_t *dev</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">bool</var>
+<br/>
 <code class="Fn" title="Fn">fido_dev_supports_pin</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_dev_t *dev</var>);
 <div class="Pp"></div>
 <var class="Ft" title="Ft">bool</var>
 <br/>
-<code class="Fn" title="Fn">fido_dev_has_pin</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+<code class="Fn" title="Fn">fido_dev_supports_uv</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_dev_t *dev</var>);
 <div class="Pp"></div>
 <var class="Ft" title="Ft">bool</var>
 <br/>
-<code class="Fn" title="Fn">fido_dev_supports_uv</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+<code class="Fn" title="Fn">fido_dev_has_pin</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_dev_t *dev</var>);
 <div class="Pp"></div>
 <var class="Ft" title="Ft">bool</var>
@@ -157,6 +175,10 @@ The <code class="Fn" title="Fn">fido_dev_open</code>() function opens the device
   <code class="Dv" title="Dv">FIDO_DISABLE_U2F_FALLBACK</code> flag was set in
   <a class="Xr" title="Xr" href="fido_init.html">fido_init(3)</a>.
 <div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_dev_open_with_info</code>() function opens
+  <var class="Fa" title="Fa">dev</var> as previously allocated using
+  <code class="Fn" title="Fn">fido_dev_new_with_info</code>().
+<div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_dev_close</code>() function closes the
   device represented by <var class="Fa" title="Fa">dev</var>. If
   <var class="Fa" title="Fa">dev</var> is already closed,
@@ -169,6 +191,13 @@ The <code class="Fn" title="Fn">fido_dev_new</code>() function returns a pointer
   to a newly allocated, empty <var class="Vt" title="Vt">fido_dev_t</var>. If
   memory cannot be allocated, NULL is returned.
 <div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_dev_new_with_info</code>() function returns
+  a pointer to a newly allocated <var class="Vt" title="Vt">fido_dev_t</var>
+  with <var class="Vt" title="Vt">fido_dev_info_t</var> parameters, for use with
+  <a class="Xr" title="Xr" href="fido_dev_info_manifest.html">fido_dev_info_manifest(3)</a>
+  and <code class="Fn" title="Fn">fido_dev_open_with_info</code>(). If memory
+  cannot be allocated, NULL is returned.
+<div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_dev_free</code>() function releases the
   memory backing <var class="Fa" title="Fa">*dev_p</var>, where
   <var class="Fa" title="Fa">*dev_p</var> must have been previously allocated by
@@ -179,14 +208,16 @@ The <code class="Fn" title="Fn">fido_dev_free</code>() function releases the
   <code class="Fn" title="Fn">fido_dev_free</code>() is a NOP.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_dev_force_fido2</code>() function can be
-  used to force CTAP2 communication with <var class="Fa" title="Fa">dev</var>.
+  used to force CTAP2 communication with <var class="Fa" title="Fa">dev</var>,
+  where <var class="Fa" title="Fa">dev</var> is an open device.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_dev_force_u2f</code>() function can be used
-  to force CTAP1 (U2F) communication with <var class="Fa" title="Fa">dev</var>.
+  to force CTAP1 (U2F) communication with <var class="Fa" title="Fa">dev</var>,
+  where <var class="Fa" title="Fa">dev</var> is an open device.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_dev_is_fido2</code>() function returns
   <code class="Dv" title="Dv">true</code> if
-  <var class="Fa" title="Fa">dev</var> is a FIDO 2 device.
+  <var class="Fa" title="Fa">dev</var> is a FIDO2 device.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_dev_is_winhello</code>() function returns
   <code class="Dv" title="Dv">true</code> if
@@ -194,24 +225,28 @@ The <code class="Fn" title="Fn">fido_dev_is_winhello</code>() function returns
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_dev_supports_credman</code>() function
   returns <code class="Dv" title="Dv">true</code> if
-  <var class="Fa" title="Fa">dev</var> supports FIDO 2.1 Credential Management.
+  <var class="Fa" title="Fa">dev</var> supports CTAP 2.1 Credential Management.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_dev_supports_cred_prot</code>() function
   returns <code class="Dv" title="Dv">true</code> if
-  <var class="Fa" title="Fa">dev</var> supports FIDO 2.1 Credential Protection.
+  <var class="Fa" title="Fa">dev</var> supports CTAP 2.1 Credential Protection.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_dev_supports_permissions</code>() function
+  returns <code class="Dv" title="Dv">true</code> if
+  <var class="Fa" title="Fa">dev</var> supports CTAP 2.1 UV token permissions.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_dev_supports_pin</code>() function returns
   <code class="Dv" title="Dv">true</code> if
-  <var class="Fa" title="Fa">dev</var> supports FIDO 2.0 Client PINs.
-<div class="Pp"></div>
-The <code class="Fn" title="Fn">fido_dev_has_pin</code>() function returns
-  <code class="Dv" title="Dv">true</code> if
-  <var class="Fa" title="Fa">dev</var> has a FIDO 2.0 Client PIN set.
+  <var class="Fa" title="Fa">dev</var> supports CTAP 2.0 Client PINs.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_dev_supports_uv</code>() function returns
   <code class="Dv" title="Dv">true</code> if
   <var class="Fa" title="Fa">dev</var> supports a built-in user verification
   method.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_dev_has_pin</code>() function returns
+  <code class="Dv" title="Dv">true</code> if
+  <var class="Fa" title="Fa">dev</var> has a CTAP 2.0 Client PIN set.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_dev_has_uv</code>() function returns
   <code class="Dv" title="Dv">true</code> if
@@ -238,7 +273,8 @@ For the format and meaning of the CTAPHID parameters returned by functions
   specification.
 <h1 class="Sh" title="Sh" id="RETURN_VALUES"><a class="permalink" href="#RETURN_VALUES">RETURN
   VALUES</a></h1>
-On success, <code class="Fn" title="Fn">fido_dev_open</code>() and
+On success, <code class="Fn" title="Fn">fido_dev_open</code>(),
+  <code class="Fn" title="Fn">fido_dev_open_with_info</code>(), and
   <code class="Fn" title="Fn">fido_dev_close</code>() return
   <code class="Dv" title="Dv">FIDO_OK</code>. On error, a different error code
   defined in

--- a/content/projects/libfido2/Manuals/fido_dev_open_with_info.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_open_with_info.partial
@@ -1,0 +1,1 @@
+fido_dev_open.partial

--- a/content/projects/libfido2/Manuals/fido_dev_set_io_functions.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_set_io_functions.partial
@@ -23,8 +23,10 @@
 <h1 class="Sh" title="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
 <code class="Nm" title="Nm">fido_dev_set_io_functions</code>,
   <code class="Nm" title="Nm">fido_dev_set_sigmask</code>,
-  <code class="Nm" title="Nm">fido_dev_set_timeout</code> &#x2014;
-<div class="Nd" title="Nd">FIDO 2 device I/O interface</div>
+  <code class="Nm" title="Nm">fido_dev_set_timeout</code>,
+  <code class="Nm" title="Nm">fido_dev_set_transport_functions</code>,
+  <code class="Nm" title="Nm">fido_dev_io_handle</code> &#x2014;
+<div class="Nd" title="Nd">FIDO2 device I/O interface</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
   &lt;<a class="In" title="In">fido.h</a>&gt;</code>
@@ -47,9 +49,20 @@ typedef struct fido_dev_io {
 typedef int fido_sigset_t; 
 #else 
 typedef sigset_t fido_sigset_t; 
-#endif
+#endif 
+ 
+typedef int   fido_dev_rx_t(struct fido_dev *, 
+                  uint8_t, unsigned char *, size_t, int); 
+typedef int   fido_dev_tx_t(struct fido_dev *, 
+                  uint8_t, const unsigned char *, size_t); 
+ 
+typedef struct fido_dev_transport { 
+	fido_dev_rx_t *rx; 
+	fido_dev_tx_t *tx; 
+} fido_dev_transport_t;
 </pre>
 </div>
+<div class="Pp"></div>
 <br/>
 <var class="Ft" title="Ft">int</var>
 <br/>
@@ -68,6 +81,17 @@ typedef sigset_t fido_sigset_t;
 <code class="Fn" title="Fn">fido_dev_set_timeout</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_dev_t
   *dev</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">int
   ms</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
+<code class="Fn" title="Fn">fido_dev_set_transport_functions</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_dev_t
+  *dev</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_dev_transport_t *t</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">void *</var>
+<br/>
+<code class="Fn" title="Fn">fido_dev_io_handle</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_dev_t *dev</var>);
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
 The <code class="Fn" title="Fn">fido_dev_set_io_functions</code>() function sets
   the I/O handlers used by <i class="Em" title="Em">libfido2</i> to talk to
@@ -137,15 +161,62 @@ The <code class="Fn" title="Fn">fido_dev_set_timeout</code>() function informs
   default behaviour. When using the Windows Hello backend,
   <var class="Fa" title="Fa">ms</var> is used as a guidance and may be
   overwritten by the platform.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_dev_set_transport_functions</code>()
+  function sets the transport functions used by
+  <i class="Em" title="Em">libfido2</i> to talk to
+  <var class="Fa" title="Fa">dev</var>. While the I/O handlers are responsible
+  for sending and receiving transmission units of initialization and
+  continuation packets already formatted by
+  <i class="Em" title="Em">libfido2</i>, the transport handlers are responsible
+  for sending and receiving the CTAPHID commands and data directly, as defined
+  in the FIDO Client to Authenticator Protocol (CTAP) standard. They are defined
+  as follows:
+<dl class="Bl-tag">
+  <dt><var class="Vt" title="Vt">fido_dev_tx_t</var></dt>
+  <dd>Receives a device, a CTAPHID command to transmit, a data buffer to
+      transmit, and the length of the data buffer. On success, 0 is returned. On
+      error, -1 is returned.</dd>
+  <dt><var class="Vt" title="Vt">fido_dev_rx_t</var></dt>
+  <dd>Receives a device, a CTAPHID command whose response the caller expects to
+      receive, a data buffer to receive into, the size of the data buffer
+      determining the maximum length of a response, and the maximum number of
+      milliseconds to wait for a response. On success, the number of bytes read
+      into the data buffer is returned. On error, -1 is returned.</dd>
+</dl>
+<div class="Pp"></div>
+When transport functions are specified, <i class="Em" title="Em">libfido2</i>
+  will use them instead of the <code class="Dv" title="Dv">read</code> and
+  <code class="Dv" title="Dv">write</code> functions of the I/O handlers.
+  However, the I/O handlers must still be specified to open and close the
+  device.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_dev_io_handle</code>() function returns the
+  opaque pointer returned by the <code class="Dv" title="Dv">open</code>
+  function of the I/O handlers. This is useful mainly for the transport
+  functions, which unlike the I/O handlers are passed the
+  <var class="Vt" title="Vt">fido_dev_t</var> pointer instead of the opaque I/O
+  handle.
 <h1 class="Sh" title="Sh" id="RETURN_VALUES"><a class="permalink" href="#RETURN_VALUES">RETURN
   VALUES</a></h1>
 On success, <code class="Fn" title="Fn">fido_dev_set_io_functions</code>(),
+  <code class="Fn" title="Fn">fido_dev_set_transport_functions</code>(),
   <code class="Fn" title="Fn">fido_dev_set_sigmask</code>(), and
   <code class="Fn" title="Fn">fido_dev_set_timeout</code>() return
   <code class="Dv" title="Dv">FIDO_OK</code>. On error, a different error code
   defined in
   <code class="In" title="In">&lt;<a class="In" title="In">fido/err.h</a>&gt;</code>
-  is returned.</div>
+  is returned.
+<h1 class="Sh" title="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
+  ALSO</a></h1>
+<a class="Xr" title="Xr" href="fido_dev_info_manifest.html">fido_dev_info_manifest(3)</a>,
+  <a class="Xr" title="Xr" href="fido_dev_open.html">fido_dev_open(3)</a>
+<div class="Pp"></div>
+<cite class="Rs" title="Rs"><span class="RsR">Client to Authenticator Protocol
+  (CTAP)</span>,
+  <a class="RsU" href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html">https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html</a>,
+  <span class="RsQ">FIDO Alliance</span>, <span class="RsD">2021-06-15</span>,
+  <span class="RsO">Proposed Standard, Version 2.1</span>.</cite></div>
 <table class="foot">
   <tr>
     <td class="foot-date">May 25, 2018</td>

--- a/content/projects/libfido2/Manuals/fido_dev_set_pin.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_set_pin.partial
@@ -25,7 +25,7 @@
   <code class="Nm" title="Nm">fido_dev_get_retry_count</code>,
   <code class="Nm" title="Nm">fido_dev_get_uv_retry_count</code>,
   <code class="Nm" title="Nm">fido_dev_reset</code> &#x2014;
-<div class="Nd" title="Nd">FIDO 2 device management functions</div>
+<div class="Nd" title="Nd">FIDO2 device management functions</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
   &lt;<a class="In" title="In">fido.h</a>&gt;</code>

--- a/content/projects/libfido2/Manuals/fido_dev_set_transport_functions.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_set_transport_functions.partial
@@ -1,0 +1,1 @@
+fido_dev_set_io_functions.partial

--- a/content/projects/libfido2/Manuals/fido_dev_supports_permissions.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_supports_permissions.partial
@@ -1,0 +1,1 @@
+fido_dev_open.partial

--- a/content/projects/libfido2/Manuals/fido_init.partial
+++ b/content/projects/libfido2/Manuals/fido_init.partial
@@ -21,16 +21,29 @@
 </table>
 <div class="manual-text">
 <h1 class="Sh" title="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
-<code class="Nm" title="Nm">fido_init</code> &#x2014;
-<div class="Nd" title="Nd">initialise the FIDO 2 library</div>
+<code class="Nm" title="Nm">fido_init</code>,
+  <code class="Nm" title="Nm">fido_set_log_handler</code> &#x2014;
+<div class="Nd" title="Nd">initialise the FIDO2 library</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
   &lt;<a class="In" title="In">fido.h</a>&gt;</code>
 <div class="Pp"></div>
+<div class="Bd">
+<pre class="Li">
+typedef void fido_log_handler_t(const char *);
+</pre>
+</div>
+<div class="Pp"></div>
+<br/>
 <var class="Ft" title="Ft">void</var>
 <br/>
 <code class="Fn" title="Fn">fido_init</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">int
   flags</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">void</var>
+<br/>
+<code class="Fn" title="Fn">fido_set_log_handler</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_log_handler_t
+  *handler</var>);
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
 The <code class="Fn" title="Fn">fido_init</code>() function initialises the
   <i class="Em" title="Em">libfido2</i> library. Its invocation must precede
@@ -47,7 +60,14 @@ If <code class="Dv" title="Dv">FIDO_DISABLE_U2F_FALLBACK</code> is set in
   <var class="Fa" title="Fa">flags</var>, then
   <i class="Em" title="Em">libfido2</i> will not fallback to U2F in
   <a class="Xr" title="Xr" href="fido_dev_open.html">fido_dev_open(3)</a> if a
-  device claims to be FIDO2 but fails to respond to a FIDO2 command.
+  device claims to support FIDO2 but fails to respond to a CTAP 2.0 greeting.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_set_log_handler</code>() function causes
+  <var class="Fa" title="Fa">handler</var> to be called for each log line
+  generated in the context of the executing thread. Lines passed to
+  <var class="Fa" title="Fa">handler</var> include a trailing newline character
+  and are not printed by <i class="Em" title="Em">libfido2</i> on
+  <i class="Em" title="Em">stderr</i>.
 <h1 class="Sh" title="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
 <a class="Xr" title="Xr" href="fido_assert_new.html">fido_assert_new(3)</a>,

--- a/content/projects/libfido2/Manuals/fido_set_log_handler.partial
+++ b/content/projects/libfido2/Manuals/fido_set_log_handler.partial
@@ -1,0 +1,1 @@
+fido_init.partial

--- a/content/projects/libfido2/Manuals/fido_strerr.partial
+++ b/content/projects/libfido2/Manuals/fido_strerr.partial
@@ -22,7 +22,7 @@
 <div class="manual-text">
 <h1 class="Sh" title="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
 <code class="Nm" title="Nm">fido_strerr</code> &#x2014;
-<div class="Nd" title="Nd">FIDO 2 error codes</div>
+<div class="Nd" title="Nd">FIDO2 error codes</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
   &lt;<a class="In" title="In">fido.h</a>&gt;</code>

--- a/content/projects/libfido2/Manuals/rs256_pk_new.partial
+++ b/content/projects/libfido2/Manuals/rs256_pk_new.partial
@@ -23,11 +23,11 @@
 <h1 class="Sh" title="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
 <code class="Nm" title="Nm">rs256_pk_new</code>,
   <code class="Nm" title="Nm">rs256_pk_free</code>,
-  <code class="Nm" title="Nm">rs256_pk_from_EVP_PKEY</code>,
   <code class="Nm" title="Nm">rs256_pk_from_RSA</code>,
+  <code class="Nm" title="Nm">rs256_pk_from_EVP_PKEY</code>,
   <code class="Nm" title="Nm">rs256_pk_from_ptr</code>,
   <code class="Nm" title="Nm">rs256_pk_to_EVP_PKEY</code> &#x2014;
-<div class="Nd" title="Nd">FIDO 2 COSE RS256 API</div>
+<div class="Nd" title="Nd">FIDO2 COSE RS256 API</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
   &lt;<a class="In" title="In">openssl/rsa.h</a>&gt;</code>


### PR DESCRIPTION
- new API calls:
  * fido_dev_info_set(3);
  * fido_dev_io_handle(3);
  * fido_dev_new_with_info(3);
  * fido_dev_open_with_info(3).
- add aliases for:
  * eddsa_pk_from_EVP_PKEY(3);
  * fido_assert_set_authdata_raw(3);
  * fido_dev_has_pin(3).
- add documentation for:
  * fido_cred_verify_self(3);
  * fido_dev_supports_permissions(3);
  * fido_set_log_handler(3).
- clarify fido_dev_force_{fido2,u2f};
- assorted consistency, concision, and clarity fixes.