### PR TITLE
libfido2: sync docs with 1.14.0

### DIFF
--- a/content/projects/libfido2/Manuals/fido2-assert.partial
+++ b/content/projects/libfido2/Manuals/fido2-assert.partial
@@ -28,7 +28,7 @@
   <tr>
     <td><code class="Nm" title="Nm">fido2-assert</code></td>
     <td><code class="Fl" title="Fl">-G</code>
-      [<div class="Op"><code class="Fl" title="Fl">-bdhpruv</code></div>]
+      [<div class="Op"><code class="Fl" title="Fl">-bdhpruvw</code></div>]
       [<div class="Op"><code class="Fl" title="Fl">-t</code>
       <var class="Ar" title="Ar">option</var></div>]
       [<div class="Op"><code class="Fl" title="Fl">-i</code>
@@ -144,6 +144,11 @@ The options are as follows:
   <dd>If obtaining an assertion, prompt the user for a PIN and request user
       verification from the authenticator. If verifying an assertion, check
       whether the user verification bit was signed by the authenticator.</dd>
+  <dt><a class="permalink" href="#w"><code class="Fl" title="Fl" id="w">-w</code></a></dt>
+  <dd>Tells <code class="Nm" title="Nm">fido2-assert</code> that the first line
+      of input when obtaining an assertion shall be interpreted as unhashed
+      client data. This is required by Windows Hello, which calculates the
+      client data hash internally.</dd>
 </dl>
 <div class="Pp"></div>
 If a <i class="Em" title="Em">tty</i> is available,
@@ -222,7 +227,7 @@ Assuming <span class="Pa" title="Pa">cred</span> contains a
   <a class="Xr" title="Xr" href="fido2-token.html">fido2-token(1)</a></div>
 <table class="foot">
   <tr>
-    <td class="foot-date">November 5, 2019</td>
-    <td class="foot-os">Linux 5.3.12-arch1-1</td>
+    <td class="foot-date">July 3, 2023</td>
+    <td class="foot-os">Debian</td>
   </tr>
 </table>

--- a/content/projects/libfido2/Manuals/fido2-cred.partial
+++ b/content/projects/libfido2/Manuals/fido2-cred.partial
@@ -28,7 +28,7 @@
   <tr>
     <td><code class="Nm" title="Nm">fido2-cred</code></td>
     <td><code class="Fl" title="Fl">-M</code>
-      [<div class="Op"><code class="Fl" title="Fl">-bdhqruv</code></div>]
+      [<div class="Op"><code class="Fl" title="Fl">-bdhqruvw</code></div>]
       [<div class="Op"><code class="Fl" title="Fl">-c</code>
       <var class="Ar" title="Ar">cred_protect</var></div>]
       [<div class="Op"><code class="Fl" title="Fl">-i</code>
@@ -139,6 +139,11 @@ The options are as follows:
   <dd>If making a credential, request user verification. If verifying a
       credential, check whether the user verification bit was signed by the
       authenticator.</dd>
+  <dt><a class="permalink" href="#w"><code class="Fl" title="Fl" id="w">-w</code></a></dt>
+  <dd>Tells <code class="Nm" title="Nm">fido2-cred</code> that the first line of
+      input when making a credential shall be interpreted as unhashed client
+      data. This is required by Windows Hello, which calculates the client data
+      hash internally.</dd>
 </dl>
 <h1 class="Sh" title="Sh" id="INPUT_FORMAT"><a class="permalink" href="#INPUT_FORMAT">INPUT
   FORMAT</a></h1>
@@ -224,7 +229,7 @@ Please note that <code class="Nm" title="Nm">fido2-cred</code> handles Basic
   <i class="Em" title="Em">not</i> verified.</div>
 <table class="foot">
   <tr>
-    <td class="foot-date">November 5, 2019</td>
-    <td class="foot-os">Linux 5.3.12-arch1-1</td>
+    <td class="foot-date">July 3, 2023</td>
+    <td class="foot-os">Debian</td>
   </tr>
 </table>

--- a/content/projects/libfido2/Manuals/fido_assert_authdata_raw_len.partial
+++ b/content/projects/libfido2/Manuals/fido_assert_authdata_raw_len.partial
@@ -1,0 +1,1 @@
+fido_assert_new.partial

--- a/content/projects/libfido2/Manuals/fido_assert_authdata_raw_ptr.partial
+++ b/content/projects/libfido2/Manuals/fido_assert_authdata_raw_ptr.partial
@@ -1,0 +1,1 @@
+fido_assert_new.partial

--- a/content/projects/libfido2/Manuals/fido_assert_new.partial
+++ b/content/projects/libfido2/Manuals/fido_assert_new.partial
@@ -29,6 +29,7 @@
   <code class="Nm" title="Nm">fido_assert_user_icon</code>,
   <code class="Nm" title="Nm">fido_assert_user_name</code>,
   <code class="Nm" title="Nm">fido_assert_authdata_ptr</code>,
+  <code class="Nm" title="Nm">fido_assert_authdata_raw_ptr</code>,
   <code class="Nm" title="Nm">fido_assert_blob_ptr</code>,
   <code class="Nm" title="Nm">fido_assert_clientdata_hash_ptr</code>,
   <code class="Nm" title="Nm">fido_assert_hmac_secret_ptr</code>,
@@ -37,6 +38,7 @@
   <code class="Nm" title="Nm">fido_assert_sig_ptr</code>,
   <code class="Nm" title="Nm">fido_assert_id_ptr</code>,
   <code class="Nm" title="Nm">fido_assert_authdata_len</code>,
+  <code class="Nm" title="Nm">fido_assert_authdata_raw_len</code>,
   <code class="Nm" title="Nm">fido_assert_blob_len</code>,
   <code class="Nm" title="Nm">fido_assert_clientdata_hash_len</code>,
   <code class="Nm" title="Nm">fido_assert_hmac_secret_len</code>,
@@ -96,6 +98,12 @@
 <div class="Pp"></div>
 <var class="Ft" title="Ft">const unsigned char *</var>
 <br/>
+<code class="Fn" title="Fn">fido_assert_authdata_raw_ptr</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_assert_t *assert</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">size_t idx</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">const unsigned char *</var>
+<br/>
 <code class="Fn" title="Fn">fido_assert_clientdata_hash_ptr</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_assert_t *assert</var>);
 <div class="Pp"></div>
@@ -138,6 +146,12 @@
 <var class="Ft" title="Ft">size_t</var>
 <br/>
 <code class="Fn" title="Fn">fido_assert_authdata_len</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_assert_t *assert</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">size_t idx</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">size_t</var>
+<br/>
+<code class="Fn" title="Fn">fido_assert_authdata_raw_len</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_assert_t *assert</var>,
   <var class="Fa" title="Fa" style="white-space: nowrap;">size_t idx</var>);
 <div class="Pp"></div>
