### PR TITLE
Add webauthn-server-attestation subpage to java-webauthn-server

### DIFF
--- a/content/projects/java-webauthn-server/.conf.json
+++ b/content/projects/java-webauthn-server/.conf.json
@@ -17,8 +17,9 @@
       "files": [
         ["README.adoc", "index.adoc"],
         ["NEWS", "Release_Notes.adoc"],
+        ["webauthn-server-attestation/README", "webauthn-server-attestation/index.adoc"],
         ["webauthn-server-demo/README", "webauthn-server-demo/index.adoc"]
-	  ]
+      ]
     }
   ],
   "javadoc": {


### PR DESCRIPTION
This should fix some broken links, see: https://github.com/Yubico/java-webauthn-server/issues/271#issuecomment-1532976111