### PR TITLE
Tickets 421593

### DIFF
--- a/content/PGP/Card_edit.adoc
+++ b/content/PGP/Card_edit.adoc
@@ -46,7 +46,7 @@ To check the application version you may run, after inserting your YubiKey:
 
 Where "01 00 05" means version 1.0.5. (see security advisory above if version < 1.0.10)
 
-Note that with the release of YubiKey 4, this number will always be
+Note that with the release of YubiKey 4 and 5, this number will always be
 equal to the firmware version.
 
 == YubiKey 4 touch
@@ -73,8 +73,14 @@ fix:: touch is enabled and can not be disabled unless a new private
 The touch parameter can be individually set on each one of the three
 private keys and requires the use of the admin PIN.
 
-In order to activate this functionality, it is necessary to use a custom
+In order to activate this functionality, you can use a custom
 bash script called link:https://github.com/a-dma/yubitouch[yubitouch.sh].
+
+Alternatively, you kan use the
+link:https://developers.yubico.com/yubikey-manager/[YubiKey Manager CLI]
+to set the touch ID policy.  See the
+link:https://docs.yubico.com/software/yubikey/tools/ykman/OpenPGP_Commands.html#ykman-openpgp-keys-set-touch-options-key-policy[ykman openpgp documentation]
+for more information.
 
 == Example
 

--- a/content/PIV/Guides/Certificate_authority.adoc
+++ b/content/PIV/Guides/Certificate_authority.adoc
@@ -6,7 +6,7 @@ to generate HTTPS certificates for internal servers.
 === Considerations
 For our example, we have chosen to use one root CA with a private key
 stored in an offline machine, that signs sub-CAs with private keys
-stored on YubiKeys, which signs end-entity (EE) certs.  We'll
+stored on YubiKeys, which signs end-entity (EE) certificates.  We'll
 generate the Sub-CA private keys on an offline host and save a copy of
 those keys.
 
@@ -71,8 +71,9 @@ counter as follows:
   permitted;DNS=yubico.com
   permitted;URI.0=yubico.com
   permitted;URI.1=.yubico.com
-  permitted;IP.0=0.0.0.0/255.255.255.255
-  permitted;IP.1=::/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+  excluded;IP.0=0.0.0.0/0.0.0.0
+  excluded;IP.1=0:0:0:0:0:0:0:0/0:0:0:0:0:0:0:0
+
   EOF
   $ datefudge "2014-01-01 UTC" openssl req -new -sha256 -x509 -set_serial 1 -days 1000000 -config yubico-internal-https-ca.conf -key yubico-internal-https-ca-key.pem -out yubico-internal-https-ca-crt.pem
   $ echo 01 > yubico-internal-https-ca-crt.srl
@@ -141,7 +142,7 @@ Generate the Sub-CA certificate:
   $ openssl x509 -sha256 -CA yubico-internal-https-ca-crt.pem -CAkey yubico-internal-https-ca-key.pem -req -in yubico-internal-https-subca-$user-csr.pem -extfile yubico-internal-https-subca-$user-crt.conf -out yubico-internal-https-subca-$user-crt.pem
   $ echo 00 > yubico-internal-https-subca-$user-crt.srl
 
-You may inspect the newly generated EE cert with this command:
+You may inspect the newly generated Sub-CA certificate with this command:
 
   $ openssl x509 -text < yubico-internal-https-subca-$user-crt.pem
 
@@ -149,7 +150,7 @@ Import Sub-CA key to the YubiKey:
 
   $ yubico-piv-tool -k $key -a import-key -s 9c < yubico-internal-https-subca-$user-key.pem
 
-Import Sub-CA cert to the YubiKey:
+Import Sub-CA certificate to the YubiKey:
 
   $ yubico-piv-tool -k $key -a import-certificate -s 9c < yubico-internal-https-subca-$user-crt.pem
 
@@ -189,6 +190,6 @@ Then sign the certificate using the:
   x509 -engine pkcs11 -CAkeyform engine -CAkey slot_1-id_2 -sha256 -CA yubico-internal-https-subca-$user-crt.pem -req -passin pass:$pin -in yubico-internal-https-ee-$host-csr.pem -extfile yubico-internal-https-ee-$host-crt.conf -out yubico-internal-https-ee-$host-crt.pem
   EOF
 
-You may inspect the newly generated EE cert with this command:
+You may inspect the newly generated EE certificate with this command:
 
   $ openssl x509 -text < yubico-internal-https-ee-$host-crt.pem


### PR DESCRIPTION
The subnet masks in the CA docs did not make sense, as they allowed only issuance of non-routable all-0s addresses. Changed to masks corresponding to /0 prefixes, and changed from permitted to excluded as using DNS names should be preferred over IP addresses.
