### PR TITLE
libfido2: sync docs with 1.11.0

### DIFF
--- a/content/projects/libfido2/Manuals/fido2-token.partial
+++ b/content/projects/libfido2/Manuals/fido2-token.partial
@@ -272,8 +272,8 @@ The options are as follows:
   <dd>Deletes a &#x201C;largeBlob&#x201D; encrypted with
       <var class="Ar" title="Ar">key_path</var> from
       <var class="Ar" title="Ar">device</var>, where
-      <var class="Ar" title="Ar">key_path</var> must hold the blob's
-      base64-encoded encryption key. A PIN or equivalent user-verification
+      <var class="Ar" title="Ar">key_path</var> holds the blob's base64-encoded
+      32-byte AES-256 GCM encryption key. A PIN or equivalent user-verification
       gesture is required.</dd>
   <dt><a class="permalink" href="#D_3"><code class="Fl" title="Fl" id="D_3">-D</code></a>
     <code class="Fl" title="Fl">-b</code> <code class="Fl" title="Fl">-n</code>
@@ -312,8 +312,8 @@ The options are as follows:
   <dd>Gets a CTAP 2.1 &#x201C;largeBlob&#x201D; encrypted with
       <var class="Ar" title="Ar">key_path</var> from
       <var class="Ar" title="Ar">device</var>, where
-      <var class="Ar" title="Ar">key_path</var> must hold the blob's
-      base64-encoded encryption key. The blob is written to
+      <var class="Ar" title="Ar">key_path</var> holds the blob's base64-encoded
+      32-byte AES-256 GCM encryption key. The blob is written to
       <var class="Ar" title="Ar">blob_path</var>. A PIN or equivalent
       user-verification gesture is required.</dd>
   <dt><a class="permalink" href="#G_2"><code class="Fl" title="Fl" id="G_2">-G</code></a>
@@ -398,14 +398,13 @@ The options are as follows:
     <var class="Ar" title="Ar">key_path</var>
     <var class="Ar" title="Ar">blob_path</var>
     <var class="Ar" title="Ar">device</var></dt>
-  <dd>Sets <var class="Ar" title="Ar">blob_path</var> as a CTAP 2.1
-      &#x201C;largeBlob&#x201D; encrypted with
+  <dd>Sets a CTAP 2.1 &#x201C;largeBlob&#x201D; encrypted with
       <var class="Ar" title="Ar">key_path</var> on
       <var class="Ar" title="Ar">device</var>, where
-      <var class="Ar" title="Ar">blob_path</var> holds the blob's plaintext, and
-      <var class="Ar" title="Ar">key_path</var> the blob's base64-encoded
-      encryption. A PIN or equivalent user-verification gesture is
-    required.</dd>
+      <var class="Ar" title="Ar">key_path</var> holds the blob's base64-encoded
+      32-byte AES-256 GCM encryption key. The blob is read from
+      <var class="Fa" title="Fa">blob_path</var>. A PIN or equivalent
+      user-verification gesture is required.</dd>
   <dt><a class="permalink" href="#S_4"><code class="Fl" title="Fl" id="S_4">-S</code></a>
     <code class="Fl" title="Fl">-b</code> <code class="Fl" title="Fl">-n</code>
     <var class="Ar" title="Ar">rp_id</var>
@@ -413,10 +412,10 @@ The options are as follows:
     <var class="Ar" title="Ar">cred_id</var></div>]
     <var class="Ar" title="Ar">blob_path</var>
     <var class="Ar" title="Ar">device</var></dt>
-  <dd>Sets <var class="Ar" title="Ar">blob_path</var> as a CTAP 2.1
-      &#x201C;largeBlob&#x201D; associated with
+  <dd>Sets a CTAP 2.1 &#x201C;largeBlob&#x201D; associated with
       <var class="Ar" title="Ar">rp_id</var> on
-      <var class="Ar" title="Ar">device</var>. If
+      <var class="Ar" title="Ar">device</var>. The blob is read from
+      <var class="Fa" title="Fa">blob_path</var>. If
       <var class="Ar" title="Ar">rp_id</var> has multiple credentials enrolled
       on <var class="Ar" title="Ar">device</var>, the credential ID must be
       specified using <code class="Fl" title="Fl">-i</code>
@@ -517,7 +516,7 @@ Whether the CTAP 2.1 &#x201C;user verification always&#x201D; feature is
   vendor-specific.</div>
 <table class="foot">
   <tr>
