### PR TITLE
document the native SSH setup

### DIFF
--- a/content/PGP/SSH_authentication/Windows.adoc
+++ b/content/PGP/SSH_authentication/Windows.adoc
@@ -3,9 +3,17 @@ This guide explains how to set up accessing GitHub over SSH on Windows with the 
 
 The YubiKey 5, YubiKey 4, and YubiKey NEO all support the OpenPGP interface for smart cards. This can be used with GPG4Win for encryption and signing, as well as for SSH authentication. These in turn can be used by several other useful tools, like Git and Cygwin, etc. This document guides you through setting up the required software for getting SSH to work on Windows with the YubiKey OpenPGP application.
 
+=== Install an SSH Client
 
-=== Install PuTTY
+You can choose to install either PuTTY, the native windows client or both.
+
+==== Install PuTTY
 Putty is an open source SSH client for connecting via SSH from a Windows system. PuTTY includes support for the Pageant protocol, which is used by other applications in this solution. Download link:https://www.chiark.greenend.org.uk/~sgtatham/putty/download.html[PuTTY] and install it.
+
+==== Install OpenSSH Client feature
+
+The recent builds of Windows 10 and Windows 11 contain a native build of the OpenSSH binaries.
+The client can be installed using the `Optional Features` ( Windows Settings > Apps > Optional features, then search for "SSH")
 
 
 == Setting up Access to the YubiKey’s OpenPGP Application
@@ -28,8 +36,11 @@ GPG4Win has built-in support for SSH authentication.
 **Step 3** Enable SSH support by editing the `gpg-agent.conf` file located in the `gnupg` directory `%APPDATA%\.gnupg\` on Windows, where the typical path is `C:\Users\<username>\AppData\Roaming\`. Add the following lines to it:
 
 ....
-enable-putty-support
 enable-ssh-support
+# To Enable support for PuTTY
+enable-putty-support
+# To Enable support for the native Microsoft OpenSSH binaries (requires gpg 2.4.0 / Gpg4win 4.1.0 or higher)
+enable-win32-openssh-support
 use-standard-socket
 default-cache-ttl 600
 max-cache-ttl 7200
@@ -139,3 +150,4 @@ After installation, open a Cygwin shell and edit the `~/.bashrc` file by adding 
 # ssh-pageant #
 eval $(/usr/bin/ssh-pageant -r -a "/tmp/.ssh-pageant-$USERNAME")
 ....
+


### PR DESCRIPTION
the native SSH setup works with gpg 2.4+ so add this documentation and make the choice of ssh client a personal one.