### PR TITLE
libfido2: sync docs with 1.13.0

### DIFF
--- a/content/projects/libfido2/Manuals/fido_assert_allow_cred.partial
+++ b/content/projects/libfido2/Manuals/fido_assert_allow_cred.partial
@@ -21,8 +21,9 @@
 </table>
 <div class="manual-text">
 <h1 class="Sh" title="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
-<code class="Nm" title="Nm">fido_assert_allow_cred</code> &#x2014;
-<div class="Nd" title="Nd">allow a credential in a FIDO2 assertion</div>
+<code class="Nm" title="Nm">fido_assert_allow_cred</code>,
+  <code class="Nm" title="Nm">fido_assert_empty_allow_list</code> &#x2014;
+<div class="Nd" title="Nd">manage allow lists in a FIDO2 assertion</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
   &lt;<a class="In" title="In">fido.h</a>&gt;</code>
@@ -33,6 +34,11 @@
   *assert</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
   unsigned char *ptr</var>,
   <var class="Fa" title="Fa" style="white-space: nowrap;">size_t len</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
+<code class="Fn" title="Fn">fido_assert_empty_allow_list</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_assert_t
+  *assert</var>);
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
 The <code class="Fn" title="Fn">fido_assert_allow_cred</code>() function adds
   <var class="Fa" title="Fa">ptr</var> to the list of credentials allowed in
@@ -46,10 +52,16 @@ The <code class="Fn" title="Fn">fido_assert_allow_cred</code>() function adds
 <div class="Pp"></div>
 For the format of a FIDO2 credential ID, please refer to the Web Authentication
   (webauthn) standard.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_assert_empty_allow_list</code>() function
+  empties the list of credentials allowed in
+  <var class="Fa" title="Fa">assert</var>.
 <h1 class="Sh" title="Sh" id="RETURN_VALUES"><a class="permalink" href="#RETURN_VALUES">RETURN
   VALUES</a></h1>
 The error codes returned by
-  <code class="Fn" title="Fn">fido_assert_allow_cred</code>() are defined in
+  <code class="Fn" title="Fn">fido_assert_allow_cred</code>() and
+  <code class="Fn" title="Fn">fido_assert_empty_allow_list</code>() are defined
+  in
   <code class="In" title="In">&lt;<a class="In" title="In">fido/err.h</a>&gt;</code>.
   On success, <code class="Dv" title="Dv">FIDO_OK</code> is returned.
 <h1 class="Sh" title="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
@@ -59,7 +71,7 @@ The error codes returned by
   <a class="Xr" title="Xr" href="fido_dev_get_assert.html">fido_dev_get_assert(3)</a></div>
 <table class="foot">
   <tr>
-    <td class="foot-date">May 23, 2018</td>
+    <td class="foot-date">December 1, 2022</td>
     <td class="foot-os">Linux 5.3.12-arch1-1</td>
   </tr>
 </table>

--- a/content/projects/libfido2/Manuals/fido_assert_empty_allow_list.partial
+++ b/content/projects/libfido2/Manuals/fido_assert_empty_allow_list.partial
@@ -1,0 +1,1 @@
+fido_assert_allow_cred.partial

--- a/content/projects/libfido2/Manuals/fido_cred_empty_exclude_list.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_empty_exclude_list.partial
@@ -1,0 +1,1 @@
+fido_cred_exclude.partial

--- a/content/projects/libfido2/Manuals/fido_cred_exclude.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_exclude.partial
@@ -21,9 +21,9 @@
 </table>
 <div class="manual-text">
 <h1 class="Sh" title="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
-<code class="Nm" title="Nm">fido_cred_exclude</code> &#x2014;
-<div class="Nd" title="Nd">appends a credential ID to a credential's list of
-  excluded credentials</div>
+<code class="Nm" title="Nm">fido_cred_exclude</code>,
+  <code class="Nm" title="Nm">fido_cred_empty_exclude_list</code> &#x2014;
+<div class="Nd" title="Nd">manage exclude lists in a FIDO2 credential</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
   &lt;<a class="In" title="In">fido.h</a>&gt;</code>
@@ -34,6 +34,11 @@
   *cred</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
   unsigned char *ptr</var>,
   <var class="Fa" title="Fa" style="white-space: nowrap;">size_t len</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
+<code class="Fn" title="Fn">fido_cred_empty_exclude_list</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_cred_t
+  *cred</var>);
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
 The <code class="Fn" title="Fn">fido_cred_exclude</code>() function adds
   <var class="Fa" title="Fa">ptr</var> to the list of credentials excluded by
@@ -54,10 +59,16 @@ If <code class="Nm" title="Nm">fido_cred_exclude</code> returns success and
 <div class="Pp"></div>
 For the format of a FIDO2 credential ID, please refer to the Web Authentication
   (webauthn) standard.
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_cred_empty_exclude_list</code>() function
+  empties the list of credentials excluded by
+  <var class="Fa" title="Fa">cred</var>.
 <h1 class="Sh" title="Sh" id="RETURN_VALUES"><a class="permalink" href="#RETURN_VALUES">RETURN
   VALUES</a></h1>
 The error codes returned by
-  <code class="Fn" title="Fn">fido_cred_exclude</code>() are defined in
+  <code class="Fn" title="Fn">fido_cred_exclude</code>() and
+  <code class="Fn" title="Fn">fido_cred_empty_exclude_list</code>() are defined
+  in
   <code class="In" title="In">&lt;<a class="In" title="In">fido/err.h</a>&gt;</code>.
   On success, <code class="Dv" title="Dv">FIDO_OK</code> is returned.
 <h1 class="Sh" title="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
@@ -67,7 +78,7 @@ The error codes returned by
   <a class="Xr" title="Xr" href="fido_dev_make_cred.html">fido_dev_make_cred(3)</a></div>
 <table class="foot">
   <tr>
-    <td class="foot-date">May 23, 2018</td>
+    <td class="foot-date">December 2, 2022</td>
     <td class="foot-os">Linux 5.3.12-arch1-1</td>
   </tr>
 </table>


### PR DESCRIPTION
- new API calls:
  * fido_assert_empty_allow_list;
  * fido_cred_empty_exclude_list.