### PR TITLE
libfido2: sync docs with 1.12.0

### DIFF
--- a/content/projects/libfido2/Manuals/eddsa_pk_new.partial
+++ b/content/projects/libfido2/Manuals/eddsa_pk_new.partial
@@ -112,12 +112,13 @@ The <code class="Fn" title="Fn">eddsa_pk_from_EVP_PKEY</code>() and
 <h1 class="Sh" title="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
 <a class="Xr" title="Xr" href="es256_pk_new.html">es256_pk_new(3)</a>,
+  <a class="Xr" title="Xr" href="es384_pk_new.html">es384_pk_new(3)</a>,
   <a class="Xr" title="Xr" href="fido_assert_verify.html">fido_assert_verify(3)</a>,
   <a class="Xr" title="Xr" href="fido_cred_pubkey_ptr.html">fido_cred_pubkey_ptr(3)</a>,
   <a class="Xr" title="Xr" href="rs256_pk_new.html">rs256_pk_new(3)</a></div>
 <table class="foot">
   <tr>
-    <td class="foot-date">May 15, 2019</td>
-    <td class="foot-os">Linux 5.3.12-arch1-1</td>
+    <td class="foot-date">July 15, 2022</td>
+    <td class="foot-os">Debian</td>
   </tr>
 </table>

--- a/content/projects/libfido2/Manuals/es256_pk_new.partial
+++ b/content/projects/libfido2/Manuals/es256_pk_new.partial
@@ -127,12 +127,13 @@ The <code class="Fn" title="Fn">es256_pk_from_EC_KEY</code>(),
 <h1 class="Sh" title="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
 <a class="Xr" title="Xr" href="eddsa_pk_new.html">eddsa_pk_new(3)</a>,
+  <a class="Xr" title="Xr" href="es384_pk_new.html">es384_pk_new(3)</a>,
   <a class="Xr" title="Xr" href="fido_assert_verify.html">fido_assert_verify(3)</a>,
   <a class="Xr" title="Xr" href="fido_cred_pubkey_ptr.html">fido_cred_pubkey_ptr(3)</a>,
   <a class="Xr" title="Xr" href="rs256_pk_new.html">rs256_pk_new(3)</a></div>
 <table class="foot">
   <tr>
-    <td class="foot-date">May 24, 2018</td>
-    <td class="foot-os">Linux 5.3.12-arch1-1</td>
+    <td class="foot-date">July 15, 2022</td>
+    <td class="foot-os">Debian</td>
   </tr>
 </table>

--- a/content/projects/libfido2/Manuals/es384_pk_free.partial
+++ b/content/projects/libfido2/Manuals/es384_pk_free.partial
@@ -1,0 +1,1 @@
+es384_pk_new.partial

--- a/content/projects/libfido2/Manuals/es384_pk_from_EC_KEY.partial
+++ b/content/projects/libfido2/Manuals/es384_pk_from_EC_KEY.partial
@@ -1,0 +1,1 @@
+es384_pk_new.partial

--- a/content/projects/libfido2/Manuals/es384_pk_from_EVP_PKEY.partial
+++ b/content/projects/libfido2/Manuals/es384_pk_from_EVP_PKEY.partial
@@ -1,0 +1,1 @@
+es384_pk_new.partial

--- a/content/projects/libfido2/Manuals/es384_pk_from_ptr.partial
+++ b/content/projects/libfido2/Manuals/es384_pk_from_ptr.partial
@@ -1,0 +1,1 @@
+es384_pk_new.partial

--- a/content/projects/libfido2/Manuals/es384_pk_new.partial
+++ b/content/projects/libfido2/Manuals/es384_pk_new.partial
@@ -14,110 +14,112 @@
 </style>
 <table class="head">
   <tr>
-    <td class="head-ltitle">RS256_PK_NEW(3)</td>
+    <td class="head-ltitle">ES384_PK_NEW(3)</td>
     <td class="head-vol">Library Functions Manual</td>
-    <td class="head-rtitle">RS256_PK_NEW(3)</td>
+    <td class="head-rtitle">ES384_PK_NEW(3)</td>
   </tr>
 </table>
 <div class="manual-text">
 <h1 class="Sh" title="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
-<code class="Nm" title="Nm">rs256_pk_new</code>,
-  <code class="Nm" title="Nm">rs256_pk_free</code>,
-  <code class="Nm" title="Nm">rs256_pk_from_RSA</code>,
-  <code class="Nm" title="Nm">rs256_pk_from_EVP_PKEY</code>,
-  <code class="Nm" title="Nm">rs256_pk_from_ptr</code>,
-  <code class="Nm" title="Nm">rs256_pk_to_EVP_PKEY</code> &#x2014;
-<div class="Nd" title="Nd">FIDO2 COSE RS256 API</div>
+<code class="Nm" title="Nm">es384_pk_new</code>,
+  <code class="Nm" title="Nm">es384_pk_free</code>,
+  <code class="Nm" title="Nm">es384_pk_from_EC_KEY</code>,
+  <code class="Nm" title="Nm">es384_pk_from_EVP_PKEY</code>,
+  <code class="Nm" title="Nm">es384_pk_from_ptr</code>,
+  <code class="Nm" title="Nm">es384_pk_to_EVP_PKEY</code> &#x2014;
+<div class="Nd" title="Nd">FIDO2 COSE ES384 API</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
-  &lt;<a class="In" title="In">openssl/rsa.h</a>&gt;</code>
+  &lt;<a class="In" title="In">openssl/ec.h</a>&gt;</code>
 <br/>
 <code class="In" title="In">#include
