### PR TITLE
yhsm: documentation, fix typo in key IDs

### DIFF
--- a/content/YubiHSM2/Backup_and_Restore/index.adoc
+++ b/content/YubiHSM2/Backup_and_Restore/index.adoc
@@ -24,7 +24,7 @@ When this Wrap Key is present, any Object in the same Domain and with the Capabi
 $ yubihsm-shell -a generate-asymmetric-key -A rsa2048 -c exportable-under-wrap,sign-pkcs,decrypt-pkcs
 ...
 Generated Asymmetric key 0x6e77
-$ yubihsm-shell -a get-wrapped --wrap-id=0x6e77 --object-id=0xd581 -t asymmetric-key --out=key_6e77.yhw
+$ yubihsm-shell -a get-wrapped --wrap-id=0xd581 --object-id=0x6e77 -t asymmetric-key --out=key_6e77.yhw
 ...
 ----
 


### PR DESCRIPTION
The ID of the Wrap key and of the object to be exported were swapped
around in the "Backup and Restore" guide.

Closes Yubico/yubihsm-shell#248.