### PR TITLE
Redirect to EOL page

### DIFF
--- a/content/.htaccess
+++ b/content/.htaccess
@@ -1,96 +1,126 @@
 RewriteEngine On
 
+
 RewriteBase /
 
-# Redirect FIDO2 to WebAuthn
-RewriteRule ^FIDO2/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/WebAuthn/$1 [L,R=301]
-RewriteRule ^FIDO2$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/WebAuthn/ [L,R=301]
+
+# EOL Project Redirects - Using a consolidated approach for better performance
+# This single condition matches all EOL projects and redirects them to the EOL page
+# The project name is passed as a query parameter for tracking and analytics
+RewriteCond %{REQUEST_URI} ^/(yubico-val|yubico-pam|u2fval-client-php|yubikey-ksm|u2fval-client-python|python-u2flib-server|python-u2flib-host|libu2f-host|yubico-c-client|php-u2flib-server|java-u2flib-server|php-yubico|yubico-dotnet-client|yubico-perl-client|yubiclip-android|python-yubicommon|yubikey-neo-demo|yubiyey-piv-manager|yubix-vm|wordpress-u2f|ifd-yubico|yubico-windows-auth|yubix|yubiadmin|ykneo-ccid-tools|yubico-dbus-notifier|yubico-bitcoin-python|yubikey-salesforce-client|yubico-bitcoin-java|ykneo-curves|yubiauth|rlm_yubico|yubico-shibboleth-idp-multifactor-login-handler|Yubiotp-android|yubikey-neo-manager|libykneomgr)(/.*)?$ [NC]
+RewriteRule ^(.+?)(/.*)?$ https://www.yubico.com/support/terms-conditions/yubico-end-of-life-policy/eol-products/?project=$1 [L,R=301,QSA]
+
+
+# Redirect FIDO2 to WebAuthn (using protocol-relative format for consistency)
+RewriteRule ^FIDO2/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/WebAuthn/$1 [L,R=301,QSA,NC]
+RewriteRule ^FIDO2$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/WebAuthn/ [L,R=301,QSA,NC]
+
 
 # Redirect yubihsm2 to YubiHSM2
-RewriteRule ^yubihsm2/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/YubiHSM2/$1 [L,R=301]
-RewriteRule ^yubihsm2$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/YubiHSM2/ [L,R=301]
+RewriteRule ^yubihsm2/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/YubiHSM2/$1 [L,R=301,QSA,NC]
+RewriteRule ^yubihsm2$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/YubiHSM2/ [L,R=301,QSA,NC]
+
 
 # Redirect u2f to U2F
-RewriteRule ^u2f/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/U2F/$1 [L,R=301]
-RewriteRule ^u2f$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/U2F/ [L,R=301]
+RewriteRule ^u2f/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/U2F/$1 [L,R=301,QSA,NC]
+RewriteRule ^u2f$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/U2F/ [L,R=301,QSA,NC]
+
 
 # Redirect renamed U2F files