-  &lt;<a class="In" title="In">fido/rs256.h</a>&gt;</code>
+  &lt;<a class="In" title="In">fido/es384.h</a>&gt;</code>
 <div class="Pp"></div>
-<var class="Ft" title="Ft">rs256_pk_t *</var>
+<var class="Ft" title="Ft">es384_pk_t *</var>
 <br/>
-<code class="Fn" title="Fn">rs256_pk_new</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">void</var>);
+<code class="Fn" title="Fn">es384_pk_new</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">void</var>);
 <div class="Pp"></div>
 <var class="Ft" title="Ft">void</var>
 <br/>
-<code class="Fn" title="Fn">rs256_pk_free</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">rs256_pk_t
+<code class="Fn" title="Fn">es384_pk_free</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">es384_pk_t
   **pkp</var>);
 <div class="Pp"></div>
 <var class="Ft" title="Ft">int</var>
 <br/>
-<code class="Fn" title="Fn">rs256_pk_from_EVP_PKEY</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">rs256_pk_t
+<code class="Fn" title="Fn">es384_pk_from_EC_KEY</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">es384_pk_t
+  *pk</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
+  EC_KEY *ec</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
+<code class="Fn" title="Fn">es384_pk_from_EVP_PKEY</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">es384_pk_t
   *pk</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
   EVP_PKEY *pkey</var>);
 <div class="Pp"></div>
 <var class="Ft" title="Ft">int</var>
 <br/>
-<code class="Fn" title="Fn">rs256_pk_from_RSA</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">rs256_pk_t
-  *pk</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const RSA
-  *rsa</var>);
-<div class="Pp"></div>
-<var class="Ft" title="Ft">int</var>
-<br/>
-<code class="Fn" title="Fn">rs256_pk_from_ptr</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">rs256_pk_t
+<code class="Fn" title="Fn">es384_pk_from_ptr</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">es384_pk_t
   *pk</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const void
   *ptr</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">size_t
   len</var>);
 <div class="Pp"></div>
 <var class="Ft" title="Ft">EVP_PKEY *</var>
 <br/>
-<code class="Fn" title="Fn">rs256_pk_to_EVP_PKEY</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
-  rs256_pk_t *pk</var>);
+<code class="Fn" title="Fn">es384_pk_to_EVP_PKEY</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  es384_pk_t *pk</var>);
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
-RS256 is the name given in the CBOR Object Signing and Encryption (COSE) RFC to
-  PKCS#1.5 2048-bit RSA with SHA-256. The COSE RS256 API of
+ES384 is the name given in the CBOR Object Signing and Encryption (COSE) RFC to
+  ECDSA over P-384 with SHA-384. The COSE ES384 API of
   <i class="Em" title="Em">libfido2</i> is an auxiliary API with routines to
-  convert between the different RSA public key types used in
+  convert between the different ECDSA public key types used in
   <i class="Em" title="Em">libfido2</i> and
   <i class="Em" title="Em">OpenSSL</i>.
 <div class="Pp"></div>
-In <i class="Em" title="Em">libfido2</i>, RS256 public keys are abstracted by
-  the <var class="Vt" title="Vt">rs256_pk_t</var> type.
+In <i class="Em" title="Em">libfido2</i>, ES384 public keys are abstracted by
+  the <var class="Vt" title="Vt">es384_pk_t</var> type.
 <div class="Pp"></div>
-The <code class="Fn" title="Fn">rs256_pk_new</code>() function returns a pointer
-  to a newly allocated, empty <var class="Vt" title="Vt">rs256_pk_t</var> type.
+The <code class="Fn" title="Fn">es384_pk_new</code>() function returns a pointer
+  to a newly allocated, empty <var class="Vt" title="Vt">es384_pk_t</var> type.
   If memory cannot be allocated, NULL is returned.
 <div class="Pp"></div>
-The <code class="Fn" title="Fn">rs256_pk_free</code>() function releases the
+The <code class="Fn" title="Fn">es384_pk_free</code>() function releases the
   memory backing <var class="Fa" title="Fa">*pkp</var>, where
   <var class="Fa" title="Fa">*pkp</var> must have been previously allocated by
