### PR TITLE
YubiHSM2 doc content

### DIFF
--- a/content/YubiHSM2/Backup_and_Restore/index.adoc
+++ b/content/YubiHSM2/Backup_and_Restore/index.adoc
@@ -1,10 +1,8 @@
 == Backup and Restore
 
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-backup-restore.html[YubiHSM 2: Backup and Restore]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Authenticate_Session.adoc
+++ b/content/YubiHSM2/Commands/Authenticate_Session.adoc
@@ -1,9 +1,7 @@
 == AUTHENTICATE SESSION
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#authenticate-session-command[AUTHENTICATE SESSION Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Blink_Device.adoc
+++ b/content/YubiHSM2/Commands/Blink_Device.adoc
@@ -1,9 +1,7 @@
 == BLINK DEVICE
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#blink-device-command[BLINK DEVICE Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Change_Authentication_Key.adoc
+++ b/content/YubiHSM2/Commands/Change_Authentication_Key.adoc
@@ -1,9 +1,7 @@
 == CHANGE AUTHENTICATION KEY
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#change-authentication-key-command[CHANGE AUTHENTICATION KEY Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Close_Session.adoc
+++ b/content/YubiHSM2/Commands/Close_Session.adoc
@@ -1,9 +1,7 @@
 == CLOSE SESSION
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#close-session-command[CLOSE SESSION Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Create_Otp_Aead.adoc
+++ b/content/YubiHSM2/Commands/Create_Otp_Aead.adoc
@@ -1,9 +1,7 @@
 == CREATE OTP AEAD
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#create-otp-aead-command[CREATE OTP AEAD Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Create_Session.adoc
+++ b/content/YubiHSM2/Commands/Create_Session.adoc
@@ -1,9 +1,7 @@
 == CREATE SESSION
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#create-session-command[CREATE SESSION Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Decrypt_Aes_Cbc.adoc
+++ b/content/YubiHSM2/Commands/Decrypt_Aes_Cbc.adoc
@@ -1,9 +1,7 @@
 == DECRYPT AES CBC
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#decrypt-cbc-command[DECRYPT CBC Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Decrypt_Aes_Ecb.adoc
+++ b/content/YubiHSM2/Commands/Decrypt_Aes_Ecb.adoc
@@ -1,9 +1,7 @@
 == DECRYPT AES ECB
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#decrypt-ecb-command[DECRYPT ECB Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Decrypt_Oaep.adoc
+++ b/content/YubiHSM2/Commands/Decrypt_Oaep.adoc
@@ -1,9 +1,7 @@
 == DECRYPT OAEP
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#decrypt-oaep-command[DECRYPT OAEP Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Decrypt_Otp.adoc
+++ b/content/YubiHSM2/Commands/Decrypt_Otp.adoc
@@ -1,9 +1,7 @@
 == DECRYPT OTP
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#decrypt-otp-command[DECRYPT OTP Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Decrypt_Pkcs1.adoc
+++ b/content/YubiHSM2/Commands/Decrypt_Pkcs1.adoc
@@ -1,9 +1,7 @@
 == DECRYPT PKCS1
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#decrypt-pkcs1-command[DECRYPT PKCS1 Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Delete_Object.adoc
+++ b/content/YubiHSM2/Commands/Delete_Object.adoc
@@ -1,9 +1,7 @@
 == DELETE OBJECT
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#delete-object-command[DELETE OBJECT Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Derive_Ecdh.adoc
+++ b/content/YubiHSM2/Commands/Derive_Ecdh.adoc
@@ -1,9 +1,7 @@
 == DERIVE ECDH
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#derive-ecdh-command[DERIVE ECDH Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Device_Info.adoc
+++ b/content/YubiHSM2/Commands/Device_Info.adoc
@@ -1,9 +1,7 @@
 == DEVICE INFO
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#device-info-command[DEVICE INFO Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Echo.adoc
+++ b/content/YubiHSM2/Commands/Echo.adoc
@@ -1,9 +1,7 @@
 == ECHO
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#echo-command[ECHO Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Encrypt_Aes_Cbc.adoc
+++ b/content/YubiHSM2/Commands/Encrypt_Aes_Cbc.adoc
@@ -1,9 +1,7 @@
 == ENCRYPT AES CBC
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#encrypt-cbc-command[ENCRYPT CBC Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Encrypt_Aes_Ecb.adoc
+++ b/content/YubiHSM2/Commands/Encrypt_Aes_Ecb.adoc
@@ -1,9 +1,7 @@
 == ENCRYPT AES ECB
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#encrypt-ecb-command[ENCRYPT ECB Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Export_Wrapped.adoc
+++ b/content/YubiHSM2/Commands/Export_Wrapped.adoc
@@ -1,9 +1,7 @@
 == EXPORT WRAPPED
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#export-wrapped-command[EXPORT WRAPPED Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Generate_Asymmetric_Key.adoc
+++ b/content/YubiHSM2/Commands/Generate_Asymmetric_Key.adoc
@@ -1,9 +1,7 @@
 == GENERATE ASYMMETRIC KEY
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#generate-asymmetric-key-command[GENERATE ASYMMETRIC KEY Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Generate_Hmac_Key.adoc
+++ b/content/YubiHSM2/Commands/Generate_Hmac_Key.adoc
@@ -1,9 +1,7 @@
 == GENERATE HMAC KEY
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#generate-hmac-key-command[GENERATE HMAC KEY Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Generate_Otp_Aead_Key.adoc
+++ b/content/YubiHSM2/Commands/Generate_Otp_Aead_Key.adoc
@@ -1,9 +1,7 @@
 == GENERATE OTP AEAD KEY
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#generate-otp-aead-key-command[GENERATE OTP AEAD KEY Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Generate_Symmetric_Key.adoc
+++ b/content/YubiHSM2/Commands/Generate_Symmetric_Key.adoc
@@ -1,9 +1,7 @@
 == GENERATE SYMMETRIC KEY
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#generate-symmetric-key-command[GENERATE SYMMETRIC KEY Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Generate_Wrap_Key.adoc
+++ b/content/YubiHSM2/Commands/Generate_Wrap_Key.adoc
@@ -1,9 +1,7 @@
 == GENERATE WRAP KEY
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#generate-wrap-key-command[GENERATE WRAP KEY Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Get_Device_Pubkey.adoc
+++ b/content/YubiHSM2/Commands/Get_Device_Pubkey.adoc
@@ -1,9 +1,7 @@
 == GET DEVICE PUBLIC KEY
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#get-device-public-key-command[GET DEVICE PUBLIC KEY Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Get_Log_Entries.adoc
+++ b/content/YubiHSM2/Commands/Get_Log_Entries.adoc
@@ -1,10 +1,8 @@
 == GET LOG ENTRIES
 
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#get-log-entries-command[GET LOG ENTRIES Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Get_Object_Info.adoc
+++ b/content/YubiHSM2/Commands/Get_Object_Info.adoc
@@ -1,10 +1,8 @@
 == GET OBJECT INFO
 
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#get-object-info-command[GET OBJECT INFO Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Get_Opaque.adoc
+++ b/content/YubiHSM2/Commands/Get_Opaque.adoc
@@ -1,10 +1,8 @@
 == GET OPAQUE
 
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#get-opaque-command[GET OPAQUE Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Get_Option.adoc
+++ b/content/YubiHSM2/Commands/Get_Option.adoc
@@ -1,9 +1,7 @@
 == GET OPTION
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#get-option-command[GET OPTION Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Get_Pseudo_Random.adoc
+++ b/content/YubiHSM2/Commands/Get_Pseudo_Random.adoc
@@ -1,10 +1,8 @@
 == GET PSEUDO RANDOM
 
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#get-pseudo-random-command[GET PSEUDO RANDOM Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Get_Public_Key.adoc
+++ b/content/YubiHSM2/Commands/Get_Public_Key.adoc
@@ -1,10 +1,8 @@
 == GET PUBLIC KEY
 
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#get-public-key-command[GET PUBLIC KEY Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Get_Storage_Info.adoc
+++ b/content/YubiHSM2/Commands/Get_Storage_Info.adoc
@@ -1,10 +1,8 @@
 == GET STORAGE INFO
 
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#get-storage-info-command[GET STORAGE INFO Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Get_Template.adoc
+++ b/content/YubiHSM2/Commands/Get_Template.adoc
@@ -1,9 +1,7 @@
 == GET TEMPLATE
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#get-template-command[GET TEMPLATE Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Import_Wrapped.adoc
+++ b/content/YubiHSM2/Commands/Import_Wrapped.adoc
@@ -1,10 +1,7 @@
 == IMPORT WRAPPED
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#import-wrapped-command[IMPORT WRAPPED Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/List_Objects.adoc
+++ b/content/YubiHSM2/Commands/List_Objects.adoc
@@ -1,9 +1,7 @@
 == LIST OBJECTS
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#list-objects-command[LIST OBJECTS Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Put_Asymmetric_Key.adoc
+++ b/content/YubiHSM2/Commands/Put_Asymmetric_Key.adoc
@@ -1,10 +1,8 @@
 == PUT ASYMMETRIC KEY
 
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#put-asymmetric-key-command[PUT ASYMMETRIC KEY Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Put_Authentication_Key.adoc
+++ b/content/YubiHSM2/Commands/Put_Authentication_Key.adoc
@@ -1,10 +1,8 @@
 == PUT AUTHENTICATION KEY
 
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#put-authentication-key-command[PUT AUTHENTICATION KEY Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Put_Hmac_Key.adoc
+++ b/content/YubiHSM2/Commands/Put_Hmac_Key.adoc
@@ -1,9 +1,7 @@
 == PUT HMAC KEY
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#put-hmac-key-command[PUT HMAC KEY Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Put_Opaque.adoc
+++ b/content/YubiHSM2/Commands/Put_Opaque.adoc
@@ -1,9 +1,7 @@
 == PUT OPAQUE
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#put-opaque-command[PUT OPAQUE Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Put_Otp_Aead_Key.adoc
+++ b/content/YubiHSM2/Commands/Put_Otp_Aead_Key.adoc
@@ -1,10 +1,8 @@
 == PUT OTP AEAD KEY
 
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#put-otp-aead-key-command[PUT OTP AEAD KEY Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Put_Symmetric_Key.adoc
+++ b/content/YubiHSM2/Commands/Put_Symmetric_Key.adoc
@@ -1,10 +1,8 @@
 == PUT SYMMETRIC KEY
 
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#put-symmetric-key-command[PUT SYMMETRIC KEY Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Put_Template.adoc
+++ b/content/YubiHSM2/Commands/Put_Template.adoc
@@ -1,10 +1,8 @@
 == PUT TEMPLATE
 
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#put-template-command[PUT TEMPLATE Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Put_Wrap_Key.adoc
+++ b/content/YubiHSM2/Commands/Put_Wrap_Key.adoc
@@ -1,10 +1,8 @@
 == PUT WRAP KEY
 
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#put-wrap-key-command[PUT WRAP KEY Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Randomize_Otp_Aead.adoc
+++ b/content/YubiHSM2/Commands/Randomize_Otp_Aead.adoc
@@ -1,10 +1,8 @@
 == RANDOMIZE OTP AEAD
 
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#randomize-otp-aead-command[RANDOMIZE OTP AEAD Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Reset_Device.adoc
+++ b/content/YubiHSM2/Commands/Reset_Device.adoc
@@ -1,10 +1,8 @@
 == RESET DEVICE
 
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#reset-device-command[RESET DEVICE Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Rewrap_Otp_Aead.adoc
+++ b/content/YubiHSM2/Commands/Rewrap_Otp_Aead.adoc
@@ -1,10 +1,8 @@
 == REWRAP OTP AEAD
 
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#rewrap-otp-aead-command[REWRAP OTP AEAD Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Session_Message.adoc
+++ b/content/YubiHSM2/Commands/Session_Message.adoc
@@ -1,10 +1,8 @@
 == SESSION MESSAGE
 
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#session-message-command[SESSION MESSAGE Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Set_Log_Index.adoc
+++ b/content/YubiHSM2/Commands/Set_Log_Index.adoc
@@ -1,9 +1,7 @@
 == SET LOG INDEX
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#set-log-index-command[SET LOG INDEX Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Set_Option.adoc
+++ b/content/YubiHSM2/Commands/Set_Option.adoc
@@ -1,9 +1,7 @@
 == SET OPTION
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#set-option-command[SET OPTION Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Sign_Attestation_Certificate.adoc
+++ b/content/YubiHSM2/Commands/Sign_Attestation_Certificate.adoc
@@ -1,9 +1,7 @@
 == SIGN ATTESTATION CERTIFICATE
 
