### PR TITLE
Remove large binaries from the deployed container

### DIFF
--- a/content/.conf.json
+++ b/content/.conf.json
@@ -68,6 +68,7 @@
           {
             "url": "git@github.com:Yubico/yubico-binaries.git",
             "preserve_mtimes": true,
+            "skip_lfs": true,
             "files": [
               ["%(name)s/releases/*", "Releases/"],
               ["%(name)s/mans/*.adoc", "Manuals/"],

--- a/content/Archive_Old_Dev_Docs/YubiHSM2/.conf.json
+++ b/content/Archive_Old_Dev_Docs/YubiHSM2/.conf.json
@@ -13,6 +13,7 @@
     {
       "url": "git@github.com:Yubico/yubico-binaries.git",
       "preserve_mtimes": true,
+      "skip_lfs": true,
       "files": [
         ["yubihsm2/releases/*", "Releases/"]
       ]

--- a/content/YubiHSM2/.conf.json
+++ b/content/YubiHSM2/.conf.json
@@ -13,6 +13,7 @@
     {
       "url": "git@github.com:Yubico/yubico-binaries.git",
       "preserve_mtimes": true,
+      "skip_lfs": true,
       "files": [
         ["yubihsm2/releases/*", "Releases/"]
       ]

--- a/content/projects/windows-apis/.conf.json
+++ b/content/projects/windows-apis/.conf.json
@@ -8,7 +8,8 @@
     "git": [
       {
         "url": "git@github.com:Yubico/yubico-binaries.git",
-    	"files": [["windows-apis/releases/*", "Releases/"]]
+        "skip_lfs": true,
+        "files": [["windows-apis/releases/*", "Releases/"]]
       }
     ]
 }

--- a/devyco/modules/git.py
+++ b/devyco/modules/git.py
@@ -4,6 +4,7 @@ Activated by a "git" entry in .conf.json, containing the following settings:
     url: Git repository URL (required).
     files: List of filepatterns to copy from the repository (default: all)
     preserve_mtimes: If true, set mtimes based on commit times (default: false)
+    skip_lfs: If true, fetch the repo without pulling Git LFS objects
 
 The "git" entry can also be a list of objects containing the settings above if
 multiple repositories should be clones.
@@ -94,8 +95,10 @@ class GitModule(Module):
                                       cwd=repo_dir, stderr=sys.stdout.fileno())
             else:
                 print "clone:", url
-                subprocess.check_call(['git', 'clone', url, repo_dir],
-                                stderr=sys.stdout.fileno())
+                clone_cmd = ['git', 'clone', url, repo_dir]
+                if conf.get('skip_lfs'):
+                    clone_cmd += ['-c', 'filter.lfs.process=git-lfs filter-process --skip']
+                subprocess.check_call(clone_cmd, stderr=sys.stdout.fileno())
             subprocess.check_call(['git', 'reset', 'origin/%s' % branch, '--hard'],
                                   cwd=repo_dir, stderr=sys.stdout.fileno())
 


### PR DESCRIPTION
Depends on https://github.com/Yubico/yubico-binaries/pull/144

The developers.yubico.com site builds into a huge Docker image that contains about 15 GB of binaries. This causes some issues in our Kubernetes clusters and generally just isn't a good use of resources, so we'd like to shrink the container image.
https://yubico.atlassian.net/browse/INFRA-5045

Fastly has been configured to route requests directly to a GCS bucket instead of from the `developers` pod.
https://github.com/Yubico/infra-fastly/pull/166

That means that we don't need the binaries in this container anymore. The https://github.com/Yubico/yubico-binaries repo is still cloned during the build process, but the Git LFS objects aren't fetched. The LFS pointer files are used as placeholders so the release page generation scripts will still work the same as before.