@@ -240,15 +254,16 @@ The <code class="Fn" title="Fn">fido_assert_user_display_name</code>(),
   resident/discoverable credentials were involved in the assertion.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_assert_authdata_ptr</code>(),
+  <code class="Fn" title="Fn">fido_assert_authdata_raw_ptr</code>(),
   <code class="Fn" title="Fn">fido_assert_clientdata_hash_ptr</code>(),
   <code class="Fn" title="Fn">fido_assert_id_ptr</code>(),
   <code class="Fn" title="Fn">fido_assert_user_id_ptr</code>(),
   <code class="Fn" title="Fn">fido_assert_sig_ptr</code>(),
   <code class="Fn" title="Fn">fido_assert_sigcount</code>(), and
   <code class="Fn" title="Fn">fido_assert_flags</code>() functions return
-  pointers to the CBOR-encoded authenticator data, client data hash, credential
-  ID, user ID, signature, signature count, and authenticator data flags of
-  statement <var class="Fa" title="Fa">idx</var> in
+  pointers to the CBOR-encoded and raw authenticator data, client data hash,
+  credential ID, user ID, signature, signature count, and authenticator data
+  flags of statement <var class="Fa" title="Fa">idx</var> in
   <var class="Fa" title="Fa">assert</var>.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_assert_hmac_secret_ptr</code>() function
@@ -268,6 +283,7 @@ The <code class="Fn" title="Fn">fido_assert_blob_ptr</code>() and
   Blob Key (largeBlobKey) are CTAP 2.1 extensions.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_assert_authdata_len</code>(),
+  <code class="Fn" title="Fn">fido_assert_authdata_raw_len</code>(),
   <code class="Fn" title="Fn">fido_assert_clientdata_hash_len</code>(),
   <code class="Fn" title="Fn">fido_assert_id_len</code>(),
   <code class="Fn" title="Fn">fido_assert_user_id_len</code>(),
@@ -314,7 +330,7 @@ The <code class="Fn" title="Fn">fido_assert_rp_id</code>(),
   <a class="Xr" title="Xr" href="fido_dev_largeblob_get.html">fido_dev_largeblob_get(3)</a></div>
 <table class="foot">
   <tr>
-    <td class="foot-date">April 27, 2022</td>
-    <td class="foot-os">Linux 5.17.4-200.fc35.x86_64</td>
+    <td class="foot-date">June 19, 2023</td>
+    <td class="foot-os">Debian</td>
   </tr>
 </table>

--- a/content/projects/libfido2/Manuals/fido_assert_set_authdata.partial
+++ b/content/projects/libfido2/Manuals/fido_assert_set_authdata.partial
@@ -32,7 +32,8 @@
   <code class="Nm" title="Nm">fido_assert_set_up</code>,
   <code class="Nm" title="Nm">fido_assert_set_uv</code>,
   <code class="Nm" title="Nm">fido_assert_set_rp</code>,