-**This content is deprecated. **
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#sign-attestation-certificate-command[SIGN ATTESTATION CERTIFICATE Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Sign_Ecdsa.adoc
+++ b/content/YubiHSM2/Commands/Sign_Ecdsa.adoc
@@ -1,9 +1,7 @@
 == SIGN ECDSA
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#sign-ecdsa-command[SIGN ECDSA Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Sign_Eddsa.adoc
+++ b/content/YubiHSM2/Commands/Sign_Eddsa.adoc
@@ -1,9 +1,7 @@
 == SIGN EDDSA
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#sign-eddsa-command[SIGN EDDSA Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Sign_Hmac.adoc
+++ b/content/YubiHSM2/Commands/Sign_Hmac.adoc
@@ -1,9 +1,7 @@
 == SIGN HMAC
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#sign-hmac-command[SIGN HMAC Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Sign_Pkcs1.adoc
+++ b/content/YubiHSM2/Commands/Sign_Pkcs1.adoc
@@ -1,9 +1,7 @@
 == SIGN PKCS1
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#sign-pkcs1-command[SIGN PKCS1 Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Sign_Pss.adoc
+++ b/content/YubiHSM2/Commands/Sign_Pss.adoc
@@ -1,9 +1,7 @@
 == SIGN PSS
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#sign-pss-command[SIGN PSS Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Sign_Ssh_Certificate.adoc
+++ b/content/YubiHSM2/Commands/Sign_Ssh_Certificate.adoc
@@ -1,9 +1,7 @@
 == SIGN SSH CERTIFICATE
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#sign-ssh-certificate-command[SIGN SSH CERTIFICATE Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Unwrap_Data.adoc
+++ b/content/YubiHSM2/Commands/Unwrap_Data.adoc
@@ -1,10 +1,8 @@
 == UNWRAP DATA
 
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#unwrap-data-command[UNWRAP DATA Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Verify_Hmac.adoc
+++ b/content/YubiHSM2/Commands/Verify_Hmac.adoc
@@ -1,10 +1,8 @@
 == VERIFY HMAC
 
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#verify-hmac-command[VERIFY HMAC Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/Wrap_Data.adoc
+++ b/content/YubiHSM2/Commands/Wrap_Data.adoc
@@ -1,10 +1,8 @@
 == WRAP DATA
 
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#wrap-data-command[WRAP DATA Command]
+Please update your bookmarks.