-  <code class="Fn" title="Fn">rs256_pk_new</code>(). On return,
+  <code class="Fn" title="Fn">es384_pk_new</code>(). On return,
   <var class="Fa" title="Fa">*pkp</var> is set to NULL. Either
   <var class="Fa" title="Fa">pkp</var> or <var class="Fa" title="Fa">*pkp</var>
-  may be NULL, in which case <code class="Fn" title="Fn">rs256_pk_free</code>()
+  may be NULL, in which case <code class="Fn" title="Fn">es384_pk_free</code>()
   is a NOP.
 <div class="Pp"></div>
-The <code class="Fn" title="Fn">rs256_pk_from_EVP_PKEY</code>() function fills
+The <code class="Fn" title="Fn">es384_pk_from_EC_KEY</code>() function fills
+  <var class="Fa" title="Fa">pk</var> with the contents of
+  <var class="Fa" title="Fa">ec</var>. No references to
+  <var class="Fa" title="Fa">ec</var> are kept.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">es384_pk_from_EVP_PKEY</code>() function fills
   <var class="Fa" title="Fa">pk</var> with the contents of
   <var class="Fa" title="Fa">pkey</var>. No references to
   <var class="Fa" title="Fa">pkey</var> are kept.
 <div class="Pp"></div>
-The <code class="Fn" title="Fn">rs256_pk_from_RSA</code>() function fills
-  <var class="Fa" title="Fa">pk</var> with the contents of
-  <var class="Fa" title="Fa">rsa</var>. No references to
-  <var class="Fa" title="Fa">rsa</var> are kept.
-<div class="Pp"></div>
-The <code class="Fn" title="Fn">rs256_pk_from_ptr</code>() function fills
+The <code class="Fn" title="Fn">es384_pk_from_ptr</code>() function fills
   <var class="Fa" title="Fa">pk</var> with the contents of
   <var class="Fa" title="Fa">ptr</var>, where
   <var class="Fa" title="Fa">ptr</var> points to
-  <var class="Fa" title="Fa">len</var> bytes. No references to
+  <var class="Fa" title="Fa">len</var> bytes. The
+  <var class="Fa" title="Fa">ptr</var> pointer may point to an uncompressed
+  point, or to the concatenation of the x and y coordinates. No references to
   <var class="Fa" title="Fa">ptr</var> are kept.
 <div class="Pp"></div>
-The <code class="Fn" title="Fn">rs256_pk_to_EVP_PKEY</code>() function converts
+The <code class="Fn" title="Fn">es384_pk_to_EVP_PKEY</code>() function converts
   <var class="Fa" title="Fa">pk</var> to a newly allocated
   <var class="Fa" title="Fa">EVP_PKEY</var> type with a reference count of 1. No
   internal references to the returned pointer are kept. If an error occurs,
-  <code class="Fn" title="Fn">rs256_pk_to_EVP_PKEY</code>() returns NULL.
+  <code class="Fn" title="Fn">es384_pk_to_EVP_PKEY</code>() returns NULL.
 <h1 class="Sh" title="Sh" id="RETURN_VALUES"><a class="permalink" href="#RETURN_VALUES">RETURN
   VALUES</a></h1>
-The <code class="Fn" title="Fn">rs256_pk_from_EVP_PKEY</code>(),
-  <code class="Fn" title="Fn">rs256_pk_from_RSA</code>(), and
-  <code class="Fn" title="Fn">rs256_pk_from_ptr</code>() functions return
+The <code class="Fn" title="Fn">es384_pk_from_EC_KEY</code>(),
+  <code class="Fn" title="Fn">es384_pk_from_EVP_PKEY</code>(), and
+  <code class="Fn" title="Fn">es384_pk_from_ptr</code>() functions return
   <code class="Dv" title="Dv">FIDO_OK</code> on success. On error, a different
   error code defined in
   <code class="In" title="In">&lt;<a class="In" title="In">fido/err.h</a>&gt;</code>
@@ -126,9 +128,9 @@ The <code class="Fn" title="Fn">rs256_pk_from_EVP_PKEY</code>(),
   ALSO</a></h1>
 <a class="Xr" title="Xr" href="eddsa_pk_new.html">eddsa_pk_new(3)</a>,
   <a class="Xr" title="Xr" href="es256_pk_new.html">es256_pk_new(3)</a>,
-  <a class="Xr" title="Xr" href="es384_pk_new.html">es384_pk_new(3)</a>,
   <a class="Xr" title="Xr" href="fido_assert_verify.html">fido_assert_verify(3)</a>,
-  <a class="Xr" title="Xr" href="fido_cred_pubkey_ptr.html">fido_cred_pubkey_ptr(3)</a></div>
+  <a class="Xr" title="Xr" href="fido_cred_pubkey_ptr.html">fido_cred_pubkey_ptr(3)</a>,
+  <a class="Xr" title="Xr" href="rs256_pk_new.html">rs256_pk_new(3)</a></div>
 <table class="foot">
   <tr>
     <td class="foot-date">July 15, 2022</td>

