### PR TITLE
Added ref for new software supply chain guide

### DIFF
--- a/content/Developer_Program/Secure_Software_Supply_Chain_Guide.adoc
+++ b/content/Developer_Program/Secure_Software_Supply_Chain_Guide.adoc
@@ -1,0 +1,19 @@
+= Secure Software Supply Chain Guide
+:description: Developer guide to teach you how to maximize the power of the YubiKey to secure your software supply chain. This guide contains examples on how to use the YubiKey to enable account protections, commit signing, and code signing. By the end of this guide you, and your organization will have the tools needed to quickly onboard developers to allow them to focus more time on producing code, and less time configuring their environment.
+:keywords: software supply chain, ssh, gpg, passkeys, yubikeys, yubihsm
+
+Protection for all stages of the development lifecycle
+
+What happens when the call is coming from inside the house? Organizations that develop applications are increasingly being targeted in software supply chain attacks.
+
+A software supply chain attack is when malicious code is added into software that was meant to be trusted. An attack doesn't only refer to the code that is committed by your developers, it can also refer to code from:
+
+* Dependencies/packages
+* Code written by parties external to your company
+* Web services called by your codebase
+
+With this in mind you may be asking what can be done to protect your codebase? Yubico’s various products can be leveraged in ways that can help protect software through the development lifecycle. In this series we will explore different attack scenarios, and step-by-step instructions on how to mitigate the risk using YubiKeys and the YubiHSM2.
+
+Click the link below if you're ready to begin!
+
+link:https://yubicolabs.github.io/secure-software-supply-chain-guide/[Link to Yubico's Secure Software Supply Chain Guide]


### PR DESCRIPTION
Added a reference to the dev program site to the new secure software supply chain guide; similar to what we have for the passkey workshop. This will add to the SEO and searchability of the guide 