--- a/content/YubiHSM2/Commands/index.adoc
+++ b/content/YubiHSM2/Commands/index.adoc
@@ -1,9 +1,7 @@
 == Commands
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html[YubiHSM Command Reference]
+Please update your bookmarks.

--- a/content/YubiHSM2/Component_Reference/KSP/Code_Signing_Example.adoc
+++ b/content/YubiHSM2/Component_Reference/KSP/Code_Signing_Example.adoc
@@ -1,9 +1,7 @@
 == Creating a Code-Signing Certificate using the Key Storage Provider
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-ksp-windows-guide.html#example-creating-a-code-signing-certificate-using-the-key-storage-provider[Example: Creating a Code Signing Certificate Using the Key Storage Provider]
+Please update your bookmarks.

--- a/content/YubiHSM2/Component_Reference/KSP/Software_keys_to_ksp.adoc
+++ b/content/YubiHSM2/Component_Reference/KSP/Software_keys_to_ksp.adoc
@@ -1,9 +1,7 @@
 == Move Software Keys to Key Storage Provider
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:<https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-ksp-windows-guide.html[Using Key Storage Provider (KSP) - Windows Only]
+Please update your bookmarks.

--- a/content/YubiHSM2/Component_Reference/KSP/Status_codes.adoc
+++ b/content/YubiHSM2/Component_Reference/KSP/Status_codes.adoc
@@ -1,9 +1,7 @@
 == Status Codes
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:<https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-ksp-windows-guide.html#status-codes-reference[Status Codes Reference]
+Please update your bookmarks.

--- a/content/YubiHSM2/Component_Reference/KSP/index.adoc
+++ b/content/YubiHSM2/Component_Reference/KSP/index.adoc
@@ -1,9 +1,7 @@
 == Key Storage Provider
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:<https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hhsm2-sdk-tools-libraries.html#key-storage-provider-ksp-windows-only[Key Storage Provider (KSP) - Windows Only]
+Please update your bookmarks.

--- a/content/YubiHSM2/Component_Reference/PKCS_11/Compatibility.adoc
+++ b/content/YubiHSM2/Component_Reference/PKCS_11/Compatibility.adoc
@@ -1,9 +1,7 @@
 == PKCS#11 Tool Compatibility, Interoperability and Known Restrictions
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-pkcs11-guide.html#pkcs-11-tool-compatibility-interoperability-and-known-restrictions[PKCS#11 Tool Compatibility, Interoperatibility, and Known Restrictions]
+Please update your bookmarks.

--- a/content/YubiHSM2/Component_Reference/PKCS_11/index.adoc
+++ b/content/YubiHSM2/Component_Reference/PKCS_11/index.adoc
@@ -1,9 +1,7 @@
 == PKCS#11 with YubiHSM 2
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-pkcs11-guide.html#pkcs-11-with-yubihsm-2[PKCS#11 with YubiHSM 2]
+Please update your bookmarks.

--- a/content/YubiHSM2/Component_Reference/libyubihsm/index.adoc
+++ b/content/YubiHSM2/Component_Reference/libyubihsm/index.adoc
@@ -1,9 +1,7 @@
 == Libyubihsm
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-sdk-tools-libraries.html#libyubihsm[Libyubihsm]
+Please update your bookmarks.

