### PR TITLE
rename OS X to macOS

### DIFF
--- a/content/OATH/OATH_Walk-Through.adoc
+++ b/content/OATH/OATH_Walk-Through.adoc
@@ -52,7 +52,7 @@ a)	Select the credential method: scan a QR code or enter Base32-encoded secret. 
 b)	Tap the YubiKey or connect it to display the codes.
 
 
-=== Configure YubiKey for Windows, OS X, or Linux with YubiKey Manager (GUI)
+=== Configure YubiKey for Windows, macOS, or Linux with YubiKey Manager (GUI)
 The link:https://developers.yubico.com/yubioath-flutter/[Yubico Authenticator for Desktop] enables you to read OATH codes from your YubiKey over USB. Support the newer OATH implementation as well as the older slot-based implementation.
 
 **Step 1**: Verify supported version:

--- a/content/OATH/YubiKey_OATH_software.adoc
+++ b/content/OATH/YubiKey_OATH_software.adoc
@@ -8,7 +8,7 @@ _For YubiKey 4, 5 and NEO._
 
 The link:/yubioath-flutter[Yubico Authenticator] app enables reading OATH codes from your YubiKey over NFC, or over USB (via a USB on-the-go adapter or by directly connecting a YubiKey 4C or 5Ci to a phone with a USB-C port).
 
-=== Windows, OS X and Linux
+=== Windows, macOS and Linux
 _For YubiKey 4, 5, NEO, Standard and Edge._
 
 The link:/yubioath-flutter[Yubico Authenticator for Desktop] enables reading OATH codes from your YubiKey over USB. The tools supports the newer OATH implementation (YubiKey NEO and 4) as well as the older slot-based implementation (YubiKey Standard and Edge).

--- a/content/OTP/OTP_Walk-Through.adoc
+++ b/content/OTP/OTP_Walk-Through.adoc
@@ -269,7 +269,7 @@ If you get stuck, you can check link:https://stackoverflow.com[Stack Overflow]. 
 
 View and download the relevant plug-in components.
 
-* link:https://developers.yubico.com/yubico-pam/[Yubico PAM module] – Pluggable Authentication Modules (PAM) for GNU/Linux, Solaris and Mac OS X for user authentication. -- Requires
+* link:https://developers.yubico.com/yubico-pam/[Yubico PAM module] – Pluggable Authentication Modules (PAM) for GNU/Linux, Solaris and macOS for user authentication. -- Requires
 link:https://developers.yubico.com/yubico-c-client/[libykclient],
 link:https://github.com/Yubico/yubico-pam[libpam-dev,]
 cURL,

--- a/content/PGP/SSH_authentication/index.adoc
+++ b/content/PGP/SSH_authentication/index.adoc
@@ -7,7 +7,7 @@ using your YubiKey we recommend disabling password login on your SSH server.
 === Configuration guides
 
  - link:Windows.html[Windows]
- - https://florin.myip.org/blog/easy-multifactor-authentication-ssh-using-yubikey-neo-tokens[OS X]
+ - https://florin.myip.org/blog/easy-multifactor-authentication-ssh-using-yubikey-neo-tokens[macOS]
  - https://www.esev.com/blog/post/2015-01-pgp-ssh-key-on-yubikey-neo[Linux]
  - https://gist.github.com/artizirk/d09ce3570021b0f65469cb450bee5e29[Ubuntu (18.04 and newer)]
  - https://chromium.googlesource.com/apps/libapps/+/HEAD/nassh/doc/hardware-keys.md[ChromeOS]

--- a/content/PIV/Guides/PIV_Walk-Through.adoc
+++ b/content/PIV/Guides/PIV_Walk-Through.adoc
@@ -20,7 +20,7 @@ The Yubico PIV tool is available link:https://developers.yubico.com/yubico-piv-t
 Install:
 
 * OpenSSH
-* For OS X, iOS 10.13 or later.
+* For macOS, iOS 10.13 or later.
 
 To implement the PIV security protocol in your app, ensure that your app:
 
@@ -46,7 +46,7 @@ The steps to enable your app to use the PIV protocol vary depending upon the ope
 === Configuration Prerequisites
 To manage the PIV security protocol on your PIV-compliant app, on the administrative system, install the Yubico PIV tool and the Yubico PKCS#11 module, ykcs11, which is part of the PIV tool package.
 
