### PR TITLE
de-duplicate backticks when formatting is constrained

### DIFF
--- a/content/OATH/OATH_Walk-Through.adoc
+++ b/content/OATH/OATH_Walk-Through.adoc
@@ -41,7 +41,7 @@ a) Build the APK to install on the Android device. From the device command line,
 $ ./gradlew assemble
 ....
 
-The compiled file is stored in the directory, ``app/build/outputs/apk``.
+The compiled file is stored in the directory, `app/build/outputs/apk`.
 
 b) Manage OATH credentials by command. See link:https://developers.yubico.com/OATH/YKOATH_Protocol.html[YKOATH protocol specification]. The YKOATH protocol includes commands for: Select, Put, Delete, Set Code, Reset, List, Calculate, Validate, Calculate All, Send Remaining.
 
@@ -61,7 +61,7 @@ The link:https://developers.yubico.com/yubioath-desktop/[Yubico Authenticator fo
 * macOS High Sierra 10.13 or later
 * Ubuntu 16.04 LTS or later
 
-**Step 2**: For Linux, ensure the ``pcscd`` service is installed and running.
+**Step 2**: For Linux, ensure the `pcscd` service is installed and running.
 
 **Step 3**:	If using USB, verify USB connection requirements:
 

--- a/content/PGP/SSH_authentication/Windows.adoc
+++ b/content/PGP/SSH_authentication/Windows.adoc
@@ -129,11 +129,11 @@ link:https://6xgate.github.io/TortoisePlink/[download and install Tortoise Plink
 == Using Cygwin with GPG4Win
 link:https://cygwin.com/install.html[Cygwin] provides a Unix-like terminal with several useful tools, such as SSH.  During installation, you will be asked which packages to install. 
 
-*	Do not install ``gpg``, as you will use the already installed ``GPG4Win``.  
+*	Do not install `gpg`, as you will use the already installed `GPG4Win`.  
 
-*	Make sure to install ``ssh-pageant`` to enable the SSH client that is included to use the YubiKey for authentication.  
+*	Make sure to install `ssh-pageant` to enable the SSH client that is included to use the YubiKey for authentication.  
 
-After installation, open a Cygwin shell and edit the ``~/.bashrc`` file by adding the following at the bottom:
+After installation, open a Cygwin shell and edit the `~/.bashrc` file by adding the following at the bottom:
 
 ....
 # ssh-pageant #

--- a/content/PIV/Guides/PIV_Walk-Through.adoc
+++ b/content/PIV/Guides/PIV_Walk-Through.adoc
@@ -83,12 +83,12 @@ yubico-piv-tool -a import-certificate -s 9a -i cert.pem
 === Locate the PKCS#11 Module
 Locate the ykcs11 installation, which comes as part of the PIV tool. Unzip a release to find it in the lib directory, or alternatively, install OpenSC and use the link:https://github.com/OpenSC/OpenSC/wiki[opensc-pkcs11.so library].
 
-* For Debian-based systems, the default path is ``/usr/local/lib/libykcs11``
-* For MacOS, the default path is ``/usr/local/lib/libykcs11.dylib``
+* For Debian-based systems, the default path is `/usr/local/lib/libykcs11`
+* For MacOS, the default path is `/usr/local/lib/libykcs11.dylib`
 
 
 === Export the SSH Public Key
-Export the public key in the correct SSH format and add it to ``authorized_keys`` on the target system.
+Export the public key in the correct SSH format and add it to `authorized_keys` on the target system.
 
 Export the keys by running the following command, which exports all the keys stored on the YubiKey in sequence. Use the sequence to identify the public key associated with your targeted private key.
 

--- a/content/WebAuthn/WebAuthn_Developer_Guide/Algorithms.adoc
+++ b/content/WebAuthn/WebAuthn_Developer_Guide/Algorithms.adoc
@@ -1,10 +1,10 @@
 == WebAuthn Algorithms ==
 