--- a/content/projects/libfido2/Manuals/es384_pk_to_EVP_PKEY.partial
+++ b/content/projects/libfido2/Manuals/es384_pk_to_EVP_PKEY.partial
@@ -1,0 +1,1 @@
+es384_pk_new.partial

--- a/content/projects/libfido2/Manuals/fido_assert_new.partial
+++ b/content/projects/libfido2/Manuals/fido_assert_new.partial
@@ -234,7 +234,10 @@ The <code class="Fn" title="Fn">fido_assert_user_display_name</code>(),
   pointers to the user display name, icon, and name attributes of statement
   <var class="Fa" title="Fa">idx</var> in
   <var class="Fa" title="Fa">assert</var>. If not NULL, the values returned by
-  these functions point to NUL-terminated UTF-8 strings.
+  these functions point to NUL-terminated UTF-8 strings. The user display name,
+  icon, and name attributes will typically only be returned by the authenticator
+  if user verification was performed by the authenticator and multiple
+  resident/discoverable credentials were involved in the assertion.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_assert_authdata_ptr</code>(),
   <code class="Fn" title="Fn">fido_assert_clientdata_hash_ptr</code>(),

--- a/content/projects/libfido2/Manuals/fido_assert_verify.partial
+++ b/content/projects/libfido2/Manuals/fido_assert_verify.partial
@@ -56,10 +56,12 @@ The <code class="Fn" title="Fn">fido_assert_verify</code>() function verifies
   <var class="Fa" title="Fa">cose_alg</var>, where
   <var class="Fa" title="Fa">cose_alg</var> is
   <code class="Dv" title="Dv">COSE_ES256</code>,
+  <code class="Dv" title="Dv">COSE_ES384</code>,
   <code class="Dv" title="Dv">COSE_RS256</code>, or
   <code class="Dv" title="Dv">COSE_EDDSA</code>, and
   <var class="Fa" title="Fa">pk</var> points to a
   <var class="Vt" title="Vt">es256_pk_t</var>,
+  <var class="Vt" title="Vt">es384_pk_t</var>,
   <var class="Vt" title="Vt">rs256_pk_t</var>, or
   <var class="Vt" title="Vt">eddsa_pk_t</var> type accordingly.
 <div class="Pp"></div>
@@ -80,7 +82,7 @@ The error codes returned by
   <a class="Xr" title="Xr" href="fido_assert_set_authdata.html">fido_assert_set_authdata(3)</a></div>
 <table class="foot">
   <tr>
-    <td class="foot-date">May 24, 2018</td>
-    <td class="foot-os">Linux 5.3.12-arch1-1</td>
+    <td class="foot-date">July 15, 2022</td>
+    <td class="foot-os">Debian</td>
   </tr>
 </table>

--- a/content/projects/libfido2/Manuals/fido_cbor_info_certs_len.partial
+++ b/content/projects/libfido2/Manuals/fido_cbor_info_certs_len.partial
@@ -1,0 +1,1 @@
+fido_cbor_info_new.partial

--- a/content/projects/libfido2/Manuals/fido_cbor_info_certs_name_ptr.partial
+++ b/content/projects/libfido2/Manuals/fido_cbor_info_certs_name_ptr.partial
@@ -1,0 +1,1 @@
+fido_cbor_info_new.partial

--- a/content/projects/libfido2/Manuals/fido_cbor_info_certs_value_ptr.partial
+++ b/content/projects/libfido2/Manuals/fido_cbor_info_certs_value_ptr.partial
@@ -1,0 +1,1 @@
+fido_cbor_info_new.partial

--- a/content/projects/libfido2/Manuals/fido_cbor_info_maxrpid_minpinlen.partial
+++ b/content/projects/libfido2/Manuals/fido_cbor_info_maxrpid_minpinlen.partial
@@ -1,0 +1,1 @@
+fido_cbor_info_new.partial

--- a/content/projects/libfido2/Manuals/fido_cbor_info_minpinlen.partial
+++ b/content/projects/libfido2/Manuals/fido_cbor_info_minpinlen.partial
@@ -1,0 +1,1 @@
+fido_cbor_info_new.partial

--- a/content/projects/libfido2/Manuals/fido_cbor_info_new.partial
+++ b/content/projects/libfido2/Manuals/fido_cbor_info_new.partial
@@ -34,6 +34,9 @@
   <code class="Nm" title="Nm">fido_cbor_info_algorithm_type</code>,
   <code class="Nm" title="Nm">fido_cbor_info_algorithm_cose</code>,
   <code class="Nm" title="Nm">fido_cbor_info_algorithm_count</code>,
+  <code class="Nm" title="Nm">fido_cbor_info_certs_name_ptr</code>,
+  <code class="Nm" title="Nm">fido_cbor_info_certs_value_ptr</code>,
+  <code class="Nm" title="Nm">fido_cbor_info_certs_len</code>,
   <code class="Nm" title="Nm">fido_cbor_info_aaguid_len</code>,
   <code class="Nm" title="Nm">fido_cbor_info_extensions_len</code>,
   <code class="Nm" title="Nm">fido_cbor_info_protocols_len</code>,