-For SSH on PKCS#11, configure public key authentication with link:https://developers.yubico.com/PIV/Guides/SSH_with_PIV_and_PKCS11.html[OpenSSH through PKCS#11], which provides examples for OS X and Linux systems.
+For SSH on PKCS#11, configure public key authentication with link:https://developers.yubico.com/PIV/Guides/SSH_with_PIV_and_PKCS11.html[OpenSSH through PKCS#11], which provides examples for macOS and Linux systems.
 
 
 === Generate or Import an SSH Private Key with a YubiKey

--- a/content/PIV/Guides/SSH_user_certificates.adoc
+++ b/content/PIV/Guides/SSH_user_certificates.adoc
@@ -1,6 +1,6 @@
 == Using SSH User Certificates with PIV keys
 This is a step-by-step on how to setup SSH user certificates using PIV
-for hardware-backed keys. This guide is primarily for an OS X or
+for hardware-backed keys. This guide is primarily for an macOS or
 Linux system.
 
 === Prerequisites
@@ -42,7 +42,7 @@ b. Generate a key and sign a certificate. (Note the second operation will requir
   $ ssh-add -D
   $ ssh-add -e /PATH/TO/libykcs11.so
 
-  * Make sure to use the correct path (e.g. `/usr/local/lib`) and extension (`.so` for Linux, `.dylib` for Mac OS X) for libykcs11.
+  * Make sure to use the correct path (e.g. `/usr/local/lib`) and extension (`.so` for Linux, `.dylib` for macOS) for libykcs11.
 
   * Beware that `ssh-add -D` doesn't seem to clear PKCS#11 libraries, only keys
 (https://lists.mindrot.org/pipermail/openssh-unix-dev/2016-July/035154.html[link]).

--- a/content/PIV/Guides/SSH_with_PIV_and_PKCS11.adoc
+++ b/content/PIV/Guides/SSH_with_PIV_and_PKCS11.adoc
@@ -1,11 +1,11 @@
 == Using PIV for SSH through PKCS #11
-This is a step-by-step guide on setting up a YubiKey with PIV to work for public-key authentication with OpenSSH through PKCS #11. These instructions apply primarily to OS X and Linux systems.
+This is a step-by-step guide on setting up a YubiKey with PIV to work for public-key authentication with OpenSSH through PKCS #11. These instructions apply primarily to macOS and Linux systems.
 
 === Prerequisites
 * a YubiKey with the PIV application loaded
 * the yubico-piv-tool software (download from link:../yubico-piv-tool/Releases/)
 * OpenSSH
-* For OS X, iOS 10.13 and later are supported
+* For macOS, iOS 10.13 and later are supported
 
 OpenSC is no longer required, since we now have a functional PKCS #11 module, namely ykcs11.
 

--- a/content/PIV/Introduction/Platform_support.adoc
+++ b/content/PIV/Introduction/Platform_support.adoc
@@ -4,8 +4,8 @@ You can use your PIV-enabled YubiKey on a variety of platforms.
 === Windows
 Windows has built-in PIV support. You can use it for logging in to an Active Directory connected machine, to encrypt files using BitLocker, to sign executables using signtool.exe, etc. For more information, see: https://technet.microsoft.com/en-us/library/ee706526(v=ws.10).aspx
 
-=== Linux and OS X
-Linux and OS X support PIV by using the tools provided by the https://github.com/OpenSC/OpenSC/wiki[OpenSC project].
+=== Linux and macOS
+Linux and macOS support PIV by using the tools provided by the https://github.com/OpenSC/OpenSC/wiki[OpenSC project].
 
 This enables you to sign software, to authenticate over SSH, and so on.
 

--- a/content/PIV/index.adoc
+++ b/content/PIV/index.adoc
@@ -8,4 +8,4 @@ You can read more about the PIV standards here:
 https://csrc.nist.gov/groups/SNS/piv/standards.html
 
 PIV is primarily used for non-web applications. It has built-in support under
-Windows, and can be used on OS X and Linux via the OpenSC project.
+Windows, and can be used on macOS and Linux via the OpenSC project.


### PR DESCRIPTION
In 2016, with the release of macOS 10.12 Sierra, the name was changed from OS X to macOS