### PR TITLE
YubiHSM: Fix format of SDK release notes. Add yubihsm-manager section…

### DIFF
--- a/content/YubiHSM2/Component_Reference/.conf.json
+++ b/content/YubiHSM2/Component_Reference/.conf.json
@@ -2,6 +2,7 @@
   "order": [
     "yubihsm-connector",
     "yubihsm-shell",
+    "yubihsm-manager",
     "yubihsm-setup",
     "libyubihsm",
     "python-yubihsm",

--- a/content/YubiHSM2/Component_Reference/yubihsm-manager/index.adoc
+++ b/content/YubiHSM2/Component_Reference/yubihsm-manager/index.adoc
@@ -1,0 +1,5 @@
+== YubiHSM 2 Manager
+
+- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/index.html[YubiHSM 2 User Guide]
+
+- link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-tools-manager.html[YubiHSM 2 Manager]

--- a/content/YubiHSM2/Component_Reference/yubihsm-setup/index.adoc
+++ b/content/YubiHSM2/Component_Reference/yubihsm-setup/index.adoc
@@ -1,5 +1,7 @@
 == YubiHSM 2 Setup
 
+IMPORTANT: The YubiHSM Setup is deprecated. Please use link:https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-tools-manager.html[YubiHSM 2 Manager] instead.
+
 **This content is moved.**
 
 For current content see: 

--- a/content/YubiHSM2/Releases/Release_notes.adoc
+++ b/content/YubiHSM2/Releases/Release_notes.adoc
@@ -5,16 +5,16 @@
 ==== Content:
 
 * yubihsm-shell 2.7.3
-* yubihsm-connector 3.0.4
+* yubihsm-connector 3.0.7
 * yubihsm-setup 2.3.4
 * yubihsm-ksp 2.6.0
 * yubihsm-manager 1.0.0
 
 ==== Improvements:
 
-Manager: Initial release of ``yubihsm-manager``. Interactive CLI with guided menus for YubiHSM 2 management. Supersedes the previous ``yubihsm-setup`` tool with a more user-friendly interface and expanded functionality
-Library: Fix a bug in defining capabilities related to managing Public Wrap Key objects
-Connector: Dependency updates
+* Manager: Initial release of ``yubihsm-manager``. Interactive CLI with guided menus for YubiHSM 2 management. Supersedes the previous ``yubihsm-setup`` tool with a more user-friendly interface and expanded functionality
+* Library: Fix a bug in defining capabilities related to managing Public Wrap Key objects
+* Connector: Dependency updates
 
 === 2026.03
 
@@ -27,9 +27,9 @@ Connector: Dependency updates
 
 ==== Improvements:
 
-Library: Ensure that command audit for command 0x05 cannot be turned on
-PKCS11: Improve handling of public key component of RSA Wrap Key
-PKCS11: Fix a bug where generating an RSA key pair can potentially result in the wrong type of object being created
+* Library: Ensure that command audit for command 0x05 cannot be turned on
+* PKCS11: Improve handling of public key component of RSA Wrap Key
+* PKCS11: Fix a bug where generating an RSA key pair can potentially result in the wrong type of object being created
 
 === 2026.01
 


### PR DESCRIPTION
…. Add note that yubihsm-setup is deprecated