@@ -45,7 +48,13 @@
   <code class="Nm" title="Nm">fido_cbor_info_maxcredcntlst</code>,
   <code class="Nm" title="Nm">fido_cbor_info_maxcredidlen</code>,
   <code class="Nm" title="Nm">fido_cbor_info_maxlargeblob</code>,
-  <code class="Nm" title="Nm">fido_cbor_info_fwversion</code> &#x2014;
+  <code class="Nm" title="Nm">fido_cbor_info_maxrpid_minpinlen</code>,
+  <code class="Nm" title="Nm">fido_cbor_info_minpinlen</code>,
+  <code class="Nm" title="Nm">fido_cbor_info_fwversion</code>,
+  <code class="Nm" title="Nm">fido_cbor_info_uv_attempts</code>,
+  <code class="Nm" title="Nm">fido_cbor_info_uv_modality</code>,
+  <code class="Nm" title="Nm">fido_cbor_info_rk_remaining</code>,
+  <code class="Nm" title="Nm">fido_cbor_info_new_pin_required</code> &#x2014;
 <div class="Nd" title="Nd">FIDO2 CBOR Info API</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
@@ -119,6 +128,21 @@
 <code class="Fn" title="Fn">fido_cbor_info_algorithm_count</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_cbor_info_t *ci</var>);
 <div class="Pp"></div>
+<var class="Ft" title="Ft">char **</var>
+<br/>
+<code class="Fn" title="Fn">fido_cbor_info_certs_name_ptr</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cbor_info_t *ci</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">const uint64_t *</var>
+<br/>
+<code class="Fn" title="Fn">fido_cbor_info_certs_value_ptr</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cbor_info_t *ci</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">size_t</var>
+<br/>
+<code class="Fn" title="Fn">fido_cbor_info_certs_len</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cbor_info_t *ci</var>);
+<div class="Pp"></div>
 <var class="Ft" title="Ft">size_t</var>
 <br/>
 <code class="Fn" title="Fn">fido_cbor_info_aaguid_len</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
@@ -176,7 +200,37 @@
 <div class="Pp"></div>
 <var class="Ft" title="Ft">uint64_t</var>
 <br/>
+<code class="Fn" title="Fn">fido_cbor_info_maxrpid_minpinlen</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cbor_info_t *ci</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">uint64_t</var>
+<br/>
+<code class="Fn" title="Fn">fido_cbor_info_minpinlen</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cbor_info_t *ci</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">uint64_t</var>
+<br/>
 <code class="Fn" title="Fn">fido_cbor_info_fwversion</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cbor_info_t *ci</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">uint64_t</var>
+<br/>
+<code class="Fn" title="Fn">fido_cbor_info_uv_attempts</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cbor_info_t *ci</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">uint64_t</var>
+<br/>
+<code class="Fn" title="Fn">fido_cbor_info_uv_modality</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cbor_info_t *ci</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int64_t</var>
+<br/>
+<code class="Fn" title="Fn">fido_cbor_info_rk_remaining</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cbor_info_t *ci</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">bool</var>
+<br/>
+<code class="Fn" title="Fn">fido_cbor_info_new_pin_required</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_cbor_info_t *ci</var>);
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
 The <code class="Fn" title="Fn">fido_cbor_info_new</code>() function returns a
@@ -236,6 +290,13 @@ The <code class="Fn" title="Fn">fido_cbor_info_algorithm_count</code>() function
   that the first algorithm in <var class="Fa" title="Fa">ci</var> has an
   <var class="Fa" title="Fa">idx</var> (index) value of 0.
 <div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_cbor_info_certs_name_ptr</code>() and
+  <code class="Fn" title="Fn">fido_cbor_info_certs_value_ptr</code>() functions
+  return pointers to the array of certification names and their respective
+  values in <var class="Fa" title="Fa">ci</var>. The length of the
+  certifications array is returned by
+  <code class="Fn" title="Fn">fido_cbor_info_certs_len</code>().
+<div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_cbor_info_maxmsgsiz</code>() function
   returns the maximum message size attribute of
   <var class="Fa" title="Fa">ci</var>.
@@ -252,12 +313,68 @@ The <code class="Fn" title="Fn">fido_cbor_info_maxcredidlen</code>() function
   returns the maximum supported length of a credential ID as reported in
   <var class="Fa" title="Fa">ci</var>.
 <div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_cbor_info_maxrpid_minpinlen</code>()
+  function returns the maximum number of RP IDs that may be passed to
+  <a class="Xr" title="Xr" href="fido_dev_set_pin_minlen_rpid.html">fido_dev_set_pin_minlen_rpid(3)</a>,
+  as reported in <var class="Fa" title="Fa">ci</var>. The minimum PIN length
+  attribute is a CTAP 2.1 addition. If the attribute is not advertised by the
+  authenticator, the
+  <code class="Fn" title="Fn">fido_cbor_info_maxrpid_minpinlen</code>() function
+  returns zero.
+<div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_cbor_info_maxlargeblob</code>() function
   returns the maximum length in bytes of an authenticator's serialized largeBlob
   array as reported in <var class="Fa" title="Fa">ci</var>.
 <div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_cbor_info_minpinlen</code>() function