-The cryptographic algorithm used to generate a public keypair during a FIDO2/WebAuthn registration is determined by the capabilities of the FIDO2 Authenticator and the preferences of the Relying Party (RP). The allowed algorithms are defined in the ``pubKeyCredParams`` section.
+The cryptographic algorithm used to generate a public keypair during a FIDO2/WebAuthn registration is determined by the capabilities of the FIDO2 Authenticator and the preferences of the Relying Party (RP). The allowed algorithms are defined in the `pubKeyCredParams` section.
 
 The  COSE Algorithms registry contains definitions of all possible algorithms that can be used. This is enforced due to some transports, such as Bluetooth or NFC, having restrictions in data bandwidth that make transmission of JSON files problematic. To avoid this issue, FIDO2 interactions must be capable of being translated to the CBOR format, including the algorithms utilized.
 
-The RP will further narrow down the supported algorithms, depending on which are supported on the FIDO2 server. For example, in Yubico’s python-fido2 server, the supported algorithms include ES256, RS256, PS256, and EdDSA. At registration, the supported algorithms for the public key (``pubKeyCredParams``) must be presented as either a JSON or CBOR format.
+The RP will further narrow down the supported algorithms, depending on which are supported on the FIDO2 server. For example, in Yubico’s python-fido2 server, the supported algorithms include ES256, RS256, PS256, and EdDSA. At registration, the supported algorithms for the public key (`pubKeyCredParams`) must be presented as either a JSON or CBOR format.
 
 
 == Sample JSON pubKeyCredParams:
@@ -56,9 +56,9 @@ The RP will further narrow down the supported algorithms, depending on which are
 
 The order in which the algorithms are listed by the RP will define the priority of the algorithm to be used.
 
-The authenticator will also have a subset of algorithms it supports for generating a public keypair. When generating a new public keypair during registration, the authenticator does not offer a prioritization of algorithms to be used; the algorithm with the highest priority set by the RP will be selected. The CTAP2 command, ``authenticatorGetInfo``, can be used to list the algorithms supported on an authenticator, should more information be required. YubiKeys currently support RS256 (Firmware 5.1.X and below only), EdDSA, ES256, and Ed25519 (Firmware 5.2.X and above only).
+The authenticator will also have a subset of algorithms it supports for generating a public keypair. When generating a new public keypair during registration, the authenticator does not offer a prioritization of algorithms to be used; the algorithm with the highest priority set by the RP will be selected. The CTAP2 command, `authenticatorGetInfo`, can be used to list the algorithms supported on an authenticator, should more information be required. YubiKeys currently support RS256 (Firmware 5.1.X and below only), EdDSA, ES256, and Ed25519 (Firmware 5.2.X and above only).
 
-If the ``pubKeyCredParams`` parameter does not contain a valid ``COSEAlgorithmIdentifier`` value that is supported by the authenticator, the registration event will fail with the error code ``CTAP2_ERR_UNSUPPORTED_ALGORITHM``.
+If the `pubKeyCredParams` parameter does not contain a valid `COSEAlgorithmIdentifier` value that is supported by the authenticator, the registration event will fail with the error code `CTAP2_ERR_UNSUPPORTED_ALGORITHM`.
 
 When defining the supported algorithms and prioritizing them, we recommend supporting at minimum ES256 and RS256. ES256 is supported on the vast majority of FIDO2 Authenticator devices, like the YubiKey, while most platform-based FIDO2 Authenticators include support for RS256.
 

