### PR TITLE
Fix naming of Enhanced PIN devices in yubico-metadata.json

### DIFF
--- a/static/FIDO/yubico-metadata.json
+++ b/static/FIDO/yubico-metadata.json
@@ -1,6 +1,6 @@
 {
   "identifier": "2fb54029-7613-4f1d-94f1-fb876c14a6fe",
-  "version": 20,
+  "version": 21,
   "vendorInfo": {
     "url": "https://yubico.com",
     "imageUrl": "https://developers.yubico.com/FIDO/Images/yubico.png",
@@ -381,16 +381,6 @@
               "value": "d7781e5de35346aaafe23ca49f13332a"
             }
           }
-        },
-        {
-          "type": "x509Extension",
-          "parameters": {
-            "key": "1.3.6.1.4.1.45724.1.1.4",
-            "value": {
-              "type": "hex",
-              "value": "662ef48a95e24aaaa6c15b9c40375824"
-            }
-          }
         }
       ]
     },
@@ -431,7 +421,37 @@
               "value": "6ab56fad881f4a43acb20be065924522"
             }
           }
-        },
+        }
+      ]
+    },
+
+    {
+      "deviceId": "1.3.6.1.4.1.41482.1.7",
+      "displayName": "YubiKey 5/5C NFC - Enhanced PIN",
+      "transports": 12,
+      "deviceUrl": "https://support.yubico.com/hc/en-us/articles/20452481977756-YubiKey-5-NFC-Enhanced-PIN",
+      "imageUrl": "https://developers.yubico.com/FIDO/Images/YK5NFC-CNFC.png",
+      "selectors": [
+        {
+          "type": "x509Extension",
+          "parameters": {
+            "key": "1.3.6.1.4.1.45724.1.1.4",
+            "value": {
+              "type": "hex",
+              "value": "662ef48a95e24aaaa6c15b9c40375824"
+            }
+          }
+        }
+      ]
+    },
+
+    {
+      "deviceId": "1.3.6.1.4.1.41482.1.7",
+      "displayName": "YubiKey 5/5C NFC - Enhanced PIN (enterprise profile)",
+      "transports": 12,
+      "deviceUrl": "https://support.yubico.com/hc/en-us/articles/20452481977756-YubiKey-5-NFC-Enhanced-PIN",
+      "imageUrl": "https://developers.yubico.com/FIDO/Images/YK5NFC-CNFC.png",
+      "selectors": [
         {
           "type": "x509Extension",
           "parameters": {


### PR DESCRIPTION
Related to: https://yubico.atlassian.net/browse/RFE-3439