+  returns the minimum PIN length enforced by the authenticator as reported in
+  <var class="Fa" title="Fa">ci</var>. The minimum PIN length attribute is a
+  CTAP 2.1 addition. If the attribute is not advertised by the authenticator,
+  the <code class="Fn" title="Fn">fido_cbor_info_minpinlen</code>() function
+  returns zero.
+<div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_cbor_info_fwversion</code>() function
   returns the firmware version attribute of <var class="Fa" title="Fa">ci</var>.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_cbor_info_uv_attempts</code>() function
+  returns the number of UV attempts that the platform may attempt before falling
+  back to PIN authentication. If 1, then all
+  <a class="Xr" title="Xr" href="fido_dev_get_uv_retry_count.html">fido_dev_get_uv_retry_count(3)</a>
+  retries are handled internally by the authenticator and the platform may only
+  attempt non-PIN UV once. The UV attempts attribute is a CTAP 2.1 addition. If
+  the attribute is not advertised by the authenticator, the
+  <code class="Fn" title="Fn">fido_cbor_info_uv_attempts</code>() function
+  returns zero.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_cbor_info_uv_modality</code>() function
+  returns a bitmask representing different UV modes supported by the
+  authenticator, as defined in the FIDO Registry of Predefined Values and
+  reported in <var class="Fa" title="Fa">ci</var>. See the
+  <i class="Em" title="Em">FIDO_UV_MODE_*</i> definitions in
+  <code class="In" title="In">&lt;<a class="In" title="In">fido/param.h</a>&gt;</code>
+  for the set of values defined by libfido2 and a brief description of each. The
+  UV modality attribute is a CTAP 2.1 addition. If the attribute is not
+  advertised by the authenticator, the
+  <code class="Fn" title="Fn">fido_cbor_info_uv_modality</code>() function
+  returns zero.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_cbor_info_rk_remaining</code>() function
+  returns the estimated number of additional resident/discoverable credentials
+  that can be stored on the authenticator as reported in
+  <var class="Fa" title="Fa">ci</var>. The estimated number of remaining
+  resident credentials is a CTAP 2.1 addition. If the attribute is not
+  advertised by the authenticator, the
+  <code class="Fn" title="Fn">fido_cbor_info_rk_remaining</code>() function
+  returns -1.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_cbor_info_new_pin_required</code>()
+  function returns whether a new PIN is required by the authenticator as
+  reported in <var class="Fa" title="Fa">ci</var>. If
+  <code class="Fn" title="Fn">fido_cbor_info_new_pin_required</code>() returns
+  true, operations requiring PIN authentication will fail until a new PIN is set
+  on the authenticator. The
+  <a class="Xr" title="Xr" href="fido_dev_set_pin.html">fido_dev_set_pin(3)</a>
+  function can be used to set a new PIN.
 <div class="Pp"></div>
 A complete example of how to use these functions can be found in the
   <span class="Pa" title="Pa">example/info.c</span> file shipped with
@@ -278,7 +395,16 @@ The <code class="Fn" title="Fn">fido_cbor_info_aaguid_ptr</code>(),
   <i class="Em" title="Em">const</i> qualifier is invoked.
 <h1 class="Sh" title="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
-<a class="Xr" title="Xr" href="fido_dev_open.html">fido_dev_open(3)</a></div>
+<a class="Xr" title="Xr" href="fido_dev_get_uv_retry_count.html">fido_dev_get_uv_retry_count(3)</a>,
+  <a class="Xr" title="Xr" href="fido_dev_open.html">fido_dev_open(3)</a>,
+  <a class="Xr" title="Xr" href="fido_dev_set_pin.html">fido_dev_set_pin(3)</a>,
+  <a class="Xr" title="Xr" href="fido_dev_set_pin_minlen_rpid.html">fido_dev_set_pin_minlen_rpid(3)</a>
+<div class="Pp"></div>
+<cite class="Rs" title="Rs"><span class="RsR">FIDO Registry of Predefined
+  Values</span>,
+  <a class="RsU" href="https://fidoalliance.org/specs/common-specs/fido-registry-v2.2-rd-20210525.html">https://fidoalliance.org/specs/common-specs/fido-registry-v2.2-rd-20210525.html</a>,
+  <span class="RsQ">FIDO Alliance</span>, <span class="RsD">2021-05-25</span>,
+  <span class="RsO">Review Draft, Version 2.2</span>.</cite></div>
 <table class="foot">
   <tr>
     <td class="foot-date">April 22, 2022</td>

