### PR TITLE
YubiHSM2: fix put option command-audit example

### DIFF
--- a/content/YubiHSM2/Commands/Set_Option.adoc
+++ b/content/YubiHSM2/Commands/Set_Option.adoc
@@ -12,7 +12,7 @@ TAG-LENGTH-VALUE (TLV).
 
 Turn off audit logging for Sign HMAC (command `53`) and Verify HMAC (command `5c`):
 
-  yubihsm> put option 0 command_audit 53005c00
+  yubihsm> put option 0 command-audit 53005c00
 
 == Protocol Details
 


### PR DESCRIPTION
- yubihsm-shell expects command-audit not command_audit