-    <td class="foot-date">September 13, 2019</td>
-    <td class="foot-os">Linux 5.3.12-arch1-1</td>
+    <td class="foot-date">April 11, 2022</td>
+    <td class="foot-os">Linux 5.17.4-200.fc35.x86_64</td>
   </tr>
 </table>

--- a/content/projects/libfido2/Manuals/fido_assert_new.partial
+++ b/content/projects/libfido2/Manuals/fido_assert_new.partial
@@ -252,7 +252,9 @@ The <code class="Fn" title="Fn">fido_assert_hmac_secret_ptr</code>() function
   returns a pointer to the hmac-secret attribute of statement
   <var class="Fa" title="Fa">idx</var> in
   <var class="Fa" title="Fa">assert</var>. The HMAC Secret Extension
-  (hmac-secret) is a CTAP 2.0 extension.
+  (hmac-secret) is a CTAP 2.0 extension. Note that the resulting hmac-secret
+  varies according to whether user verification was performed by the
+  authenticator.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_assert_blob_ptr</code>() and
   <code class="Fn" title="Fn">fido_assert_largeblob_key_ptr</code>() functions
@@ -309,7 +311,7 @@ The <code class="Fn" title="Fn">fido_assert_rp_id</code>(),
   <a class="Xr" title="Xr" href="fido_dev_largeblob_get.html">fido_dev_largeblob_get(3)</a></div>
 <table class="foot">
   <tr>
-    <td class="foot-date">October 22, 2019</td>
-    <td class="foot-os">Linux 5.3.12-arch1-1</td>
+    <td class="foot-date">April 27, 2022</td>
+    <td class="foot-os">Linux 5.17.4-200.fc35.x86_64</td>
   </tr>
 </table>

--- a/content/projects/libfido2/Manuals/fido_assert_set_authdata.partial
+++ b/content/projects/libfido2/Manuals/fido_assert_set_authdata.partial
@@ -205,7 +205,8 @@ The <code class="Fn" title="Fn">fido_assert_set_hmac_salt</code>() and
   <var class="Fa" title="Fa">len</var> bytes. A copy of
   <var class="Fa" title="Fa">ptr</var> is made, and no references to the passed
   pointer are kept. The HMAC Secret (hmac-secret) Extension is a CTAP 2.0
-  extension. The
+  extension. Note that the resulting hmac-secret varies according to whether
+  user verification was performed by the authenticator. The
   <code class="Fn" title="Fn">fido_assert_set_hmac_secret</code>() function is
   normally only useful when writing tests.
 <div class="Pp"></div>
@@ -246,7 +247,7 @@ The <code class="Nm" title="Nm">fido_assert_set_authdata</code> functions return
   <a class="Xr" title="Xr" href="fido_dev_get_assert.html">fido_dev_get_assert(3)</a></div>
 <table class="foot">
   <tr>
-    <td class="foot-date">May 23, 2018</td>
-    <td class="foot-os">Linux 5.3.12-arch1-1</td>
+    <td class="foot-date">April 27, 2022</td>
+    <td class="foot-os">Linux 5.17.4-200.fc35.x86_64</td>
   </tr>
 </table>

--- a/content/projects/libfido2/Manuals/fido_cbor_info_maxlargeblob.partial
+++ b/content/projects/libfido2/Manuals/fido_cbor_info_maxlargeblob.partial
@@ -1,0 +1,1 @@
+fido_cbor_info_new.partial

--- a/content/projects/libfido2/Manuals/fido_cbor_info_new.partial
+++ b/content/projects/libfido2/Manuals/fido_cbor_info_new.partial
@@ -44,6 +44,7 @@
   <code class="Nm" title="Nm">fido_cbor_info_maxcredbloblen</code>,
   <code class="Nm" title="Nm">fido_cbor_info_maxcredcntlst</code>,
   <code class="Nm" title="Nm">fido_cbor_info_maxcredidlen</code>,
+  <code class="Nm" title="Nm">fido_cbor_info_maxlargeblob</code>,
   <code class="Nm" title="Nm">fido_cbor_info_fwversion</code> &#x2014;
 <div class="Nd" title="Nd">FIDO2 CBOR Info API</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
@@ -170,6 +171,11 @@
 <div class="Pp"></div>
 <var class="Ft" title="Ft">uint64_t</var>
 <br/>