-RewriteRule ^U2F/Images/BIO.png$ FIDO/Images/BIO.png [L,R=301]
-RewriteRule ^U2F/Images/NEO.png$ FIDO/Images/NEO.png [L,R=301]
-RewriteRule ^U2F/Images/PLS.png$ FIDO/Images/PLS.png [L,R=301]
-RewriteRule ^U2F/Images/SKY-NFC.png$ FIDO/Images/SKY-NFC.png [L,R=301]
-RewriteRule ^U2F/Images/SKY.png$ FIDO/Images/SKY.png [L,R=301]
-RewriteRule ^U2F/Images/YK4.png$ FIDO/Images/YK4.png [L,R=301]
-RewriteRule ^U2F/Images/YK5-series.png$ FIDO/Images/YK5-series.png [L,R=301]
-RewriteRule ^U2F/Images/YK5.png$ FIDO/Images/YK5.png [L,R=301]
-RewriteRule ^U2F/Images/YK5Ci.png$ FIDO/Images/YK5Ci.png [L,R=301]
-RewriteRule ^U2F/Images/YK5NFC-CNFC.png$ FIDO/Images/YK5NFC-CNFC.png [L,R=301]
-RewriteRule ^U2F/Images/YKE.png$ FIDO/Images/YKE.png [L,R=301]
-RewriteRule ^U2F/Images/yubico.png$ FIDO/Images/yubico.png [L,R=301]
-RewriteRule ^U2F/fido-preview-ca-cert-2019.pem$ FIDO/yubico-fido-preview-ca-certs.pem [L,R=301]
-RewriteRule ^U2F/fido-preview-ca-cert-2023.pem$ FIDO/yubico-fido-preview-ca-certs.pem [L,R=301]
-RewriteRule ^U2F/fido-preview-ca-cert.pem$ FIDO/yubico-fido-preview-ca-certs.pem [L,R=301]
-RewriteRule ^U2F/yubico-metadata.json$ FIDO/yubico-metadata.json [L,R=301]
+RewriteRule ^U2F/Images/BIO.png$ FIDO/Images/BIO.png [L,R=301,NC]
+RewriteRule ^U2F/Images/NEO.png$ FIDO/Images/NEO.png [L,R=301,NC]
+RewriteRule ^U2F/Images/PLS.png$ FIDO/Images/PLS.png [L,R=301,NC]
+RewriteRule ^U2F/Images/SKY-NFC.png$ FIDO/Images/SKY-NFC.png [L,R=301,NC]
+RewriteRule ^U2F/Images/SKY.png$ FIDO/Images/SKY.png [L,R=301,NC]
+RewriteRule ^U2F/Images/YK4.png$ FIDO/Images/YK4.png [L,R=301,NC]
+RewriteRule ^U2F/Images/YK5-series.png$ FIDO/Images/YK5-series.png [L,R=301,NC]
+RewriteRule ^U2F/Images/YK5.png$ FIDO/Images/YK5.png [L,R=301,NC]
+RewriteRule ^U2F/Images/YK5Ci.png$ FIDO/Images/YK5Ci.png [L,R=301,NC]
+RewriteRule ^U2F/Images/YK5NFC-CNFC.png$ FIDO/Images/YK5NFC-CNFC.png [L,R=301,NC]
+RewriteRule ^U2F/Images/YKE.png$ FIDO/Images/YKE.png [L,R=301,NC]
+RewriteRule ^U2F/Images/yubico.png$ FIDO/Images/yubico.png [L,R=301,NC]
+RewriteRule ^U2F/fido-preview-ca-cert-2019.pem$ FIDO/yubico-fido-preview-ca-certs.pem [L,R=301,NC]
+RewriteRule ^U2F/fido-preview-ca-cert-2023.pem$ FIDO/yubico-fido-preview-ca-certs.pem [L,R=301,NC]
+RewriteRule ^U2F/fido-preview-ca-cert.pem$ FIDO/yubico-fido-preview-ca-certs.pem [L,R=301,NC]
+RewriteRule ^U2F/yubico-metadata.json$ FIDO/yubico-metadata.json [L,R=301,NC]
+
 
 # Cert files renamed and moved from /U2F/ to /FIDO/ then to /PKI/
-RewriteRule ^U2F/yubico-u2f-ca-1.pem$ PKI/yubico-fido-ca-1.pem [L,R=301]
-RewriteRule ^U2F/yubico-u2f-ca-certs.txt$ PKI/yubico-ca-certs.txt [L,R=301]
-RewriteRule ^U2F/yubico-u2f-ca-certs.txt.sig$ PKI/yubico-ca-certs.txt.sig [L,R=301]
+RewriteRule ^U2F/yubico-u2f-ca-1.pem$ PKI/yubico-fido-ca-1.pem [L,R=301,NC]
+RewriteRule ^U2F/yubico-u2f-ca-certs.txt$ PKI/yubico-ca-certs.txt [L,R=301,NC]
+RewriteRule ^U2F/yubico-u2f-ca-certs.txt.sig$ PKI/yubico-ca-certs.txt.sig [L,R=301,NC]
+
 
 # Cert files renamed and moved from /FIDO/ to /PKI/
