### PR TITLE
yhsm: specify the existence of a nul byte in the encrypted data

### DIFF
--- a/content/YubiHSM2/Commands/Wrap_Data.adoc
+++ b/content/YubiHSM2/Commands/Wrap_Data.adoc
@@ -31,13 +31,13 @@ D := Data to be wrapped
 
 |===========
 |T~r~ = 0xe8
-|L~r~ = 13 + L~D~ + 16
-|V~r~ = N \|\| D \|\| M
+|L~r~ = 13 + 1 + L~D~ + 16
+|V~r~ = N \|\| W \|\| M
 |===========
 
 N := Nonce (13 bytes)
 
-D := Wrapped data
+W := Wrapped data (`L~W~ = 1 + L~D~` bytes)
 
 The wrapped data includes a leading encrypted nul byte that is added
 automatically by the YubiHSM2. This byte is checked by `UNWRAP DATA`

--- a/content/YubiHSM2/Commands/Wrap_Data.adoc
+++ b/content/YubiHSM2/Commands/Wrap_Data.adoc
@@ -39,4 +39,9 @@ N := Nonce (13 bytes)
 
 D := Wrapped data
 
+The wrapped data includes a leading encrypted nul byte that is added
+automatically by the YubiHSM2. This byte is checked by `UNWRAP DATA`
+and therefore must be added if manually generating an encrypted
+message offline.
+
 M := Mac (16 bytes)


### PR DESCRIPTION
 The `WRAP_DATA` command adds a nul byte to the provided data. This byte must be present when feeding encrypted data to `UNWRAP DATA` and must be explicitly added when manually encrypting data outside of the device.