### PR TITLE
Change default branch for yubikit-android 

### DIFF
--- a/content/Mobile/Android/index.adoc
+++ b/content/Mobile/Android/index.adoc
@@ -27,7 +27,7 @@ The pre-release version of the YubiKit Android SDK supported a subset of FIDO2 f
 
 1. Pick up a link:https://www.yubico.com/products/compare-products-series/[YubiKey or a Security Key by Yubico].
 
-2. Use the link:https://github.com/Yubico/yubikit-android/tree/master/AndroidDemo[YubiKit Demo App] to learn how to integrate the YubiKit for Android with your app.
+2. Use the link:https://github.com/Yubico/yubikit-android/tree/main/AndroidDemo[YubiKit Demo App] to learn how to integrate the YubiKit for Android with your app.
 
 3. Instructions for integrating and using the library are in the link:https://github.com/Yubico/yubikit-android#readme[README file] in the root folder of the yubikit-android page on GitHub.
 

--- a/content/projects/yubikit-android/.conf.json
+++ b/content/projects/yubikit-android/.conf.json
@@ -2,7 +2,8 @@
   "template": {
     "inherit": {
       "github": {
-        "name": "yubikit-android"
+        "name": "yubikit-android",
+        "branch": "main"
       }
     }
   },


### PR DESCRIPTION
We are changing default branch name for `yubikit-android` from `master` to `main` and this PR reflects is in d.y.c.