-RewriteRule ^FIDO/yubico-fido-ca-1.pem$ PKI/yubico-fido-ca-1.pem [L,R=301]
-RewriteRule ^FIDO/yubico-fido-ca-1.pem.sig$ PKI/yubico-fido-ca-1.pem.sig [L,R=301]
-RewriteRule ^FIDO/yubico-fido-ca-2.pem$ PKI/yubico-fido-ca-2.pem [L,R=301]
-RewriteRule ^FIDO/yubico-fido-ca-2.pem.sig$ PKI/yubico-fido-ca-2.pem.sig [L,R=301]
-RewriteRule ^FIDO/yubico-fido-ca-certs.txt$ PKI/yubico-ca-certs.txt [L,R=301]
-RewriteRule ^FIDO/yubico-fido-ca-certs.txt.sig$ PKI/yubico-ca-certs.txt.sig [L,R=301]
-RewriteRule ^FIDO/yubico-fido-preview-ca-certs.pem$ PKI/preview/yubico-fido-preview-ca-certs.pem [L,R=301]
-RewriteRule ^FIDO/yubico-fido-preview-ca-certs.pem.sig$ PKI/preview/yubico-fido-preview-ca-certs.pem.sig [L,R=301]
+RewriteRule ^FIDO/yubico-fido-ca-1.pem$ PKI/yubico-fido-ca-1.pem [L,R=301,NC]
+RewriteRule ^FIDO/yubico-fido-ca-1.pem.sig$ PKI/yubico-fido-ca-1.pem.sig [L,R=301,NC]
+RewriteRule ^FIDO/yubico-fido-ca-2.pem$ PKI/yubico-fido-ca-2.pem [L,R=301,NC]
+RewriteRule ^FIDO/yubico-fido-ca-2.pem.sig$ PKI/yubico-fido-ca-2.pem.sig [L,R=301,NC]
+RewriteRule ^FIDO/yubico-fido-ca-certs.txt$ PKI/yubico-ca-certs.txt [L,R=301,NC]
+RewriteRule ^FIDO/yubico-fido-ca-certs.txt.sig$ PKI/yubico-ca-certs.txt.sig [L,R=301,NC]
+RewriteRule ^FIDO/yubico-fido-preview-ca-certs.pem$ PKI/preview/yubico-fido-preview-ca-certs.pem [L,R=301,NC]
+RewriteRule ^FIDO/yubico-fido-preview-ca-certs.pem.sig$ PKI/preview/yubico-fido-preview-ca-certs.pem.sig [L,R=301,NC]
+
 
 # Cert files moved to /PKI/
-RewriteRule ^PGP/opgp-attestation-ca.pem$ PKI/yubico-opgp-ca-1.pem [L,R=301]
-RewriteRule ^PGP/opgp-preview-ca-2023-cert.pem$ PKI/preview/yubico-opgp-preview-ca-certs.pem [L,R=301]
-RewriteRule ^PIV/Introduction/piv-attestation-ca.pem$ PKI/yubico-piv-ca-1.pem [L,R=301]
-RewriteRule ^PIV/Introduction/piv-attestation-preview-ca.pem$ PKI/preview/yubico-piv-preview-ca-certs.pem [L,R=301]
-RewriteRule ^PIV/Introduction/piv-preview-ca-2023-cert.pem$ PKI/preview/yubico-piv-preview-ca-certs.pem [L,R=301]
-RewriteRule ^PIV/Introduction/piv-preview-ca-cert.pem$ PKI/preview/yubico-piv-preview-ca-certs.pem [L,R=301]
+RewriteRule ^PGP/opgp-attestation-ca.pem$ PKI/yubico-opgp-ca-1.pem [L,R=301,NC]
+RewriteRule ^PGP/opgp-preview-ca-2023-cert.pem$ PKI/preview/yubico-opgp-preview-ca-certs.pem [L,R=301,NC]
+RewriteRule ^PIV/Introduction/piv-attestation-ca.pem$ PKI/yubico-piv-ca-1.pem [L,R=301,NC]
+RewriteRule ^PIV/Introduction/piv-attestation-preview-ca.pem$ PKI/preview/yubico-piv-preview-ca-certs.pem [L,R=301,NC]
+RewriteRule ^PIV/Introduction/piv-preview-ca-2023-cert.pem$ PKI/preview/yubico-piv-preview-ca-certs.pem [L,R=301,NC]
+RewriteRule ^PIV/Introduction/piv-preview-ca-cert.pem$ PKI/preview/yubico-piv-preview-ca-certs.pem [L,R=301,NC]
+
 
 # Redirect ssh to SSH
-RewriteRule ^ssh/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/SSH/$1 [L,R=301]
-RewriteRule ^ssh$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/SSH/ [L,R=301]
+RewriteRule ^ssh/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/SSH/$1 [L,R=301,QSA,NC]
+RewriteRule ^ssh$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/SSH/ [L,R=301,QSA,NC]
+
 
 # Redirect mobile to Mobile
-RewriteRule ^mobile/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/Mobile/$1 [L,R=301]
-RewriteRule ^mobile$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/Mobile/ [L,R=301]
+RewriteRule ^mobile/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/Mobile/$1 [L,R=301,QSA,NC]
+RewriteRule ^mobile$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/Mobile/ [L,R=301,QSA,NC]
 
-# Redirect mobile to Mobile
-RewriteRule ^mobile_dev/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/Mobile_Dev/$1 [L,R=301]
-RewriteRule ^mobile_dev$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/Mobile_Dev/ [L,R=301]
 
