### PR TITLE
Remove references to device support matrix

### DIFF
--- a/content/WebAuthn/Concepts/Passkey_Autofill/Implementation_Guidance/Modal_and_Autofill_Flow.adoc
+++ b/content/WebAuthn/Concepts/Passkey_Autofill/Implementation_Guidance/Modal_and_Autofill_Flow.adoc
@@ -23,9 +23,9 @@ In order to leverage autofill and passkeys in your application, you need to ensu
 To see if your browser supports autofill you can:
 
 * Check programmatically using the code found in our guidance link:/WebAuthn/Concepts/Passkey_Autofill/Implementation_Guidance/Autofill_-_Conditional_UI_Browser_Feature_Detection.html[Autofill / Conditional UI browser feature detection for passkeys]
-* Consult this link:https://passkeydeveloper.github.io/passkeys.dev/device-support/[Device Support Matrix] created by the WebAuthn Community Adoption Group 
+//* Consult this link:https://passkeydeveloper.github.io/passkeys.dev/device-support/[Device Support Matrix] created by the WebAuthn Community Adoption Group 
 
-The link:https://passkeydeveloper.github.io/passkeys.dev/device-support/[Device Support Matrix] linked above can also be used to verify if an operating system supports passkeys. 
+//The link:https://passkeydeveloper.github.io/passkeys.dev/device-support/[Device Support Matrix] linked above can also be used to verify if an operating system supports passkeys. 
 
 You will also need a WebAuthn Relying Party to provide the `PublicKeyCredentialRequestOptions` to trigger and verify the authentication ceremony. Please see our link:https://developers.yubico.com/Mobile_Dev/WebAuthn/WebAuthn_Primer.html#:~:text=How%20do%20I%20deploy%20an%20example%20WebAuthn%20application%3F[WebAuthn primer for developers] for options to deploy a WebAuthn RelyingParty. 
 

--- a/content/WebAuthn/Concepts/Passkey_Autofill/Implementation_Guidance/Simple_Autofill_Flow.adoc
+++ b/content/WebAuthn/Concepts/Passkey_Autofill/Implementation_Guidance/Simple_Autofill_Flow.adoc
@@ -16,9 +16,9 @@ In order to leverage autofill and passkeys in your application, you need to ensu
 To see if your browser supports autofill you can:
 
 * Check programmatically using the code found in our guidance link:/WebAuthn/Concepts/Passkey_Autofill/Implementation_Guidance/Autofill_-_Conditional_UI_Browser_Feature_Detection.html[Autofill / Conditional UI browser feature detection for passkeys]
-* Consult this link:https://passkeydeveloper.github.io/passkeys.dev/device-support/[Device Support Matrix] created by the WebAuthn Community Adoption Group 
+//* Consult this link:https://passkeydeveloper.github.io/passkeys.dev/device-support/[Device Support Matrix] created by the WebAuthn Community Adoption Group 
 
-The link:https://passkeydeveloper.github.io/passkeys.dev/device-support/[Device Support Matrix] linked above can also be used to verify if an operating system supports passkeys. 
+//The link:https://passkeydeveloper.github.io/passkeys.dev/device-support/[Device Support Matrix] linked above can also be used to verify if an operating system supports passkeys. 
 
 You will also need a WebAuthn Relying Party to provide the `PublicKeyCredentialRequestOptions` to trigger and verify the authentication ceremony. Please see our link:https://developers.yubico.com/Mobile_Dev/WebAuthn/WebAuthn_Primer.html#:~:text=How%20do%20I%20deploy%20an%20example%20WebAuthn%20application%3F[WebAuthn primer for developers] for options to deploy a WebAuthn RelyingParty. 
 

--- a/content/WebAuthn/Concepts/Passkey_Autofill/index.adoc
+++ b/content/WebAuthn/Concepts/Passkey_Autofill/index.adoc
@@ -53,7 +53,7 @@ Autofill is currently available for use in Safari in iOS 16.
 ==== Beta releases
 The macOS 13 Beta supports autofill on Safari, along with the current Google Chrome Canary builds. Note that the Chrome implementation will only work if your OS supports passkeys. 
 
-The WebAuthn Community Adoption Group maintains this link:https://passkeydeveloper.github.io/passkeys.dev/device-support/[Device Support Matrix] where you can see what platforms currently support passkey features. 
+//The WebAuthn Community Adoption Group maintains this link:https://passkeydeveloper.github.io/passkeys.dev/device-support/[Device Support Matrix] where you can see what platforms currently support passkey features. 
 
 === Considerations
 Now that we understand what autofill is, the problem it aims to solve, and where it’s available,  let’s review some considerations. Some of these items will evolve as the autofill feature begins to be adopted, but for now ensure that you understand these implications before you commit to adding autofill into your applications
@@ -63,7 +63,7 @@ While most of the major browsers have committed to supporting autofill, there wi
 
 Applications should allow platforms that support the feature to utilize autofill. If a platform does not support the feature, then ensure that the application routes the user to a secondary login screen or flow where they are able to use the modal experience. 
 
-The WebAuthn Community Adoption Group maintains this link:https://passkeydeveloper.github.io/passkeys.dev/device-support/[Device Support Matrix] where you can see what platforms currently support passkey features 
+//The WebAuthn Community Adoption Group maintains this link:https://passkeydeveloper.github.io/passkeys.dev/device-support/[Device Support Matrix] where you can see what platforms currently support passkey features 
 
 ==== Security keys not always supported
 During testing it was discovered that the autofill feature does not allow for the use of a passkey on a security key. Additional options are given to the user, but it only allows the use of the hybrid (QR) code experience.


### PR DESCRIPTION
The references to the Device Support Matrix were not meant to be shared publicly yet - Removing their references from the documentation until they can be published.