--- a/content/projects/libfido2/Manuals/fido_cbor_info_new_pin_required.partial
+++ b/content/projects/libfido2/Manuals/fido_cbor_info_new_pin_required.partial
@@ -1,0 +1,1 @@
+fido_cbor_info_new.partial

--- a/content/projects/libfido2/Manuals/fido_cbor_info_rk_remaining.partial
+++ b/content/projects/libfido2/Manuals/fido_cbor_info_rk_remaining.partial
@@ -1,0 +1,1 @@
+fido_cbor_info_new.partial

--- a/content/projects/libfido2/Manuals/fido_cbor_info_uv_attempts.partial
+++ b/content/projects/libfido2/Manuals/fido_cbor_info_uv_attempts.partial
@@ -1,0 +1,1 @@
+fido_cbor_info_new.partial

--- a/content/projects/libfido2/Manuals/fido_cbor_info_uv_modality.partial
+++ b/content/projects/libfido2/Manuals/fido_cbor_info_uv_modality.partial
@@ -1,0 +1,1 @@
+fido_cbor_info_new.partial

--- a/content/projects/libfido2/Manuals/fido_cred_new.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_new.partial
@@ -272,8 +272,8 @@ If the CTAP 2.1 <code class="Dv" title="Dv">FIDO_EXT_CRED_PROTECT</code>
   <i class="Em" title="Em">libfido2</i>.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_cred_fmt</code>() function returns a
-  pointer to a NUL-terminated string containing the format of
-  <var class="Fa" title="Fa">cred</var>, or NULL if
+  pointer to a NUL-terminated string containing the attestation statement format
+  identifier of <var class="Fa" title="Fa">cred</var>, or NULL if
   <var class="Fa" title="Fa">cred</var> does not have a format set.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_cred_rp_id</code>(),

--- a/content/projects/libfido2/Manuals/fido_cred_set_authdata.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_set_authdata.partial
@@ -306,25 +306,28 @@ The <code class="Fn" title="Fn">fido_cred_set_rk</code>() and
   authenticator to use its default settings.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_cred_set_fmt</code>() function sets the
-  attestation format of <var class="Fa" title="Fa">cred</var> to
-  <var class="Fa" title="Fa">fmt</var>, where
-  <var class="Fa" title="Fa">fmt</var> must be
+  attestation statement format identifier of
+  <var class="Fa" title="Fa">cred</var> to <var class="Fa" title="Fa">fmt</var>,
+  where <var class="Fa" title="Fa">fmt</var> must be
   <var class="Vt" title="Vt">packed</var> (the format used in FIDO2),
-  <var class="Vt" title="Vt">fido-u2f</var> (the format used by U2F), or
-  <var class="Vt" title="Vt">none</var>. A copy of
+  <var class="Vt" title="Vt">fido-u2f</var> (the format used in U2F),
+  <var class="Vt" title="Vt">tpm</var> (the format used by TPM-based
+  authenticators), or <var class="Vt" title="Vt">none</var>. A copy of
   <var class="Fa" title="Fa">fmt</var> is made, and no references to the passed
   pointer are kept. Note that not all authenticators support FIDO2 and therefore
-  may not be able to generate <var class="Vt" title="Vt">packed</var>.
+  may only be able to generate <var class="Vt" title="Vt">fido-u2f</var>
+  attestation statements.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_cred_set_type</code>() function sets the
   type of <var class="Fa" title="Fa">cred to</var>
   <var class="Fa" title="Fa">cose_alg</var>, where
   <var class="Fa" title="Fa">cose_alg</var> is
   <code class="Dv" title="Dv">COSE_ES256</code>,
+  <code class="Dv" title="Dv">COSE_ES384</code>,
   <code class="Dv" title="Dv">COSE_RS256</code>, or
   <code class="Dv" title="Dv">COSE_EDDSA</code>. The type of a credential may
-  only be set once. Note that not all authenticators support COSE_RS256 or
-  COSE_EDDSA.
+  only be set once. Note that not all authenticators support COSE_RS256,
+  COSE_ES384, or COSE_EDDSA.
 <div class="Pp"></div>
 Use of the <code class="Nm" title="Nm">fido_cred_set_authdata</code> set of
   functions may happen in two distinct situations: when generating a new
@@ -354,7 +357,7 @@ The error codes returned by the
   <a class="Xr" title="Xr" href="fido_dev_make_cred.html">fido_dev_make_cred(3)</a></div>
 <table class="foot">
   <tr>
-    <td class="foot-date">May 23, 2018</td>
-    <td class="foot-os">Linux 5.3.12-arch1-1</td>
+    <td class="foot-date">July 15, 2022</td>
+    <td class="foot-os">Debian</td>
   </tr>
 </table>

--- a/content/projects/libfido2/Manuals/fido_dev_enable_entattest.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_enable_entattest.partial
@@ -106,7 +106,10 @@ The <code class="Fn" title="Fn">fido_dev_set_pin_minlen_rpid</code>() function
   list of RP identifiers is denoted by <var class="Fa" title="Fa">rpid</var>, a
   vector of <var class="Fa" title="Fa">n</var> NUL-terminated UTF-8 strings. A
   copy of <var class="Fa" title="Fa">rpid</var> is made, and no reference to it
