### PR TITLE
yubihsm: rename old audit capability to get-log-entries

### DIFF
--- a/content/YubiHSM2/Usage_Guides/Admin_guide.adoc
+++ b/content/YubiHSM2/Usage_Guides/Admin_guide.adoc
@@ -87,7 +87,7 @@ yubihsm> session open 1 password
 Created session 0
 
 # Create an Authentication Key for Auditing
-yubihsm> put authkey 0 0 "Audit auth key" all audit none $AUDIT_PASS
+yubihsm> put authkey 0 0 "Audit auth key" all get-log-entries none $AUDIT_PASS
 Stored Authentication key 0xd054
 
 # Optionally enable forced audits


### PR DESCRIPTION
Update the documentation to reflect the name changes from v2.0.0.

https://developers.yubico.com/yubihsm-shell/API_Changes.html

Closes #449.