+<code class="Fn" title="Fn">fido_cbor_info_maxlargeblob</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cbor_info_t *ci</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">uint64_t</var>
+<br/>
 <code class="Fn" title="Fn">fido_cbor_info_fwversion</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_cbor_info_t *ci</var>);
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
@@ -246,6 +252,10 @@ The <code class="Fn" title="Fn">fido_cbor_info_maxcredidlen</code>() function
   returns the maximum supported length of a credential ID as reported in
   <var class="Fa" title="Fa">ci</var>.
 <div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_cbor_info_maxlargeblob</code>() function
+  returns the maximum length in bytes of an authenticator's serialized largeBlob
+  array as reported in <var class="Fa" title="Fa">ci</var>.
+<div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_cbor_info_fwversion</code>() function
   returns the firmware version attribute of <var class="Fa" title="Fa">ci</var>.
 <div class="Pp"></div>
@@ -271,7 +281,7 @@ The <code class="Fn" title="Fn">fido_cbor_info_aaguid_ptr</code>(),
 <a class="Xr" title="Xr" href="fido_dev_open.html">fido_dev_open(3)</a></div>
 <table class="foot">
   <tr>
-    <td class="foot-date">May 24, 2018</td>
-    <td class="foot-os">Linux 5.3.12-arch1-1</td>
+    <td class="foot-date">April 22, 2022</td>
+    <td class="foot-os">Linux 5.17.4-200.fc35.x86_64</td>
   </tr>
 </table>

--- a/content/projects/libfido2/Manuals/fido_dev_enable_entattest.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_enable_entattest.partial
@@ -89,10 +89,10 @@ The <code class="Fn" title="Fn">fido_dev_toggle_always_uv</code>() function
   <var class="Fa" title="Fa">pin</var> parameter may be NULL if
   <var class="Fa" title="Fa">dev</var> does not have a PIN set.
 <div class="Pp"></div>
-The <code class="Fn" title="Fn">fido_dev_force_pin_change</code>() instructs
-  <var class="Fa" title="Fa">dev</var> to require a PIN change. Subsequent PIN
-  authentication attempts against <var class="Fa" title="Fa">dev</var> will fail
-  until its PIN is changed.
+The <code class="Fn" title="Fn">fido_dev_force_pin_change</code>() function
+  instructs <var class="Fa" title="Fa">dev</var> to require a PIN change.
+  Subsequent PIN authentication attempts against
+  <var class="Fa" title="Fa">dev</var> will fail until its PIN is changed.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_dev_set_pin_minlen</code>() function sets
   the minimum PIN length of <var class="Fa" title="Fa">dev</var> to
@@ -130,7 +130,7 @@ The error codes returned by
   <a class="Xr" title="Xr" href="fido_dev_reset.html">fido_dev_reset(3)</a></div>
 <table class="foot">
   <tr>
-    <td class="foot-date">September 22, 2020</td>
-    <td class="foot-os">Debian</td>
+    <td class="foot-date">March 30, 2022</td>
+    <td class="foot-os">Linux 5.17.4-200.fc35.x86_64</td>
   </tr>
 </table>

--- a/content/projects/libfido2/Manuals/fido_dev_info_manifest.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_info_manifest.partial
@@ -126,7 +126,7 @@ The <code class="Fn" title="Fn">fido_dev_info_ptr</code>() function returns a
   ensure that <var class="Fa" title="Fa">i</var> is bounded. Please note that
   the first slot has index 0.
 <div class="Pp"></div>
-The <code class="Fn" title="Fn">fido_dev_info_path</code>() returns the
+The <code class="Fn" title="Fn">fido_dev_info_path</code>() function returns the
   filesystem path or subsystem-specific identification string of
   <var class="Fa" title="Fa">di</var>.
 <div class="Pp"></div>
@@ -190,7 +190,7 @@ The pointers returned by <code class="Fn" title="Fn">fido_dev_info_ptr</code>(),
   corresponding device list.</div>
 <table class="foot">
   <tr>
-    <td class="foot-date">May 25, 2018</td>
-    <td class="foot-os">Linux 5.3.12-arch1-1</td>
+    <td class="foot-date">March 30, 2022</td>
+    <td class="foot-os">Linux 5.17.4-200.fc35.x86_64</td>
   </tr>
 </table>


### PR DESCRIPTION
- new API call: fido_cbor_info_maxlargeblob(3);
- clarify wording around largeblobs in fido2-token(1);
- mention that hmac-secret varies with UV;
- miscellaneous fixes.