--- a/content/YubiHSM2/Component_Reference/python-yubihsm/index.adoc
+++ b/content/YubiHSM2/Component_Reference/python-yubihsm/index.adoc
@@ -1,9 +1,7 @@
 == Python Library
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-sdk-tools-libraries.html#python-library[Python Library]
+Please update your bookmarks.

--- a/content/YubiHSM2/Component_Reference/yubihsm-connector/index.adoc
+++ b/content/YubiHSM2/Component_Reference/yubihsm-connector/index.adoc
@@ -1,9 +1,7 @@
 == Connector
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-sdk-tools-libraries.html#yubihsm-2-connector[YubiHSM 2 Connector]
+Please update your bookmarks.

--- a/content/YubiHSM2/Component_Reference/yubihsm-setup/index.adoc
+++ b/content/YubiHSM2/Component_Reference/yubihsm-setup/index.adoc
@@ -1,11 +1,7 @@
 == YubiHSM 2 Setup
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-sdk-tools-libraries.html#yubihsm-2-setup-tool[YubiHSM 2 Setup Tool]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-backup-restore.html#backup-and-restore-using-yubihsm-setup[Backup and Restore using YubiHSM Setup]
+Please update your bookmarks.

--- a/content/YubiHSM2/Component_Reference/yubihsm-shell/index.adoc
+++ b/content/YubiHSM2/Component_Reference/yubihsm-shell/index.adoc
@@ -1,9 +1,7 @@
 == YubiHSM Shell
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-sdk-tools-libraries.html#yubihsm-shell[YubiHSM Shell]
+Please update your bookmarks.

--- a/content/YubiHSM2/Component_Reference/yubihsm-wrap/index.adoc
+++ b/content/YubiHSM2/Component_Reference/yubihsm-wrap/index.adoc
@@ -1,9 +1,7 @@
 == Yubihsm Wrap
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-sdk-tools-libraries.html#yubihsm-wrap[YubiHSM Wrap]
+Please update your bookmarks.

--- a/content/YubiHSM2/Concepts/Algorithms.adoc
+++ b/content/YubiHSM2/Concepts/Algorithms.adoc
@@ -1,10 +1,8 @@
 == ALGORITHMS
 
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-core-concepts.html#algorithms[ALGORITHMS]
+Please update your bookmarks.

--- a/content/YubiHSM2/Concepts/Attestation.adoc
+++ b/content/YubiHSM2/Concepts/Attestation.adoc
@@ -1,9 +1,7 @@
 == Attestation
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-core-concepts.html#attestation[Attestation]
+Please update your bookmarks.

--- a/content/YubiHSM2/Concepts/Capability.adoc
+++ b/content/YubiHSM2/Concepts/Capability.adoc
@@ -1,9 +1,7 @@
 == Capability
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-core-concepts.html#capability[Capability]
+Please update your bookmarks.

--- a/content/YubiHSM2/Concepts/Domain.adoc
+++ b/content/YubiHSM2/Concepts/Domain.adoc
@@ -1,9 +1,7 @@
 == Domain
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-core-concepts.html#domain[Domain]
+Please update your bookmarks.

--- a/content/YubiHSM2/Concepts/Effective_Capabilities.adoc
+++ b/content/YubiHSM2/Concepts/Effective_Capabilities.adoc
@@ -1,9 +1,7 @@
 == Effective Capabilities (Tying It All Together)
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-core-concepts.html#effective-capabilities-tying-it-all-together[Effective Capabilities (Tying It All Together)]
+Please update your bookmarks.

--- a/content/YubiHSM2/Concepts/Errors.adoc
+++ b/content/YubiHSM2/Concepts/Errors.adoc
@@ -1,9 +1,7 @@
 == Errors
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-core-concepts.html#errors[Errors]
+Please update your bookmarks.

--- a/content/YubiHSM2/Concepts/Label.adoc
+++ b/content/YubiHSM2/Concepts/Label.adoc
@@ -1,9 +1,7 @@
 == Label
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-core-concepts.html#label[label]
+Please update your bookmarks.

--- a/content/YubiHSM2/Concepts/Logs.adoc
+++ b/content/YubiHSM2/Concepts/Logs.adoc
@@ -1,9 +1,7 @@
 == Logs
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-core-concepts.html#logs[Logs]
+Please update your bookmarks.

--- a/content/YubiHSM2/Concepts/Object.adoc
+++ b/content/YubiHSM2/Concepts/Object.adoc
@@ -1,9 +1,7 @@
 == Objects
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-core-concepts.html#objects[Objects]
+Please update your bookmarks.

--- a/content/YubiHSM2/Concepts/Object_ID.adoc
+++ b/content/YubiHSM2/Concepts/Object_ID.adoc
@@ -1,9 +1,7 @@
 == Object ID
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-core-concepts.html#object-id[Object ID]
+Please update your bookmarks.

--- a/content/YubiHSM2/Concepts/Options.adoc
+++ b/content/YubiHSM2/Concepts/Options.adoc
@@ -1,9 +1,7 @@
 == Options
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-core-concepts.html#options[Options]
+Please update your bookmarks.

--- a/content/YubiHSM2/Concepts/Sequence.adoc
+++ b/content/YubiHSM2/Concepts/Sequence.adoc
@@ -1,9 +1,7 @@
 == Sequence
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-core-concepts.html#sequence[Sequence]
+Please update your bookmarks.

--- a/content/YubiHSM2/Concepts/Session.adoc
+++ b/content/YubiHSM2/Concepts/Session.adoc
@@ -1,9 +1,7 @@
 == Session
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-core-concepts.html#session[Session]
+Please update your bookmarks.

--- a/content/YubiHSM2/Concepts/index.adoc
+++ b/content/YubiHSM2/Concepts/index.adoc
@@ -1,9 +1,7 @@
 == Concepts
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-core-concepts.html[Core Concepts]
+Please update your bookmarks.