-  <code class="Nm" title="Nm">fido_assert_set_sig</code> &#x2014;
+  <code class="Nm" title="Nm">fido_assert_set_sig</code>,
+  <code class="Nm" title="Nm">fido_assert_set_winhello_appid</code> &#x2014;
 <div class="Nd" title="Nd">set parameters of a FIDO2 assertion</div>
 <h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <code class="In" title="In">#include
@@ -130,6 +131,12 @@ typedef enum {
   idx</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
   unsigned char *ptr</var>,
   <var class="Fa" title="Fa" style="white-space: nowrap;">size_t len</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
+<code class="Fn" title="Fn">fido_assert_set_winhello_appid</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_assert_t
+  *assert</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
+  char *id</var>);
 <h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
 The <code class="Nm" title="Nm">fido_assert_set_authdata</code> set of functions
   define the various parameters of a FIDO2 assertion, allowing a
@@ -218,6 +225,33 @@ The <code class="Fn" title="Fn">fido_assert_set_up</code>() and
   <code class="Dv" title="Dv">FIDO_OPT_OMIT</code> by default, allowing the
   authenticator to use its default settings.
 <div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_assert_set_winhello_appid</code>() function
+  sets the U2F application <var class="Fa" title="Fa">id</var> (&#x201C;U2F
+  AppID&#x201D;) of <var class="Fa" title="Fa">assert</var>, where
+  <var class="Fa" title="Fa">id</var> is a NUL-terminated UTF-8 string. The
+  content of <var class="Fa" title="Fa">id</var> is copied, and no references to
+  the passed pointer are kept. The
+  <code class="Fn" title="Fn">fido_assert_set_winhello_appid</code>() function
+  is a no-op unless <var class="Fa" title="Fa">assert</var> is passed to
+  <a class="Xr" title="Xr" href="fido_dev_get_assert.html">fido_dev_get_assert(3)</a>
+  with a device <var class="Fa" title="Fa">dev</var> on which
+  <a class="Xr" title="Xr" href="fido_dev_is_winhello.html">fido_dev_is_winhello(3)</a>
+  holds true. In this case, <i class="Em" title="Em">libfido2</i> will instruct
+  Windows Hello to try the assertion twice, first with the
+  <var class="Fa" title="Fa">id</var> passed to
+  <code class="Fn" title="Fn">fido_assert_set_rp</code>(), and a second time
+  with the <var class="Fa" title="Fa">id</var> passed to
+  <code class="Fn" title="Fn">fido_assert_set_winhello_appid</code>(). If the
+  second assertion succeeds,
+  <a class="Xr" title="Xr" href="fido_assert_rp_id.html">fido_assert_rp_id(3)</a>
+  will point to the U2F AppID once
+  <a class="Xr" title="Xr" href="fido_dev_get_assert.html">fido_dev_get_assert(3)</a>
+  completes. This mechanism exists in Windows Hello to ensure U2F backwards
+  compatibility without the application inadvertently prompting the user twice.
+  Note that <code class="Fn" title="Fn">fido_assert_set_winhello_appid</code>()
+  is not needed on platforms offering CTAP primitives, since the authenticator
+  can be silently probed for the existence of U2F credentials.
+<div class="Pp"></div>
 Use of the <code class="Nm" title="Nm">fido_assert_set_authdata</code> set of
   functions may happen in two distinct situations: when asking a FIDO2 device to
   produce a series of assertion statements, prior to
@@ -244,10 +278,11 @@ The <code class="Nm" title="Nm">fido_assert_set_authdata</code> functions return
   ALSO</a></h1>
 <a class="Xr" title="Xr" href="fido_assert_allow_cred.html">fido_assert_allow_cred(3)</a>,
   <a class="Xr" title="Xr" href="fido_assert_verify.html">fido_assert_verify(3)</a>,
-  <a class="Xr" title="Xr" href="fido_dev_get_assert.html">fido_dev_get_assert(3)</a></div>
+  <a class="Xr" title="Xr" href="fido_dev_get_assert.html">fido_dev_get_assert(3)</a>,
+  <a class="Xr" title="Xr" href="fido_dev_is_winhello.html">fido_dev_is_winhello(3)</a></div>
 <table class="foot">
   <tr>
-    <td class="foot-date">April 27, 2022</td>
-    <td class="foot-os">Linux 5.17.4-200.fc35.x86_64</td>
+    <td class="foot-date">April 8, 2023</td>
+    <td class="foot-os">Debian</td>
   </tr>
 </table>

--- a/content/projects/libfido2/Manuals/fido_assert_set_winhello_appid.partial
+++ b/content/projects/libfido2/Manuals/fido_assert_set_winhello_appid.partial
@@ -1,0 +1,1 @@
+fido_assert_set_authdata.partial


### PR DESCRIPTION
new API calls:
 * fido_assert_authdata_raw_len;
 * fido_assert_authdata_raw_ptr;
 * fido_assert_set_winhello_appid.