### PR TITLE
docs: update yubikit-android

### DIFF
--- a/content/projects/yubikit-android/.conf.json
+++ b/content/projects/yubikit-android/.conf.json
@@ -19,7 +19,9 @@
         ["NEWS", "Release_Notes.adoc"],
         ["android/README.adoc", "android/index.adoc"],
         ["core/README.adoc", "core/index.adoc"],
+        ["desktop/README.adoc", "desktop/index.adoc"],
         ["fido/README.adoc", "fido/index.adoc"],
+        ["fido-android-ui/README.adoc", "fido-android-ui/index.adoc"],
         ["management/README.adoc", "management/index.adoc"],
         ["oath/README.adoc", "oath/index.adoc"],
         ["openpgp/README.adoc", "openpgp/index.adoc"],
@@ -33,7 +35,7 @@
   "javadoc": {
     "groupId": "com.yubico.yubikit",
     "artifactId": "android",
-    "artifactIds": ["core", "android", "management", "oath", "piv", "yubiotp", "yubikit", "mgmt", "otp", "openpgp", "fido", "support"],
+    "artifactIds": ["core", "android", "desktop", "management", "oath", "piv", "yubiotp", "yubikit", "mgmt", "otp", "openpgp", "fido", "fido-android-ui", "support"],
     "all_versions": true
   }
 }


### PR DESCRIPTION
This pull request updates the documentation and Javadoc configuration for the `yubikit-android` project to include new modules. The main focus is on ensuring that the `desktop` and `fido-android-ui` modules are now properly referenced in both the documentation and Javadoc generation.

**Documentation updates:**

* Added mappings for `desktop/README.adoc` and `fido-android-ui/README.adoc` to their respective index files in the `.conf.json` configuration, ensuring these modules are included in the documentation build.

**Javadoc configuration updates:**

* Updated the `artifactIds` list to include `desktop` and `fido-android-ui`, so Javadoc is generated for these modules as well.