--- a/content/YubiHSM2/Product_Overview/index.adoc
+++ b/content/YubiHSM2/Product_Overview/index.adoc
@@ -1,11 +1,7 @@
 == YubiHSM 2 Product Overview
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-introduction.html[Introduction]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-device-specs.html[YubiHSM 2 Device Specifications]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/Admin_guide.adoc
+++ b/content/YubiHSM2/Usage_Guides/Admin_guide.adoc
@@ -1,9 +1,7 @@
 == YubiHSM Admin Guide
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-initial-provision-deploy-guide.html#hmac[Initial Provisioning and Deployment Guide]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/EJBCA_with_YubiHSM2.adoc
+++ b/content/YubiHSM2/Usage_Guides/EJBCA_with_YubiHSM2.adoc
@@ -1,9 +1,7 @@
 == EJBCA with YubiHSM 2
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-ejbca-guide.html[EJBCA Installation and Configuration Guide]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/Factory_reset.adoc
+++ b/content/YubiHSM2/Usage_Guides/Factory_reset.adoc
@@ -1,9 +1,7 @@
 == Resetting Device to Factory Settings
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-reset-to-factory.html[Resetting Device to Factory Settings]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/OpenSSH_certificates.adoc
+++ b/content/YubiHSM2/Usage_Guides/OpenSSH_certificates.adoc
@@ -1,9 +1,7 @@
 == OpenSSH Certificates
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-openssh-certs-host-login.html[Using OpenSSH Certificates for Host Login]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/OpenSSL_with_libp11.adoc
+++ b/content/YubiHSM2/Usage_Guides/OpenSSL_with_libp11.adoc
@@ -1,9 +1,7 @@
 == Signing/verifying and encrypting/decrypting using OpenSSL with libp11
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-openssl-libp11.html[OpenSSL with libp11 for Signing, Verifying and Encrypting, Decrypting]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/OpenSSL_with_pkcs11_engine.adoc
+++ b/content/YubiHSM2/Usage_Guides/OpenSSL_with_pkcs11_engine.adoc
@@ -1,9 +1,7 @@
 == OpenSSL with YubiHSM 2 via engine_pkcs11 and yubihsm_pkcs11
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-openssl-yubihsm2.html[OpenSSL with YubiHSM 2 via engine_pkcs11 and yubihsm_pkcs11]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/Using_OpenSC_pkcs11-tool.adoc
+++ b/content/YubiHSM2/Usage_Guides/Using_OpenSC_pkcs11-tool.adoc
@@ -1,9 +1,7 @@
 == Using OpenSC pkcs11-tool
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/sm2-opensc-pkcs11.html#using-opensc-pkcs11-tool[Using OpenSC pkcs11-tool]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/Using_YubiHSM2_with_Java/JAR_signing_with_YubiHSM2.adoc
+++ b/content/YubiHSM2/Usage_Guides/Using_YubiHSM2_with_Java/JAR_signing_with_YubiHSM2.adoc
@@ -1,9 +1,7 @@
 == Java code signing using YubiHSM 2
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-java-code-signing.html[Configuring YubiHSM 2 for Java Code Signing]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/Using_YubiHSM2_with_Java/XML_signing_with_YubiHSM2.adoc
+++ b/content/YubiHSM2/Usage_Guides/Using_YubiHSM2_with_Java/XML_signing_with_YubiHSM2.adoc
@@ -1,9 +1,7 @@
 == Signing XML files using YubiHSM 2
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/software/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/software/yubihsm-2/hsm-2-user-guide/hsm2-java-code-signing.html[Configuring YubiHSM 2 for Java Code Signing]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/Using_YubiHSM2_with_Java/example_signing_with_YubiHSM2.adoc
+++ b/content/YubiHSM2/Usage_Guides/Using_YubiHSM2_with_Java/example_signing_with_YubiHSM2.adoc
@@ -1,9 +1,7 @@
 == Example Java code using YubiHSM 2
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-java-code-signing.html[Configuring YubiHSM 2 for Java Code Signing]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/Using_YubiHSM2_with_Java/index.adoc
+++ b/content/YubiHSM2/Usage_Guides/Using_YubiHSM2_with_Java/index.adoc
@@ -1,9 +1,7 @@
 == Using YubiHSM 2 with Java
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-java-code-signing.html[Configuring YubiHSM 2 for Java Code Signing]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM2_for_ADCS_Guide/Alternative_Scenarios.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM2_for_ADCS_Guide/Alternative_Scenarios.adoc
@@ -1,10 +1,7 @@
 == Alternative Scenarios
 
+**This content is moved.**
 
-**This content is deprecated. **
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-For current content see:
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-alternative-scenarios.html[Alternative Scenarios with CA Root Key or Subordinate CAs]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM2_for_ADCS_Guide/Backing_Up_Key_Material.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM2_for_ADCS_Guide/Backing_Up_Key_Material.adoc
@@ -1,10 +1,7 @@
 == Backing Up Key Material
 
+**This content is moved.**
 
-**This content is deprecated. **
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-For current content see:
-
-- link:https://docs.yubico.com/software/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/software/yubihsm-2/hsm-2-user-guide/hsm2-backup-restore-key-material.html[Backup and Restore Key Material]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM2_for_ADCS_Guide/Configuring_the_Primary_YubiHSM_2_Device.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM2_for_ADCS_Guide/Configuring_the_Primary_YubiHSM_2_Device.adoc
@@ -1,9 +1,7 @@
 == Configuring the Primary YubiHSM 2 Device
 
-**This content is deprecated. **
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-config-primary-device.html[Configuring the Primary YubiHSM 2 Device]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM2_for_ADCS_Guide/Deploying_YubiHSM_2_with_Active_Directory_Certificate_Services.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM2_for_ADCS_Guide/Deploying_YubiHSM_2_with_Active_Directory_Certificate_Services.adoc
@@ -1,9 +1,7 @@
 == Deploying YubiHSM 2 with Active Directory Certificate Services
 
-**This content is deprecated. **
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-adcs-deploy.html[Deploying YubiHSM 2 with Active Directory Certificate Services]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM2_for_ADCS_Guide/Getting_Help.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM2_for_ADCS_Guide/Getting_Help.adoc
@@ -1,6 +1,7 @@
 == Getting Help
-Should you require assistance when deploying YubiHSM 2 with ADCS by using this guide, start by referencing the product documentation and currently known issues. If you need additional help, contact Yubico:
 
