### PR TITLE
Updated WebAuthn Compatibility Table - Adding USB-C for iPadOS 

### DIFF
--- a/content/WebAuthn/WebAuthn_Browser_Support/index.adoc
+++ b/content/WebAuthn/WebAuthn_Browser_Support/index.adoc
@@ -75,26 +75,27 @@ U2F Legacy Support
 *If a PIN is already set on the YubiKey, then a browser will display a PIN prompt only when creating a credential and when user verification has not been requested.
 Any request for user verification will fail if there is no PIN set on the YubiKey.
 
-=== iPadOS 14.6 ===
-Verified with iPad 6th generation (not iPad Pro)
+=== iPadOS 15.5 ===
+Verified with iPad 6th generation (Lightning), iPad Air (USB-C) 4th generation, and iPad Pro 2018 (USB-C)
 
 Most browsers on Apple mobile devices use link:https://developer.apple.com/documentation/webkit[Apple WebKit]. As such, these browsers will have all the same functionality available.
 
 NFC tests have been excluded since NFC is not supported on iPadOS browsers.
+USB-C is only available on iPad Pro and 4th and 5th generation iPad Air models.
 
 [%header,cols="^.^,^.,^.,^.,^.,^."]
 |===
 2+|Browser |User Presence (touch) |Resident Key / Discoverable Credential |User Verification (PIN / Biometric) |CTAP 1 /
 U2F Legacy Support
-.2+|*Safari 14.6** |Lightning  a|image::group-4.png[] a|image::group-4.png[] a|image::group-4.png[] a|image::group-4.png[]
+.3+|*Safari 14.6** |Lightning  a|image::group-4.png[] a|image::group-4.png[] a|image::group-4.png[] a|image::group-4.png[]
+^.^|USB-C a|image::group-4.png[] a|image::group-4.png[] a|image::group-4.png[] a|image::group-4.png[]
 ^.^|NFC a|N/A a|N/A a|N/A a|N/A
 .2+|*Chrome 91** |Lightning  a|image::group-4.png[] a|image::group-4.png[] a|image::group-4.png[] a|image::group-4.png[]
 ^.^|NFC a|N/A a|N/A a|N/A a|N/A
 .2+|*Firefox 34.2** |Lightning  a|image::group-4.png[] a|image::group-4.png[] a|image::group-4.png[] a|image::group-4.png[]
 ^.^|NFC a|N/A a|N/A a|N/A a|N/A
 |===
-*If a PIN is already set on the YubiKey, then a browser will display a PIN prompt only when creating a credential and when user verification has not been requested.
-Any request for user verification will fail if there is no PIN set on the YubiKey.
+*If a PIN is already set on the YubiKey, then a browser will display a PIN prompt only when creating a credential and when user verification has not been requested. Any request for user verification will fail if there is no PIN set on the YubiKey.
 
 === Android 11 ===
 Verified with Pixel 3a


### PR DESCRIPTION
Added USB-C iPad for WebAuthn using iPadOS Safari browser