### PR TITLE
libfido2: sync docs with 1.15.0

### DIFF
--- a/content/projects/libfido2/Manuals/fido_cred_new.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_new.partial
@@ -39,6 +39,8 @@
   <code class="Nm" title="Nm">fido_cred_pubkey_ptr</code>,
   <code class="Nm" title="Nm">fido_cred_sig_ptr</code>,
   <code class="Nm" title="Nm">fido_cred_user_id_ptr</code>,
+  <code class="Nm" title="Nm">fido_cred_x5c_list_count</code>,
+  <code class="Nm" title="Nm">fido_cred_x5c_list_ptr</code>,
   <code class="Nm" title="Nm">fido_cred_x5c_ptr</code>,
   <code class="Nm" title="Nm">fido_cred_attstmt_ptr</code>,
   <code class="Nm" title="Nm">fido_cred_authdata_len</code>,
@@ -50,6 +52,7 @@
   <code class="Nm" title="Nm">fido_cred_pubkey_len</code>,
   <code class="Nm" title="Nm">fido_cred_sig_len</code>,
   <code class="Nm" title="Nm">fido_cred_user_id_len</code>,
+  <code class="Nm" title="Nm">fido_cred_x5c_list_len</code>,
   <code class="Nm" title="Nm">fido_cred_x5c_len</code>,
   <code class="Nm" title="Nm">fido_cred_attstmt_len</code>,
   <code class="Nm" title="Nm">fido_cred_type</code>,
@@ -149,6 +152,17 @@
 <code class="Fn" title="Fn">fido_cred_user_id_ptr</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_cred_t *cred</var>);
 <div class="Pp"></div>
+<var class="Ft" title="Ft">size_t</var>
+<br/>
+<code class="Fn" title="Fn">fido_cred_x5c_list_count</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cred_t *cred</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">const unsigned char *</var>
+<br/>
+<code class="Fn" title="Fn">fido_cred_x5c_list_ptr</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cred_t *cred</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">size_t idx</var>);
+<div class="Pp"></div>
 <var class="Ft" title="Ft">const unsigned char *</var>
 <br/>
 <code class="Fn" title="Fn">fido_cred_x5c_ptr</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
@@ -203,6 +217,12 @@
 <br/>
 <code class="Fn" title="Fn">fido_cred_user_id_len</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
   fido_cred_t *cred</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">size_t</var>
+<br/>
+<code class="Fn" title="Fn">fido_cred_x5c_list_len</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">const
+  fido_cred_t *cred</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">size_t idx</var>);
 <div class="Pp"></div>
 <var class="Ft" title="Ft">size_t</var>
 <br/>
@@ -298,7 +318,7 @@ The <code class="Fn" title="Fn">fido_cred_authdata_ptr</code>(),
   <code class="Fn" title="Fn">fido_cred_attstmt_ptr</code>() functions return
   pointers to the CBOR-encoded and raw authenticator data, client data hash, ID,
   authenticator attestation GUID, &#x201C;largeBlobKey&#x201D;, public key,
-  signature, user ID, x509 certificate, and attestation statement parts of
+  signature, user ID, x509 leaf certificate, and attestation statement parts of
   <var class="Fa" title="Fa">cred</var>, or NULL if the respective entry is not
   set.
 <div class="Pp"></div>
@@ -314,6 +334,27 @@ The corresponding length can be obtained by
   <code class="Fn" title="Fn">fido_cred_user_id_len</code>(),
   <code class="Fn" title="Fn">fido_cred_x5c_len</code>(), and
   <code class="Fn" title="Fn">fido_cred_attstmt_len</code>().
+<div class="Pp"></div>
+The <code class="Fn" title="Fn">fido_cred_x5c_list_count</code>() function
+  returns the length of the x509 certificate chain in
+  <var class="Fa" title="Fa">cred</var> and the
+  <code class="Fn" title="Fn">fido_cred_x5c_list_ptr</code>() and
+  <code class="Fn" title="Fn">fido_cred_x5c_list_len</code>() functions return a
+  pointer to and length of the x509 certificate at index
+  <var class="Fa" title="Fa">idx</var> respectively. Please note that the leaf
+  certificate has an <var class="Fa" title="Fa">idx</var> (index) value of 0 and
+  calling
+  <code class="Fn" title="Fn">fido_cred_x5c_list_ptr</code>(<var class="Fa" title="Fa">cred</var>,
+  <var class="Fa" title="Fa">0</var>) and
+  <code class="Fn" title="Fn">fido_cred_x5c_list_len</code>(<var class="Fa" title="Fa">cred</var>,
+  <var class="Fa" title="Fa">0</var>) is equivalent to
+  <code class="Fn" title="Fn">fido_cred_x5c_ptr</code>(<var class="Fa" title="Fa">cred</var>)
+  and
+  <code class="Fn" title="Fn">fido_cred_x5c_len</code>(<var class="Fa" title="Fa">cred</var>)
+  respectively. If <var class="Fa" title="Fa">idx</var> exceeds the return value
+  of <code class="Fn" title="Fn">fido_cred_x5c_list_count</code>(),
+  <code class="Fn" title="Fn">fido_cred_x5c_list_ptr</code>() returns NULL and
+  <code class="Fn" title="Fn">fido_cred_x5c_list_len</code>() returns 0.
 <div class="Pp"></div>
 The authenticator data, x509 certificate, and signature parts of a credential
   are typically passed to a FIDO2 server for verification.

