### PR TITLE
add sitemap.xml

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -22,6 +22,7 @@ RUN apt-get install --no-install-recommends -y \
 
 COPY requirements.txt /
 COPY pipcache/*.gz  /
+COPY generate_sitemap.py /generate_sitemap.py
 RUN pip install --upgrade pip
 RUN pip install -r /requirements.txt
 

--- a/build
+++ b/build
@@ -4,6 +4,7 @@ import json
 from os import path
 from devyco.main import main
 from subprocess import check_call
+import generate_sitemap
 
 if __name__ == '__main__':
     base_dir = path.abspath(path.dirname(__file__))  # Use dir of file
@@ -16,4 +17,9 @@ if __name__ == '__main__':
     # we have repos that use LFS which require this step
     check_call(["git", "lfs", "install", "--skip-repo"])
     main(base_dir, settings)
-    print "All done!"
+
+    print("Generating sitemap...")
+    generate_sitemap.main()
+    print("Sitemap generation complete.")
+
+    print("All done!")

--- a/generate_sitemap.py
+++ b/generate_sitemap.py
@@ -1,0 +1,44 @@
+import os
+import time
+import sys
+
+OUTPUT_DIR = "htdocs/dist/"
+BASE_URL = "https://developers.yubico.com"
+
+def generate_sitemap():
+    pages = []
+
+    # Walk through the generated site files
+    for root, _, files in os.walk(OUTPUT_DIR):
+        for file in files:
+            if file.endswith(".html"):
+                url_path = os.path.relpath(os.path.join(root, file), OUTPUT_DIR)
+                lastmod = time.strftime("%Y-%m-%d", time.gmtime(os.path.getmtime(os.path.join(root, file))))
+                pages.append({"url": "/" + url_path, "lastmod": lastmod})
+
+    # Generate XML sitemap
+    sitemap_entries = []
+    for page in pages:
+        entry = '<url><loc>{}{}</loc><lastmod>{}</lastmod></url>'.format(BASE_URL, page["url"], page["lastmod"])
+        sitemap_entries.append(entry)
+
+    sitemap_xml = """<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{}
+</urlset>""".format("\n".join(sitemap_entries))
+
+    # Save sitemap.xml
+    sitemap_path = os.path.join(OUTPUT_DIR, "sitemap.xml")
+    
+    # Python 2.x: Use "wb" for binary mode
+    mode = "wb" if sys.version_info[0] < 3 else "w"
+    with open(sitemap_path, mode) as f:
+        f.write(sitemap_xml)
+
+    print("Generated sitemap at {}".format(sitemap_path))
+
+def main():
+    generate_sitemap()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Sitemaps allow you to inform search engines about URLs that are available for crawling. This makes your content more discoverable, and improves your Search Engine Optimization (SEO).

I looked into our implementation of jinja2 and came to the conclusion that manually generating the sitemap was the most straightforward path. I created a generate_sitemap.py, updated our dockerfile to copy the file and call it from our build process.