-* https://support.yubico.com/[Yubico Knowledge Base]
-* https://resources.yubico.com/53ZDUYE6/at/k76bjgrqvf9mfxkgg53gt3f/213134-YubiHSM2-solution-brief-r2.pdf[Product documentation]
-* https://support.yubico.com/hc/en-us/requests/new[Submit a support request to report an issue]
+**This content is moved.**
+
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
+
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM2_for_ADCS_Guide/Installing_the_YubiHSM_2_Tools_and_Software.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM2_for_ADCS_Guide/Installing_the_YubiHSM_2_Tools_and_Software.adoc
@@ -1,11 +1,7 @@
 == Installing the YubiHSM 2 Tools and Software
 
-**This content is deprecated. **
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/softwhardwareare/yubihsm-2/hsm-2-user-guide/hsm2-install-tools-software.html[Installing the YubiHSM 2 Tools and Software]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-verify-tools-software-install.html[Verifying the Default Configuration of the YubiHSM 2]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM2_for_ADCS_Guide/Introduction.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM2_for_ADCS_Guide/Introduction.adoc
@@ -1,9 +1,7 @@
 == Introduction
 
-**This content is deprecated. **
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-adcs-deploy.html[Deploying YubiHSM 2 with Active Directory Certificate Services]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM2_for_ADCS_Guide/Key_Splitting_and_Key_Custodians.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM2_for_ADCS_Guide/Key_Splitting_and_Key_Custodians.adoc
@@ -1,9 +1,7 @@
 == Key Splitting and Key Custodians
 
-**This content is deprecated. **
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-key-split-custodians-guide.html#key-splitting-and-key-custodians[Key Splitting and Key Custodians]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM2_for_ADCS_Guide/Prerequisites_and_Preparations.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM2_for_ADCS_Guide/Prerequisites_and_Preparations.adoc
@@ -1,9 +1,7 @@
 == Prerequisites and Preparations
 
-**This content is deprecated. **
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-adcs-deploy.html#prerequisites-and-preparations[Prerequisites and Preparations]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM2_for_ADCS_Guide/Terminology_Used.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM2_for_ADCS_Guide/Terminology_Used.adoc
@@ -1,9 +1,7 @@
 == Terminology Used
 
-**This content is deprecated. **
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-glossary.html[Glossary]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM2_for_ADCS_Guide/index.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM2_for_ADCS_Guide/index.adoc
@@ -1,12 +1,7 @@
 == YubiHSM2 for ADCS Guide
 
