### PR TITLE
Link to more relevant PIV guide from main SSH page

### DIFF
--- a/content/SSH/index.adoc
+++ b/content/SSH/index.adoc
@@ -22,7 +22,7 @@ The YubiKey stores and manages RSA and Elliptic Curve (EC) asymmetric keys withi
 
 Read about the link:/PIV/Guides/Securing_SSH_with_OpenPGP_or_PIV.html#piv[advantages and considerations of configuring OpenSSH with the YubiKey with PIV] 
 
-Follow the link:/PIV/Guides/SSH_user_certificates.html[step-by-step instructions to configure OpenSSH with the YubiKey]
+Follow the link:/PIV/Guides/SSH_with_PIV_and_PKCS11.html[step-by-step instructions to configure OpenSSH with the YubiKey]
 
 === PGP
 The YubiKey stores and manages OpenPGP keys within its OpenPGP module. It will work with SSH clients that have integrated with the OpenPGP standard.


### PR DESCRIPTION
From https://developers.yubico.com/SSH/ it really makes more sense to link to https://developers.yubico.com/PIV/Guides/SSH_with_PIV_and_PKCS11.html, in it being more in line with what the GPG and FIDO guides provide.

SSH certificates are great, but might not necessarily be the most obvious starting point for someone who simply wants to start using their YubiKey for SSH logins. Especially not following the https://developers.yubico.com/PIV/Guides/SSH_user_certificates.html guide, which risks leaving someone with an SSH CA residing on local disk, nullifying the whole security benefit of having the SSH key on the YubiKey.