### PR TITLE
Removed open source mention

### DIFF
--- a/content/PGP/SSH_authentication/Windows.adoc
+++ b/content/PGP/SSH_authentication/Windows.adoc
@@ -51,9 +51,9 @@ Once SSH support is enabled, any application that supports SSH authentication us
 link:https://www.ssh.com/academy/ssh/putty/windows[SSH documentation].
 
 
-=== Accessing via Smartcard Authentication (alternative to GPG4Win)
+=== Accessing via Smartcard Authentication (closed source alternative to GPG4Win)
 As an alternative to using GPG4Win, the Pageant executable in the
-link:https://www.smartcard-auth.de/index-en.html[Smartcard Authentication] open source project can be downloaded and used.
+link:https://www.smartcard-auth.de/index-en.html[Smartcard Authentication] can be downloaded and used at your own risk.
 
 Instructions on configuring Smartcard Authentication with PuTTY are available in this
 link:https://github.com/Yubico/developers.yubico.com/issues/388[issue in the GitHub repository for developers.yubico.com].


### PR DESCRIPTION
Following up on #388 

I will let you decide if you continue to officially recommand/trust this alternative but for now I removed the misleading "open source" mention for this closed source product.

Fixes #508 where @pk1234 clarifies himself that the product is not open source.