-* link:Introduction.adoc[Introduction]
-* link:Prerequisites_and_Preparations.adoc[Prerequisites and Preparations]
-* link:Key_Splitting_and_Key_Custodians.adoc[Key Splitting and Key Custodians]
-* link:Installing_the_YubiHSM_2_Tools_and_Software.adoc[Installing the YubiHSM 2 Tools and Software]
-* link:Configuring_the_Primary_YubiHSM_2_Device.adoc[Configuring the Primary YubiHSM 2 Device]
-* link:Deploying_YubiHSM_2_with_Active_Directory_Certificate_Services.adoc[Deploying YubiHSM 2 with Active Directory Certificate Services]
-* link:Backing_Up_Key_Material.adoc[Backing Up Key Material]
-* link:Alternative_Scenarios.adoc[Alternative Scenarios]
-* link:Getting_Help.adoc[Getting Help]
-* link:Terminology_Used.adoc[Terminology Used]
+**This content is moved.**
+
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
+
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM_2_Windows_Deployment_Guide--Configure_YubiHSM_2_Key_Storage_Provider_for_Microsoft_Windows_Server/Back_Up_and_Restore_Key_Material.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM_2_Windows_Deployment_Guide--Configure_YubiHSM_2_Key_Storage_Provider_for_Microsoft_Windows_Server/Back_Up_and_Restore_Key_Material.adoc
@@ -1,10 +1,8 @@
 == Back Up and Restore Key Material
 
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-backup-restore-key-material.html[Backup and Restore Key Material]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM_2_Windows_Deployment_Guide--Configure_YubiHSM_2_Key_Storage_Provider_for_Microsoft_Windows_Server/Configure_the_Primary_YubiHSM_2_Device.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM_2_Windows_Deployment_Guide--Configure_YubiHSM_2_Key_Storage_Provider_for_Microsoft_Windows_Server/Configure_the_Primary_YubiHSM_2_Device.adoc
@@ -1,10 +1,8 @@
 == Configure the Primary YubiHSM 2 Device
 
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-config-primary-device.html[Configuring the Primary YubiHSM 2 Device]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM_2_Windows_Deployment_Guide--Configure_YubiHSM_2_Key_Storage_Provider_for_Microsoft_Windows_Server/Configure_the_YubiHSM_2_Software.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM_2_Windows_Deployment_Guide--Configure_YubiHSM_2_Key_Storage_Provider_for_Microsoft_Windows_Server/Configure_the_YubiHSM_2_Software.adoc
@@ -1,10 +1,8 @@
 == Configure the YubiHSM 2 Software
 
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-configure-software-windows.html[Configure the YubiHSM 2 Software on Windows]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM_2_Windows_Deployment_Guide--Configure_YubiHSM_2_Key_Storage_Provider_for_Microsoft_Windows_Server/Getting_Help.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM_2_Windows_Deployment_Guide--Configure_YubiHSM_2_Key_Storage_Provider_for_Microsoft_Windows_Server/Getting_Help.adoc
@@ -1,11 +1,7 @@
 == Getting Help
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-configure-software-windows.html[Configure the YubiHSM 2 Software on Windows]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/glossary.html[Glossary]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM_2_Windows_Deployment_Guide--Configure_YubiHSM_2_Key_Storage_Provider_for_Microsoft_Windows_Server/Install_the_YubiHSM_Tools_and_Software.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM_2_Windows_Deployment_Guide--Configure_YubiHSM_2_Key_Storage_Provider_for_Microsoft_Windows_Server/Install_the_YubiHSM_Tools_and_Software.adoc
@@ -1,11 +1,7 @@
 == Install the YubiHSM 2 Tools and Software
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-install-tools-software.html[Installing the YubiHSM 2 Tools and Software]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-verify-tools-software-install.html[Verifying the Default Configuration of the YubiHSM 2]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM_2_Windows_Deployment_Guide--Configure_YubiHSM_2_Key_Storage_Provider_for_Microsoft_Windows_Server/Introduction.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM_2_Windows_Deployment_Guide--Configure_YubiHSM_2_Key_Storage_Provider_for_Microsoft_Windows_Server/Introduction.adoc
@@ -1,10 +1,8 @@
 == Introduction to YubiHSM 2 Windows Deployment Guide:
 
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-ksp-windows-server-guide.html[YubiHSM 2 with Key Storage Provider for Windows Server]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM_2_Windows_Deployment_Guide--Configure_YubiHSM_2_Key_Storage_Provider_for_Microsoft_Windows_Server/Key_Splitting_and_Key_Custodians.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM_2_Windows_Deployment_Guide--Configure_YubiHSM_2_Key_Storage_Provider_for_Microsoft_Windows_Server/Key_Splitting_and_Key_Custodians.adoc
@@ -1,9 +1,7 @@
 == Key Splitting and Key Custodians
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-key-split-custodians-guide.html[Key Splitting and Key Custodians]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM_2_Windows_Deployment_Guide--Configure_YubiHSM_2_Key_Storage_Provider_for_Microsoft_Windows_Server/Prerequisites_and_Preparations.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM_2_Windows_Deployment_Guide--Configure_YubiHSM_2_Key_Storage_Provider_for_Microsoft_Windows_Server/Prerequisites_and_Preparations.adoc
@@ -1,9 +1,7 @@
 == Prerequisites and Preparations
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-adcs-deploy.html#prerequisites-and-preparations[Prerequisites and Preparations]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM_2_Windows_Deployment_Guide--Configure_YubiHSM_2_Key_Storage_Provider_for_Microsoft_Windows_Server/Verify_the_YubiHSM_2_Setup.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM_2_Windows_Deployment_Guide--Configure_YubiHSM_2_Key_Storage_Provider_for_Microsoft_Windows_Server/Verify_the_YubiHSM_2_Setup.adoc
@@ -1,9 +1,7 @@
 == Verify the YubiHSM 2 Setup
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-verify-tools-software-install.html[Verifying the Default Configuration of the YubiHSM 2]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM_2_for_Microsoft_Host_Guardian_Service--Deployment_Guide/Back_Up_Key_Material.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM_2_for_Microsoft_Host_Guardian_Service--Deployment_Guide/Back_Up_Key_Material.adoc
@@ -1,9 +1,7 @@
 == Back Up Key Material
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-backup-restore-key-material.html[Backup and Restore Key Material]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM_2_for_Microsoft_Host_Guardian_Service--Deployment_Guide/Basic_Setup_of_YubiHSM_2_and_HGS.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM_2_for_Microsoft_Host_Guardian_Service--Deployment_Guide/Basic_Setup_of_YubiHSM_2_and_HGS.adoc
@@ -1,9 +1,7 @@
 == Basic Setup of YubiHSM 2 and HGS
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-ms-host-guardian-service-guide.html#basic-setup-of-yubihsm-2-and-host-guardian-service[Basic Setup of YubiHSM 2 and Host Guardian Service]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM_2_for_Microsoft_Host_Guardian_Service--Deployment_Guide/Create_Signing_and_Encryption_Keys_for_HGS.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM_2_for_Microsoft_Host_Guardian_Service--Deployment_Guide/Create_Signing_and_Encryption_Keys_for_HGS.adoc
@@ -1,9 +1,7 @@
 == Create Signing and Encryption Keys for HGS
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-ms-host-guardian-service-guide.html#create-signing-and-encryption-keys-for-hgs[Create Signing and Encryption Keys for HGS]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM_2_for_Microsoft_Host_Guardian_Service--Deployment_Guide/Getting_Help_and_Further_Reading.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM_2_for_Microsoft_Host_Guardian_Service--Deployment_Guide/Getting_Help_and_Further_Reading.adoc
@@ -1,9 +1,7 @@
 == Getting Help and Further Reading
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-ms-host-guardian-service-guide.html[Deploying YubiHSM 2 for Microsoft Host Guardian Service (HGS) Guide]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM_2_for_Microsoft_Host_Guardian_Service--Deployment_Guide/Introduction.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM_2_for_Microsoft_Host_Guardian_Service--Deployment_Guide/Introduction.adoc
@@ -1,9 +1,7 @@
 == Introduction
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-ms-host-guardian-service-guide.html[Deploying YubiHSM 2 for Microsoft Host Guardian Service (HGS) Guide]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM_2_for_Microsoft_Host_Guardian_Service--Deployment_Guide/Prerequisites_and_Preparations.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM_2_for_Microsoft_Host_Guardian_Service--Deployment_Guide/Prerequisites_and_Preparations.adoc
@@ -1,9 +1,7 @@
 == Prerequisites and Preparations
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-ms-host-guardian-service-guide.html#prerequisites-and-preparations[Prerequisites and Preparations]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM_2_for_Microsoft_Host_Guardian_Service--Deployment_Guide/Terminology.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM_2_for_Microsoft_Host_Guardian_Service--Deployment_Guide/Terminology.adoc
@@ -1,9 +1,7 @@
 == Terminology
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-glossary.html[Glossary]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM_2_for_Microsoft_SQL_Server_Deployment_Guide--Enabling_Always_Encrypted_with_YubiHSM_2/Back_Up_Key_Material.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM_2_for_Microsoft_SQL_Server_Deployment_Guide--Enabling_Always_Encrypted_with_YubiHSM_2/Back_Up_Key_Material.adoc
@@ -1,10 +1,8 @@
 == Back Up Key Material
 
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-backup-restore-key-material.html[Backup and Restore Key Material]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM_2_for_Microsoft_SQL_Server_Deployment_Guide--Enabling_Always_Encrypted_with_YubiHSM_2/Basic_Setup_of_YubiHSM_2_and_SQL_Server.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM_2_for_Microsoft_SQL_Server_Deployment_Guide--Enabling_Always_Encrypted_with_YubiHSM_2/Basic_Setup_of_YubiHSM_2_and_SQL_Server.adoc
@@ -1,9 +1,7 @@
 == Basic Setup of YubiHSM 2 and SQL Server
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-ms-sql-server-deploy-guide.html#basic-setup-of-yubihsm-2-and-sql-server[Basic Setup of YubiHSM 2 and SQL Server]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM_2_for_Microsoft_SQL_Server_Deployment_Guide--Enabling_Always_Encrypted_with_YubiHSM_2/Configure_SSMS_for_Database_Encryption.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM_2_for_Microsoft_SQL_Server_Deployment_Guide--Enabling_Always_Encrypted_with_YubiHSM_2/Configure_SSMS_for_Database_Encryption.adoc
@@ -1,9 +1,7 @@
 == Configure SSMS for Database Encryption
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-ms-sql-server-deploy-guide.html#configure-ssms-for-database-encryption[Configure SSMS for Database Encryption]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM_2_for_Microsoft_SQL_Server_Deployment_Guide--Enabling_Always_Encrypted_with_YubiHSM_2/Encrypt_Database_Columns.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM_2_for_Microsoft_SQL_Server_Deployment_Guide--Enabling_Always_Encrypted_with_YubiHSM_2/Encrypt_Database_Columns.adoc
@@ -1,10 +1,8 @@
 == Encrypt Database Columns
 
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-ms-sql-server-deploy-guide.html#encrypt-database-columns[Encrypt Database Columns]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM_2_for_Microsoft_SQL_Server_Deployment_Guide--Enabling_Always_Encrypted_with_YubiHSM_2/Getting_Help_and_Further_Reading.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM_2_for_Microsoft_SQL_Server_Deployment_Guide--Enabling_Always_Encrypted_with_YubiHSM_2/Getting_Help_and_Further_Reading.adoc
@@ -1,10 +1,7 @@
 == Getting Help and Further Reading
 