-  or its contents is kept.
+  or its contents is kept. The maximum value of
+  <var class="Fa" title="Fa">n</var> supported by the authenticator can be
+  obtained using
+  <a class="Xr" title="Xr" href="fido_cbor_info_maxrpid_minpinlen.html">fido_cbor_info_maxrpid_minpinlen(3)</a>.
 <div class="Pp"></div>
 Configuration settings are reflected in the payload returned by the
   authenticator in response to a
@@ -125,7 +128,8 @@ The error codes returned by
   On success, <code class="Dv" title="Dv">FIDO_OK</code> is returned.
 <h1 class="Sh" title="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
-<a class="Xr" title="Xr" href="fido_cred_pin_minlen.html">fido_cred_pin_minlen(3)</a>,
+<a class="Xr" title="Xr" href="fido_cbor_info_maxrpid_minpinlen.html">fido_cbor_info_maxrpid_minpinlen(3)</a>,
+  <a class="Xr" title="Xr" href="fido_cred_pin_minlen.html">fido_cred_pin_minlen(3)</a>,
   <a class="Xr" title="Xr" href="fido_dev_get_cbor_info.html">fido_dev_get_cbor_info(3)</a>,
   <a class="Xr" title="Xr" href="fido_dev_reset.html">fido_dev_reset(3)</a></div>
 <table class="foot">

--- a/content/projects/libfido2/Manuals/fido_dev_largeblob_get.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_largeblob_get.partial
@@ -174,8 +174,8 @@ The functions <code class="Fn" title="Fn">fido_dev_largeblob_set</code>(),
   <a class="Xr" title="Xr" href="fido_cred_largeblob_key_len.html">fido_cred_largeblob_key_len(3)</a>,
   <a class="Xr" title="Xr" href="fido_cred_largeblob_key_ptr.html">fido_cred_largeblob_key_ptr(3)</a>,
   <a class="Xr" title="Xr" href="fido_cred_set_extensions.html">fido_cred_set_extensions(3)</a>,
-  <a class="Xr" title="Xr" href="fido_credman_dev_get_rk.html">fido_credman_dev_get_rk(3)</a>,
-  <a class="Xr" title="Xr" href="fido_credman_dev_get_rp.html">fido_credman_dev_get_rp(3)</a>,
+  <a class="Xr" title="Xr" href="fido_credman_get_dev_rk.html">fido_credman_get_dev_rk(3)</a>,
+  <a class="Xr" title="Xr" href="fido_credman_get_dev_rp.html">fido_credman_get_dev_rp(3)</a>,
   <a class="Xr" title="Xr" href="fido_dev_get_assert.html">fido_dev_get_assert(3)</a>,
   <a class="Xr" title="Xr" href="fido_dev_make_cred.html">fido_dev_make_cred(3)</a>
 <h1 class="Sh" title="Sh" id="CAVEATS"><a class="permalink" href="#CAVEATS">CAVEATS</a></h1>

--- a/content/projects/libfido2/Manuals/fido_dev_set_pin.partial
+++ b/content/projects/libfido2/Manuals/fido_dev_set_pin.partial
@@ -93,6 +93,9 @@ The error codes returned by
   <code class="Fn" title="Fn">fido_dev_reset</code>() are defined in
   <code class="In" title="In">&lt;<a class="In" title="In">fido/err.h</a>&gt;</code>.
   On success, <code class="Dv" title="Dv">FIDO_OK</code> is returned.
+<h1 class="Sh" title="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
+  ALSO</a></h1>
+<a class="Xr" title="Xr" href="fido_cbor_info_uv_attempts.html">fido_cbor_info_uv_attempts(3)</a>
 <h1 class="Sh" title="Sh" id="CAVEATS"><a class="permalink" href="#CAVEATS">CAVEATS</a></h1>
 Regarding <code class="Fn" title="Fn">fido_dev_reset</code>(), the actual
   user-flow to perform a reset is outside the scope of the FIDO2 specification,


### PR DESCRIPTION
- new API calls:
  * es384_pk_free;
  * es384_pk_from_EC_KEY;
  * es384_pk_from_EVP_PKEY;
  * es384_pk_from_ptr;
  * es384_pk_new;
  * es384_pk_to_EVP_PKEY;
  * fido_cbor_info_certs_len;
  * fido_cbor_info_certs_name_ptr;
  * fido_cbor_info_certs_value_ptr;
  * fido_cbor_info_maxrpid_minpinlen;
  * fido_cbor_info_minpinlen;
  * fido_cbor_info_new_pin_required;
  * fido_cbor_info_rk_remaining;
  * fido_cbor_info_uv_attempts;
  * fido_cbor_info_uv_modality.
- correct references to fido_credman_get_dev_{rk,rp}
- miscellaneous clarity and consistency tweaks