--- a/content/projects/libfido2/Manuals/fido_cred_set_attobj.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_set_attobj.partial
@@ -1,0 +1,1 @@
+fido_cred_set_authdata.partial

--- a/content/projects/libfido2/Manuals/fido_cred_set_authdata.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_set_authdata.partial
@@ -24,6 +24,7 @@
 <code class="Nm" title="Nm">fido_cred_set_authdata</code>,
   <code class="Nm" title="Nm">fido_cred_set_authdata_raw</code>,
   <code class="Nm" title="Nm">fido_cred_set_attstmt</code>,
+  <code class="Nm" title="Nm">fido_cred_set_attobj</code>,
   <code class="Nm" title="Nm">fido_cred_set_x509</code>,
   <code class="Nm" title="Nm">fido_cred_set_sig</code>,
   <code class="Nm" title="Nm">fido_cred_set_id</code>,
@@ -71,6 +72,13 @@ typedef enum {
 <var class="Ft" title="Ft">int</var>
 <br/>
 <code class="Fn" title="Fn">fido_cred_set_attstmt</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_cred_t
+  *cred</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
+  unsigned char *ptr</var>,
+  <var class="Fa" title="Fa" style="white-space: nowrap;">size_t len</var>);
+<div class="Pp"></div>
+<var class="Ft" title="Ft">int</var>
+<br/>
+<code class="Fn" title="Fn">fido_cred_set_attobj</code>(<var class="Fa" title="Fa" style="white-space: nowrap;">fido_cred_t
   *cred</var>, <var class="Fa" title="Fa" style="white-space: nowrap;">const
   unsigned char *ptr</var>,
   <var class="Fa" title="Fa" style="white-space: nowrap;">size_t len</var>);
@@ -191,14 +199,16 @@ The <code class="Nm" title="Nm">fido_cred_set_authdata</code> set of functions
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_cred_set_authdata</code>(),
   <code class="Fn" title="Fn">fido_cred_set_attstmt</code>(),
+  <code class="Fn" title="Fn">fido_cred_set_attobj</code>(),
   <code class="Fn" title="Fn">fido_cred_set_x509</code>(),
   <code class="Fn" title="Fn">fido_cred_set_sig</code>(),
   <code class="Fn" title="Fn">fido_cred_set_id</code>(), and
   <code class="Fn" title="Fn">fido_cred_set_clientdata_hash</code>() functions
-  set the authenticator data, attestation statement, attestation certificate,
-  attestation signature, id, and client data hash parts of
-  <var class="Fa" title="Fa">cred</var> to <var class="Fa" title="Fa">ptr</var>,
-  where <var class="Fa" title="Fa">ptr</var> points to
+  set the authenticator data, attestation statement, attestation object,
+  attestation certificate, attestation signature, id, and client data hash parts
+  of <var class="Fa" title="Fa">cred</var> to
+  <var class="Fa" title="Fa">ptr</var>, where
+  <var class="Fa" title="Fa">ptr</var> points to
   <var class="Fa" title="Fa">len</var> bytes. A copy of
   <var class="Fa" title="Fa">ptr</var> is made, and no references to the passed
   pointer are kept.
@@ -224,6 +234,19 @@ The attestation statement passed to
   <code class="Fn" title="Fn">fido_cred_set_sig</code>(). The latter two are
   meant to be used in contexts where the credential's complete attestation
   statement is not available or required.
+<div class="Pp"></div>
+The attestation object passed to
+  <code class="Fn" title="Fn">fido_cred_set_attobj</code>() must be a
+  CBOR-encoded map containing &#x201C;authData&#x201D;, &#x201C;fmt&#x201D;, and
+  &#x201C;attStmt&#x201D;. An application calling
+  <code class="Fn" title="Fn">fido_cred_set_attobj</code>() does not need to
+  call <code class="Fn" title="Fn">fido_cred_set_fmt</code>(),
+  <code class="Fn" title="Fn">fido_cred_set_attstmt</code>(),
+  <code class="Fn" title="Fn">fido_cred_set_authdata</code>(), or
+  <code class="Fn" title="Fn">fido_cred_set_authdata_raw</code>().
+  <code class="Fn" title="Fn">fido_cred_set_attobj</code>() may be useful in
+  applications interfacing with the WebAuthn API, removing the need to first
+  parse the attestation object to verify the credential.
 <div class="Pp"></div>
 The <code class="Fn" title="Fn">fido_cred_set_clientdata</code>() function
   allows an application to set the client data hash of

--- a/content/projects/libfido2/Manuals/fido_cred_x5c_list_count.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_x5c_list_count.partial
@@ -1,0 +1,1 @@
+fido_cred_new.partial

--- a/content/projects/libfido2/Manuals/fido_cred_x5c_list_len.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_x5c_list_len.partial
@@ -1,0 +1,1 @@
+fido_cred_new.partial

--- a/content/projects/libfido2/Manuals/fido_cred_x5c_list_ptr.partial
+++ b/content/projects/libfido2/Manuals/fido_cred_x5c_list_ptr.partial
@@ -1,0 +1,1 @@
+fido_cred_new.partial


### PR DESCRIPTION
New API calls:
 * fido_cred_set_attobj;
 * fido_cred_x5c_list_count;
 * fido_cred_x5c_list_len;
 * fido_cred_x5c_list_ptr.