### PR TITLE
Scribe's OpenPGP key

### DIFF
--- a/content/Software_Projects/Software_Signing.adoc
+++ b/content/Software_Projects/Software_Signing.adoc
@@ -9,6 +9,13 @@ Source code releases are usually signed by an OpenPGP key of one of
 Yubico's developers.  Some ZIP files containing Windows executables are
 also signed using OpenPGP.
 
+We're undertaking an effort to slowly move away from signing with individual
+developer's OpenPGP key towards a single organization wide OpenPGP key. New releases
+will start including signatures using the following key:
+
+-[PROD] Yubico Scribe GPG Signing Key <security+signing@yubico.com>
+link:https://keys.openpgp.org/search?q=2D5641876C74EC9CB8A6FF43062BC0D272DC7CB1[`2D56 4187 6C74 EC9C B8A6  FF43 062B C0D2 72DC 7CB1`]
+
 Following are the keys for Yubico developers who are currently releasing code.
 
 - Klas Lindfors <klas@yubico.com>

--- a/content/Software_Projects/Software_Signing.adoc
+++ b/content/Software_Projects/Software_Signing.adoc
@@ -5,13 +5,9 @@ We use three different techniques to achieve this.
 
 === OpenPGP Software Signing
 
-Source code releases are usually signed by an OpenPGP key of one of
-Yubico's developers.  Some ZIP files containing Windows executables are
-also signed using OpenPGP.
+Source code releases are usually signed by an OpenPGP key of one of Yubico's developers or the centrally managed OpenPGP key. Some ZIP files containing Windows executables are also signed using OpenPGP.
 
-We're undertaking an effort to slowly move away from signing with individual
-developer's OpenPGP key towards a single organization wide OpenPGP key. New releases
-will start including signatures using the following key:
+Yubico's centrally managed OpenPGP key:
 
 -[PROD] Yubico Scribe GPG Signing Key <security+signing@yubico.com>
 link:https://keys.openpgp.org/search?q=2D5641876C74EC9CB8A6FF43062BC0D272DC7CB1[`2D56 4187 6C74 EC9C B8A6  FF43 062B C0D2 72DC 7CB1`]


### PR DESCRIPTION
- Changed wording to include text on centrally managed OpenPGP key.
- Added fingerprint and link for Scribe's public OpenPGP key