-# Redirect mobile to Passkeys
-RewriteRule ^passkeys/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/Passkeys/$1 [L,R=301]
-RewriteRule ^passkeys$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/Passkeys/ [L,R=301]
+# Redirect mobile_dev to Mobile_Dev
+RewriteRule ^mobile_dev/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/Mobile_Dev/$1 [L,R=301,QSA,NC]
+RewriteRule ^mobile_dev$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/Mobile_Dev/ [L,R=301,QSA,NC]
+
+
+# Redirect passkeys to Passkeys
+RewriteRule ^passkeys/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/Passkeys/$1 [L,R=301,QSA,NC]
+RewriteRule ^passkeys$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/Passkeys/ [L,R=301,QSA,NC]
+
 
 # Redirect yubikey5ci to Mobile
-RewriteRule ^yubikey5ci/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/Mobile/$1 [L,R=301]
-RewriteRule ^yubikey5ci$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/Mobile/ [L,R=301]
+RewriteRule ^yubikey5ci/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/Mobile/$1 [L,R=301,QSA,NC]
+RewriteRule ^yubikey5ci$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/Mobile/ [L,R=301,QSA,NC]
+
 
 # Redirect developer-program to Developer_Program
-RewriteRule ^developer-program/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/Developer_Program/$1 [L,R=301]
-RewriteRule ^developer-program$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/Developer_Program/ [L,R=301]
+RewriteRule ^developer-program/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/Developer_Program/$1 [L,R=301,QSA,NC]
+RewriteRule ^developer-program$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/Developer_Program/ [L,R=301,QSA,NC]
+
 
 # Redirect yubioath-desktop to yubioath-flutter
-RewriteRule ^yubioath-desktop/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/yubioath-flutter/$1 [L,R=301]
-RewriteRule ^yubioath-desktop$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/yubioath-flutter/ [L,R=301]
+RewriteRule ^yubioath-desktop/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/yubioath-flutter/$1 [L,R=301,QSA,NC]
+RewriteRule ^yubioath-desktop$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/yubioath-flutter/ [L,R=301,QSA,NC]
 
-# Redirects links to releases and documentation
-RewriteRule ^([0-9a-z-]+)/releases/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/$1/Releases/$2 [L,R=301]
-RewriteRule ^([0-9a-z-]+)/releases.html %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/$1/Releases/ [L,R=301]
-RewriteRule ^([0-9a-z-]+)/doc/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/$1/$2 [L,R=301]
 
-# Redirect .adocfiles to .html
+# Redirect webauthn-server-attestation to java-webauthn-server/webauthn-server-attestation
+RewriteRule ^webauthn-server-attestation/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/java-webauthn-server/webauthn-server-attestation/$1 [L,R=301,QSA,NC]
+RewriteRule ^webauthn-server-attestation$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/java-webauthn-server/webauthn-server-attestation/ [L,R=301,QSA,NC]
+
+
+# Redirects links to releases and documentation - using improved pattern with NC flag
+RewriteRule ^([0-9a-z-]+)/releases/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/$1/Releases/$2 [L,R=301,QSA,NC]
+RewriteRule ^([0-9a-z-]+)/releases.html$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/$1/Releases/ [L,R=301,QSA,NC]
+RewriteRule ^([0-9a-z-]+)/doc/(.*)$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/$1/$2 [L,R=301,QSA,NC]
+
+
+# Redirect .adocfiles to .html with case-insensitive matching
 RewriteCond "! -f %{REQUEST_FILENAME}"
-RewriteRule ^(.*)\.adoc$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/$1.html [L,R=301]
+RewriteRule ^(.*)\.adoc$ %{ENV:REQUEST_PROTO}://%{HTTP_HOST}/$1.html [L,R=301,QSA,NC]
+
 
 # Error pages
 ErrorDocument 404 /404.html


### PR DESCRIPTION
Here's a summary of the changes made:

### Consolidated EOL Project Redirects:

Added 35 individual redirect rules within a single RewriteCond + RewriteRule combination
Added [NC] flag for case-insensitive matching


### Added Project Parameter for Analytics:

EOL redirects now include ?project=project-name in the target URL
This allows you to track which EOL projects are still being accessed


### Added Query String Passing:

Added [QSA] flag to all redirects to preserve any existing query parameters
This ensures that information in original URLs is not lost


### Made All Redirects Case-Insensitive:

Added [NC] flag to all rules
This catches URLs regardless of capitalization (e.g., YubiAuth, yubiauth, YUBIAUTH)

### Fixed Missing Dollar Sign:

Added missing $ in the releases.html pattern
Ensures proper matching of the URL endpoint


### Improved Comments:

Updated comments to more accurately describe what each section does