+**This content is moved.**
 
-**This content is deprecated.**
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-For current content see:
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-ms-sql-server-deploy-guide.html[YubiHSM 2 for Microsoft SQL Server Deployment Guide]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM_2_for_Microsoft_SQL_Server_Deployment_Guide--Enabling_Always_Encrypted_with_YubiHSM_2/Introduction.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM_2_for_Microsoft_SQL_Server_Deployment_Guide--Enabling_Always_Encrypted_with_YubiHSM_2/Introduction.adoc
@@ -1,10 +1,8 @@
 == Introduction
 
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-ms-sql-server-deploy-guide.html[YubiHSM 2 for Microsoft SQL Server Deployment Guide]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM_2_for_Microsoft_SQL_Server_Deployment_Guide--Enabling_Always_Encrypted_with_YubiHSM_2/Prerequisites_and_Preparations.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM_2_for_Microsoft_SQL_Server_Deployment_Guide--Enabling_Always_Encrypted_with_YubiHSM_2/Prerequisites_and_Preparations.adoc
@@ -1,10 +1,8 @@
 == Prerequisites and Preparations
 
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-ms-sql-server-deploy-guide.html#prerequisites-and-preparations[Prerequisites and Preparations]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM_2_for_Microsoft_SQL_Server_Deployment_Guide--Enabling_Always_Encrypted_with_YubiHSM_2/Terminology.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM_2_for_Microsoft_SQL_Server_Deployment_Guide--Enabling_Always_Encrypted_with_YubiHSM_2/Terminology.adoc
@@ -1,10 +1,8 @@
 == Terminology
 
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-glossary.html[Glossary]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM_2_for_Microsoft_SQL_Server_Deployment_Guide--Enabling_Always_Encrypted_with_YubiHSM_2/Use_PowerShell_Script_to_Generate_the_CMK_and_CEK.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM_2_for_Microsoft_SQL_Server_Deployment_Guide--Enabling_Always_Encrypted_with_YubiHSM_2/Use_PowerShell_Script_to_Generate_the_CMK_and_CEK.adoc
@@ -1,10 +1,8 @@
 == Use PowerShell Script to Generate the CMK and CEK
 
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-ms-sql-server-deploy-guide.html#use-powershell-script-to-generate-the-cmk-and-cek[Use PowerShell Script to Generate the CMK and CEK]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM_2_for_Microsoft_SQL_Server_Deployment_Guide--Enabling_Always_Encrypted_with_YubiHSM_2/Use_SSMS_to_Generate_the_CMK_and_CEK.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM_2_for_Microsoft_SQL_Server_Deployment_Guide--Enabling_Always_Encrypted_with_YubiHSM_2/Use_SSMS_to_Generate_the_CMK_and_CEK.adoc
@@ -1,10 +1,8 @@
 == Use SSMS to Generate the CMK and CEK
 
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-ms-sql-server-deploy-guide.html#use-ssms-to-generate-the-cmk-and-cek[Use SSMS to Generate the CMK and CEK]
+Please update your bookmarks.

--- a/content/YubiHSM2/Usage_Guides/YubiHSM_quick_start_tutorial.adoc
+++ b/content/YubiHSM2/Usage_Guides/YubiHSM_quick_start_tutorial.adoc
@@ -1,9 +1,7 @@
 == YubiHSM 2: Practical Guide
 
-**This content is deprecated.**
+**This content is moved.**
 
-For current content see:
+For current content see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
-
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-quick-start.html[Quick Start Tutorial]
+Please update your bookmarks.

--- a/content/YubiHSM2/index.adoc
+++ b/content/YubiHSM2/index.adoc
@@ -1,9 +1,10 @@
 == What is YubiHSM 2?
 
-**This content is deprecated.**
+**This documentation content is moved.**
 
-For current content see:
+For current documentation see: link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
 
-- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-device-specs.html[YubiHSM 2 Device Specifications]
+For current YubiHSM 2 releases see: link:https://developers.yubico.com/YubiHSM2/Releases/index.html [Releases]
+
+Please update your bookmarks.


### PR DESCRIPTION
Replace 'deprecate' with 'moved'. Remove links to topics inside the YubiHSM 2 User Guide. Keep main link to YubiHSM 2 User Guide.