### PR TITLE
Update PIV_attestation.adoc

### DIFF
--- a/content/PIV/Introduction/PIV_attestation.adoc
+++ b/content/PIV/Introduction/PIV_attestation.adoc
@@ -31,8 +31,8 @@ Extensions in the generated certificate:
 ** USB-C Keychain: 03 (83 for FIPS Devices)
 ** USB-C Nano: 04 (84 for FIPS Devices)
 ** Lightning and USB-C: 05 (85 for FIPS Devices)
-* +1.3.6.1.4.1.41482.3.10+: FIPS Certified YubiKey
-* +1.3.6.1.4.1.41482.3.11+: CSPN Certified YubiKey
+* +1.3.6.1.4.1.41482.3.10+: FIPS Certified YubiKey (Only present on the factory-loaded Attestation certificate in slot f9. This certificate will be included as part of the attestation certificate chain)
+* +1.3.6.1.4.1.41482.3.11+: CSPN Certified YubiKey (Only present on the factory-loaded Attestation certificate in slot f9. This certificate will be included as part of the attestation certificate chain)
 
 The YubiKey comes with a pre-loaded attestation certificate signed by a link:piv-attestation-ca.pem[Yubico PIV CA]. This can be overwritten by loading a new key and certificate to slot f9. After the Yubico key is overwritten it can not be brought back. The attestation key and certificate will not be cleared out by a reset of the device.
 


### PR DESCRIPTION
Expanded on where users can find the FIPS/CSPN in the attestation certificate chain - pointed users to the factory-loaded certificate in slot f9.