--- a/content/WebAuthn/WebAuthn_Developer_Guide/Integration_Review_Standard_FIDO.adoc
+++ b/content/WebAuthn/WebAuthn_Developer_Guide/Integration_Review_Standard_FIDO.adoc
@@ -55,7 +55,7 @@ What platforms does your solution support with YubiKeys? (Please check all that 
 
 ==== Libraries
 
-Yubico offers integration libraries such as Yubico ``java-webauthn-server``, ``python-fido2``, and other Yubico supported libraries found https://developers.yubico.com/FIDO2/Libraries/List_of_libraries.html[here].
+Yubico offers integration libraries such as Yubico `java-webauthn-server`, `python-fido2`, and other Yubico supported libraries found https://developers.yubico.com/FIDO2/Libraries/List_of_libraries.html[here].
 
 1. What server-side libraries are being utilized?
 2. What client-side libraries are being utilized? Please specify if they come built-in to browsers and platforms, or if they are custom built.
@@ -113,7 +113,7 @@ This section is applicable only if the solution implemented a relying party or s
 
 User verification (UV) is applicable only to FIDO2 WebAuthn implementations. Enabling user verification will cause the user to be prompted for a PIN to unlock the YubiKey prior to authenticating. We recommend explicitly enabling or disabling user verification for the solution’s specific use case to prevent unintended user interaction.
 
-For second factor flows, to prevent a PIN prompt when using a YubiKey for authentication, we recommended setting UV to ``discouraged``.
+For second factor flows, to prevent a PIN prompt when using a YubiKey for authentication, we recommended setting UV to `discouraged`.
 
 1. What values are set for UV for registration?
 2. What values are set for UV for authentication?

--- a/content/WebAuthn/WebAuthn_Developer_Guide/User_Handle.adoc
+++ b/content/WebAuthn/WebAuthn_Developer_Guide/User_Handle.adoc
@@ -42,7 +42,7 @@ Universal second factor authentication (U2F) does not support the user handle.
 ====
 
 == Example
-When user John registers his security key with a Microsoft online service (the RP), the service prompts John to allow the service to create and register a credential on the key. That service identifies the pairing (the public key credential on John's key + John's account)  by means of the user handle, by setting the value for the ``user.id`` to the following, for example:
+When user John registers his security key with a Microsoft online service (the RP), the service prompts John to allow the service to create and register a credential on the key. That service identifies the pairing (the public key credential on John's key + John's account)  by means of the user handle, by setting the value for the `user.id` to the following, for example:
 
 [source,javascript]
 ----

--- a/content/WebAuthn/WebAuthn_Developer_Guide/User_Presence_vs_User_Verification.adoc
+++ b/content/WebAuthn/WebAuthn_Developer_Guide/User_Presence_vs_User_Verification.adoc
@@ -13,13 +13,13 @@ With user **presence**, the intent is not to identify the user, but to ensure th
 
 Note that the term "authorization gesture" - used in some WebAuthn reference material - is ambiguous: it can refer either to user presence or user verification.
 
-The RP has the following options for ``userVerification`` when initiating registration or authentication:
+The RP has the following options for `userVerification` when initiating registration or authentication:
 
 *DISCOURAGED*: This value indicates that the RP does not want user verification employed during the operation (for example, to minimize disruption to the user interaction flow).
 
-*PREFERRED*:	This value indicates that the RP prefers user verification for the operation if possible, but will not fail the operation if the response does not have the ``AuthenticatorDataFlags.UV`` flag set.
+*PREFERRED*:	This value indicates that the RP prefers user verification for the operation if possible, but will not fail the operation if the response does not have the `AuthenticatorDataFlags.UV` flag set.
 
-*REQUIRED*: Indicates that the RP requires user verification for the operation and will fail the operation if the response does not have the ``AuthenticatorDataFlags.UV flag`` set.
+*REQUIRED*: Indicates that the RP requires user verification for the operation and will fail the operation if the response does not have the `AuthenticatorDataFlags.UV flag` set.
 
 
 == Use Cases ==

--- a/content/WebAuthn/WebAuthn_Developer_Guide/WebAuthn_Readiness_Checklist.adoc
+++ b/content/WebAuthn/WebAuthn_Developer_Guide/WebAuthn_Readiness_Checklist.adoc
@@ -122,9 +122,9 @@ Because enabling user verification will cause the user to be prompted for a PIN 
 
 The Attestation Object is applicable only to CTAP2 and WebAuthn implementations. Refer to the https://www.w3.org/TR/webauthn/#sctn-attestation[W3C standard] to learn more. We recommend always saving the raw attestation statement after every credential creation.
 
-_Note: The WebAuthn default is set to ``none``, meaning the authenticator will not send the attestation statement._
+_Note: The WebAuthn default is set to `none`, meaning the authenticator will not send the attestation statement._
 
-* [ ] Set attestation to ``direct`` in the ``PublicKeyCredentialCreationOptions``
+* [ ] Set attestation to `direct` in the `PublicKeyCredentialCreationOptions`
 * [ ] Save the raw attestation statement to your data store
 * [ ] Get and store additional metadata about the authenticator model (e.g., image of device, etc.)
 * [ ] Use the attestation transport hint to guide the user interactions (e.g., if no NFC-enabled credentials, then prompt user to insert security key)

--- a/content/YubiHSM2/Usage_Guides/YubiHSM2_for_ADCS_Guide/Backing_Up_Key_Material.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM2_for_ADCS_Guide/Backing_Up_Key_Material.adoc
@@ -61,7 +61,7 @@ To export the CA root key under wrap using the wrap key on the device
 .	 To begin the process of restoring the data onto the secondary YubiHSM 2, if the primary YubiHSM 2 device is inserted into your computer, remove it and insert the secondary device. Restoring a
 device must be performed in an air-gapped environment in order to guarantee integrity.
 .	 In your command line application (where $ is the prompt), run YubiHSM Setup with the argument `restore`. To do this, launch your command line application, navigate to the directory containing the YubiHSM Setup program, run the following command, and press Enter.
-.. ``$ yubihsm-setup restore`
+.. `$ yubihsm-setup restore`
 .	 To start the YubiHSM Setup process, type the default authentication key password: `password` and press Enter. A confirmation message is displayed that the default authentication key was used and that you successfully have authenticated to the device:
 `Using authentication key 0x0001`
 You will now start the restore procedure, which involves providing the number of wrap keyshares required by the privacy threshold defined when setting up the primary device.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM2_for_ADCS_Guide/Configuring_the_Primary_YubiHSM_2_Device.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM2_for_ADCS_Guide/Configuring_the_Primary_YubiHSM_2_Device.adoc
@@ -138,7 +138,7 @@ To verify the YubiHSM Setup
 .	 In your command line application (where $ is the prompt), run YubiHSM Shell program. To do
 this, if you haven’t already, launch your command line application and navigate to the directory
 containing the YubiHSM Shell program. Then run the following command and press Enter.
-``$ yubihsm-shell`
+`$ yubihsm-shell`
 .	 To connect to the YubiHSM, at the yubihsm prompt, type connect and press Enter. A message
 verifying that you have a successful connection is displayed.
 .	 To open a session with the YubiHSM 2, type session open 3 and press Enter.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM_2_Windows_Deployment_Guide--Configure_YubiHSM_2_Key_Storage_Provider_for_Microsoft_Windows_Server/Configure_the_YubiHSM_2_Software.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM_2_Windows_Deployment_Guide--Configure_YubiHSM_2_Key_Storage_Provider_for_Microsoft_Windows_Server/Configure_the_YubiHSM_2_Software.adoc
@@ -38,7 +38,7 @@ image::ksp-registry-settings.png[]
 “ConnectorURL”=http://127.0.0.1:12345
 ....
 
-If the Connector is listening on IP address and port 192.168.100.252:12345, for example, the `ConnectorURL` value should be changed to ``“ConnectorURL”=http://192.168.100.252:12345`.
+If the Connector is listening on IP address and port 192.168.100.252:12345, for example, the `ConnectorURL` value should be changed to `“ConnectorURL”=http://192.168.100.252:12345`.
 
 *Step 4*: Enter the ID of the application authentication key (object ID `3` was used as an example in this guide; if you used another object ID be sure to enter that). For our example, because the hexadecimal value of 0x00000003 resolves to “3” in the Windows Registry, change the entry to:
 


### PR DESCRIPTION
replaced double backticks with single one to fix incorrect monospace rendering.

See for instance the rendering of `AuthenticatorDataFlags.UV` in 
[User_Presence_vs_User_Verification](content/WebAuthn/WebAuthn_Developer_Guide/User_Presence_vs_User_Verification.adoc)