### PR TITLE
fix: URL encode '/' in expected HMAC signature

### DIFF
--- a/content/OTP/Specifications/Test_vectors.adoc
+++ b/content/OTP/Specifications/Test_vectors.adoc
@@ -26,7 +26,7 @@ These are static test vectors for the HMAC that is used for both requests and re
 
 |mG5be6ZJU1qBGz24yPh/ESM3UdU=
 |id=1&otp=vvungrrdhvtklknvrtvuvbbkeidikkvgglrvdgrfcdft&nonce=jrFwbaYFhn0HoxZIsd9LQ6w2ceU
-|h=%2Bja8S3IjbX593/LAgTBixwPNGX4%3D
+|h=%2Bja8S3IjbX593%2FLAgTBixwPNGX4%3D
 |=================
 
 === Responses


### PR DESCRIPTION
Any standard URL encoding implementation will also URL encode a '/' in a string.
It was confusing to me why the example showed some of the special characters being url encoded ('+' and '=') and some not ('/').

Tested using _api.yubico.com/wsapi/2.0/verify_ and it works fine with the '/' encoded as well as un-encoded.