### PR TITLE
Fix CTAP 2.2 doc inaccuracies; add CTAP 2.3 page

### DIFF
--- a/content/CTAP/CTAP2.2.adoc
+++ b/content/CTAP/CTAP2.2.adoc
@@ -265,7 +265,7 @@ CTAP 2.2 expands the `authenticatorGetInfo` response with several new fields:
 
 | libfido2 / fido2-token
 | ✅ Full Support (v1.17.0+)
-| v1.17.0+ supports most CTAP 2.2 features. Check the link:https://github.com/Yubico/libfido2[libfido2 release notes] for specific feature coverage, or open an issue or pull request on GitHub if something is missing.
+| v1.17.0+ supports most CTAP 2.2 features. Check the link:https://github.com/Yubico/libfido2[libfido2 release notes] for specific feature coverage.
 
 | yubikit-swift
 | ⚠️ Limited

--- a/content/CTAP/CTAP2.2.adoc
+++ b/content/CTAP/CTAP2.2.adoc
@@ -1,37 +1,50 @@
 == CTAP 2.2: Enhanced FIDO2 Features and Enterprise Security
-:description: Comprehensive guide to CTAP 2.2 features including Persistent PIN/UV Auth Tokens, PIN complexity policies, and enterprise attestation. Learn implementation with Yubico SDKs.
-:keywords: CTAP 2.2, FIDO2, persistent PIN tokens, PIN complexity, enterprise attestation, thirdPartyPayment, credential management, YubiKey SDK
+:description: Comprehensive guide to CTAP 2.2 features including Persistent PIN/UV Auth Tokens, PIN complexity policies, payment authentication, and HMAC secret extensions. Learn implementation with Yubico SDKs.
+:keywords: CTAP 2.2, FIDO2, persistent PIN tokens, PIN complexity, enterprise attestation, thirdPartyPayment, hmac-secret-mc, credential management, YubiKey SDK
 :author: Yubico Developer Relations
 :page-layout: technical-guide
 :page-category: Authentication Protocols
 :page-tags: CTAP 2.2, FIDO2, Enterprise Security, PIN Policies, Payment Authentication
 :toc: left
-:toclevels: 4
+:toclevels: 3
 :sectanchors:
 :source-highlighter: highlight.js
-:page-last-updated: 2025-01-15
+:page-last-updated: 2026-05-22
 
 [.lead]
-CTAP 2.2 delivers powerful new capabilities for enterprise deployments and improved user experiences. This technical guide covers persistent PIN tokens, payment authentication, and other protocol enhancements—along with SDK support status across Yubico's developer tools.
+CTAP 2.2 strengthens the FIDO2 protocol with persistent PIN tokens, configurable PIN complexity policies, payment authentication support, and richer authenticator metadata. This guide covers each feature from an implementation perspective, with specific guidance for Yubico SDKs.
 
-=== CTAP 2.2: Protocol Advances for Enterprise and Ecosystem Growth
-
-==== Introduction
-
-The Client to Authenticator Protocol (CTAP) defines how authenticators communicate with clients for FIDO2 authentication. CTAP 2.2 strengthens the protocol with features that address enterprise deployment requirements and expand authentication options across the FIDO ecosystem.
-
-For roaming authenticators like YubiKeys, this release delivers capabilities that reduce friction in enterprise workflows: persistent PIN/UV auth tokens eliminate repeated prompts during credential enumeration, PIN complexity policies enforce compliance requirements at the hardware level, and the thirdPartyPayment extension enables cross-domain authentication for regulated payment transactions.
-
-CTAP 2.2 also formalizes hybrid transport, a protocol mechanism for cross-device authentication using QR codes and proximity pairing. This allows a platform authenticator on a phone to authenticate sessions on other devices like desktops—useful for everyday scenarios where convenience matters more than the highest assurance levels. Hybrid flows can create device-bound credentials (hardware-bound, like YubiKeys) or multi-device credentials (syncable across a user's devices). For scenarios requiring attestation and non-exportable keys, hardware security keys remain the appropriate authenticator choice.
-
-This guide covers CTAP 2.2 features from an implementation perspective, with specific guidance for Yubico SDKs. Many features operate at the native application layer—check our link:https://developers.yubico.com/WebAuthn/WebAuthn_Browser_Support/[browser support matrix] for WebAuthn API availability.
+++++
+<div class="last-updated-banner">
+    <!-- Simple clock icon -->
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+    <span>Last Updated on 22 May 2026</span>
+</div>
+++++
 
 [NOTE]
 ====
-**WebAuthn and Browser Support**: While CTAP 2.2 features are available at the protocol level, WebAuthn applications depend on browser support for these capabilities. Not all CTAP 2.2 features are exposed through the WebAuthn JavaScript API, and browser implementations vary. For web developers, consult our link:https://developers.yubico.com/WebAuthn/WebAuthn_Browser_Support/[WebAuthn Browser Support] page to verify which features your target browsers support before implementation.
+*WebAuthn and Browser Support*: While CTAP 2.2 features are available at the protocol level, WebAuthn applications depend on browser support for these capabilities. Not all CTAP 2.2 features are exposed through the WebAuthn JavaScript API. For web developers, consult our link:https://developers.yubico.com/WebAuthn/WebAuthn_Browser_Support/[WebAuthn Browser Support] page before implementation.
 ====
 
-==== What's New in CTAP 2.2
+[NOTE]
+====
+*CTAP 2.2 and Certification*: The FIDO Alliance did not create a separate certification category for CTAP 2.2. Certifications are issued against CTAP 2.3, which is fully backwards-compatible with CTAP 2.2. There is no `FIDO_2_2` version string in `authenticatorGetInfo`. See our link:CTAP2.3.adoc[CTAP 2.3 guide] for what CTAP 2.3 adds.
+====
+
+=== Introduction
+
+The Client to Authenticator Protocol (CTAP) defines how authenticators communicate with clients for FIDO2 authentication. CTAP 2.2 strengthens the protocol with features that address enterprise deployment requirements and expand authentication options across the FIDO ecosystem.
+
+For roaming authenticators like YubiKeys, this release delivers capabilities that reduce friction in enterprise workflows: persistent PIN/UV auth tokens provide long-lived, read-only tokens for credential enumeration without repeated PIN entry; PIN complexity policies enable authenticators to advertise and enforce device-specific PIN requirements; and the `thirdPartyPayment` extension enables cross-domain authentication for regulated payment transactions.
+
+CTAP 2.2 also formalizes hybrid transport, a protocol mechanism for cross-device authentication using QR codes and proximity pairing. This allows a platform authenticator on a phone to authenticate sessions on other devices like desktops. Hybrid flows use platform authenticators (such as those on smartphones) or multi-device passkeys. For scenarios requiring attestation and non-exportable keys, hardware security keys remain the appropriate authenticator choice.
+
+This guide covers CTAP 2.2 features from an implementation perspective, with specific guidance for Yubico SDKs. Many features operate at the native application layer—check our link:https://developers.yubico.com/WebAuthn/WebAuthn_Browser_Support/[browser support matrix] for WebAuthn API availability.
+
+=== What's New in CTAP 2.2
 
 CTAP 2.2 introduces new protocol capabilities and expands features established in CTAP 2.1. The table below highlights major changes, organized by relevance to roaming authenticators like YubiKeys.
 
@@ -39,95 +52,110 @@ CTAP 2.2 introduces new protocol capabilities and expands features established i
 |===
 | Feature | Description | Developer Benefit
 
-| **Persistent PIN/UV Auth Tokens (PPUAT)** +
-_(New in 2.2)_
-| Long-lived tokens scoped to read-only credential management operations, eliminating repeated PIN prompts when enumerating stored credentials.
-| Dramatically improves UX in enterprise SSO portals and password managers. Reduces authentication fatigue in multi-step workflows where users enumerate credentials across relying parties.
+| *Persistent PIN/UV Auth Tokens (PPUAT)* _(New in 2.2)_
+| Long-lived, read-only tokens scoped to credential enumeration operations (`enumerateRPs`, `enumerateCredentials`, `getCredentialMetadata`). Tokens persist across power cycles.
+| Improves UX in enterprise SSO portals and password managers during long-running or resumable credential enumeration. Complements the session-scoped `cm`-permission tokens from CTAP 2.1 without replacing them.
 
-| **PIN Complexity Policies** +
-_(New in 2.2)_
-| Hardware-enforced PIN requirements including character set constraints, expanding CTAP 2.1's minimum PIN length enforcement to full complexity policies.
-| Meets enterprise compliance requirements (NIST SP 800-63B) at the authenticator level. Security policies cannot be circumvented by clients.
+| *PIN Complexity Policies* _(New in 2.2)_
+| A protocol mechanism for authenticators to advertise PIN complexity requirements. Authenticators with PIN complexity enabled—via device configuration or certification requirements—can reject PINs that fail their policy.
+| Enables platforms to detect that PIN complexity is active and adapt their UX accordingly. Complements minimum-length enforcement introduced by `minPINLength` in CTAP 2.1.
 
-| **thirdPartyPayment Extension** +
-_(New in 2.2)_
+| *thirdPartyPayment Extension* _(New in 2.2)_
 | Allows a credential to be asserted in a context where the transaction initiator (e.g., a merchant) differs from the relying party that created the credential (e.g., a bank), without requiring redirects.
 | Critical for payment industry compliance with PSD2 Strong Customer Authentication. Enables standardized, phishing-resistant payment flows required by card networks and regulators.
 
-| **HMAC Secret MakeCredential (hmac-secret-mc)** +
-_(New in 2.2)_
-| Extends the existing hmac-secret extension to also support secret derivation during credential creation (MakeCredential). The original hmac-secret extension for GetAssertion continues to function unchanged.
-| Enables immediate encryption of local data with hardware-backed secrets at registration time. Critical for password managers, encrypted vaults, and offline workstation scenarios that need a secret before first authentication.
+| *HMAC Secret MakeCredential (`hmac-secret-mc`)* _(New in 2.2)_
+| Extends the existing `hmac-secret` extension to also support secret derivation during credential creation (`authenticatorMakeCredential`).
+| Enables immediate encryption of local data with hardware-backed secrets at registration time. Critical for password managers, encrypted vaults, and offline workstation scenarios.
 
-| **Hybrid Transport** +
-_(New in 2.2)_
-| Cross-device authentication protocol using QR code initiation and proximity-based pairing (BLE + network tunnel). Enables a platform authenticator on one device to authenticate sessions on another.
-| Expands FIDO adoption for consumer applications where convenience is prioritized. Developers can implement passwordless experiences that leverage users' existing devices.
+| *Hybrid Transport* _(New in 2.2)_
+| Cross-device authentication protocol using QR code initiation and proximity-based pairing (BLE + encrypted network tunnel). Enables a platform authenticator on one device to authenticate sessions on another.
+| Expands FIDO adoption for consumer applications. Developers can implement passwordless experiences that leverage users' existing devices.
 
-| **JSON-Based Messaging** +
-_(New in 2.2)_
-| Optional JSON encoding for specific CTAP commands, supplementing the existing CBOR format. Primarily used in browser-mediated credential management contexts.
-| Simplifies integration for web-based credential management UIs. JavaScript applications can parse authenticator responses without CBOR decoding in certain scenarios.
+| *JSON-Based Messaging* _(New in 2.2)_
+| Adds support for Digital Credentials API requests using JSON-based messages over hybrid transport. Signaled by the `dc` capability indicator in the hybrid handshake.
+| Enables browsers to exchange CTAP-compliant requests and responses via the Digital Credentials API without requiring CBOR decoding at the JavaScript layer.
 
-| **Enhanced Authenticator Metadata (getInfo)** +
-_(Expanded in 2.2)_
-| Richer self-description capabilities including UV counters, supported attestation formats, PIN complexity policy details, and maximum PIN length.
+| *Attestation Formats Preference (`attestationFormatsPreference`)* _(New in 2.2)_
+| A new `authenticatorMakeCredential` option allowing the platform to send an ordered list of preferred attestation statement formats. The authenticator selects the most preferred format it supports.
+| Enables clients to signal format preferences (e.g., `packed` over `fido-u2f`), reducing format negotiation overhead and simplifying attestation verification logic.
+
+| *Enhanced Authenticator Metadata (`getInfo`)* _(Expanded in 2.2)_
+| Richer self-description capabilities including UV counters (`uvCountSinceLastPinEntry`), supported attestation formats (`attestationFormats`), PIN complexity policy status (`pinComplexityPolicy`), and maximum PIN length (`maxPINLength`).
 | Enables adaptive client behavior. Applications can dynamically adjust UI and validation logic based on authenticator capabilities without trial-and-error probing.
 
 |===
 
 [NOTE]
 ====
-**Protocol Capabilities vs Device Support**: This table reflects CTAP 2.2 protocol features. Individual authenticator implementations vary—check YubiKey firmware documentation and SDK support matrices for specific device capabilities.
+*Protocol Capabilities vs Device Support*: This table reflects CTAP 2.2 protocol features. Individual authenticator implementations vary—check YubiKey firmware documentation and SDK support matrices for specific device capabilities.
 ====
 
-==== CTAP 2.2 Features Explained
+=== CTAP 2.2 Features Explained
 
-===== Persistent PIN/UV Auth Tokens (PPUAT)
+==== Persistent PIN/UV Auth Tokens (PPUAT)
 
-Spec:: Allows long-lived tokens for read-only credential management operations without repeated PIN entry.
-Use Case:: Enterprise SSO portals where users browse multiple apps in one session.
+Spec:: Allows long-lived, read-only tokens for credential management operations without repeated PIN entry.
+Use Case:: Enterprise SSO portals performing background credential audits; password managers that resume enumeration across sessions.
 Yubico Support:: Available in Yubico.NET SDK v1.14.0+, yubikit-android v2.9.0+, and python-fido2 v2.0.0+.
 
-When an application needs to enumerate stored credentials—for example to list available passkeys across relying parties—CTAP 2.1 required re-entering the PIN for each discovery operation. PPUATs allow the authenticator to issue a longer-lived token scoped specifically to read-only credential management operations (`enumerateRPs`, `enumerateCredentials`, `getCredentialMetadata`), dramatically improving the experience in enterprise portals and password managers. PPUATs do not grant assertion or credential creation permissions.
+CTAP 2.1 introduced `pinUvAuthToken` with a permissions model. A single PIN entry produces a token with `cm` (credential management) scope, valid for the duration of that session. PPUATs extend this by introducing a separate, narrower token that persists across power cycles and is scoped exclusively to _read-only_ credential management operations: `enumerateRPs`, `enumerateCredentials`, and `getCredentialMetadata`. This eliminates re-authentication in long-running or resumable enumeration workflows without granting the broader write access carried by a full `cm`-scoped token.
+
+PPUATs do not grant assertion or credential creation permissions.
 
 [CAUTION]
 ====
-**Browser Limitation**: PPUATs are a protocol-level feature not currently exposed through WebAuthn APIs. This feature is primarily useful for native applications that communicate directly with authenticators via CTAP.
+*Browser Limitation*: PPUATs are a protocol-level feature not currently exposed through WebAuthn APIs. This feature is primarily useful for native applications that communicate directly with authenticators via CTAP.
 ====
 
-===== PIN Complexity Policies
+==== PIN Complexity Policies
 
-Spec:: Authenticators can enforce PIN rules beyond minimum length, including character set requirements.
-Use Case:: Enterprises subject to NIST SP 800-63B or similar requirements.
+Spec:: Authenticators can enforce PIN rules beyond minimum length and can advertise whether a complexity policy is active.
+Use Case:: Enterprises with organizational PIN policies; devices configured for Common Criteria or equivalent certification requirements.
 Yubico Support:: Available in Yubico.NET SDK v1.14.0+, libfido2, and python-fido2 v2.0.0+.
 
-CTAP 2.1 introduced minimum PIN length enforcement. CTAP 2.2 expands this to full complexity policies, allowing authenticators to require not only longer PINs but also specific character set requirements. Enforcement happens at the hardware level, so security policies cannot be bypassed by a non-compliant client.
+CTAP 2.1 introduced minimum PIN length enforcement via `minPINLength`. CTAP 2.2 expands this with the `pinComplexityPolicy` mechanism, allowing authenticators to advertise and enforce additional PIN quality rules.
 
-===== thirdPartyPayment Extension
+What this mechanism does—and does not—mandate:
+
+* The CTAP 2.2 specification introduces the _protocol_ for expressing and querying PIN complexity status. It does not define specific complexity rules or require all CTAP 2.2 authenticators to enforce complexity.
+* Enforcement is authenticator-specific and typically driven by device certification requirements (such as Common Criteria) or explicit configuration during provisioning.
+* On standard YubiKey 5 Series devices, PIN complexity requires explicit configuration. On YubiKey 5 FIPS Series and YubiKey 5 Enhanced PIN, it is enabled by default.
+* YubiKey's PIN complexity policy blocks trivial and commonly-used values such as sequential patterns and dictionary words. This follows NIST SP 800-63B guidance to check PINs against commonly-used values. Note that NIST SP 800-63B explicitly _discourages_ character-composition rules (requiring uppercase, digits, etc.); Yubico's implementation follows this approach.
+
+Clients can query the `pinComplexityPolicy` field in `authenticatorGetInfo` to detect whether PIN complexity is enabled on a given device and adapt their UX accordingly.
+
+[NOTE]
+====
+*CTAP 2.3 and PIN Complexity*: CTAP 2.3 adds `pinComplexityPolicyURL`—a URL the authenticator can return pointing to device-specific PIN composition rules. This lets platforms tell users not just that their PIN was rejected, but why, and where to learn more. See the link:CTAP2.3.adoc[CTAP 2.3 guide] for details.
+====
+
+==== thirdPartyPayment Extension
 
 Spec:: Enables assertion of a credential where the transaction initiator differs from the credential's relying party.
 Use Case:: Payment providers integrating PSD2 SCA via Secure Payment Confirmation (SPC).
 Yubico Support:: Available in Yubico.NET SDK v1.14.0+, yubikit-android v2.9.0+, and python-fido2 v2.0.0+.
 
-The thirdPartyPayment extension allows a credential registered at one origin (e.g., a bank) to be used for authentication in a context where a different party initiates the transaction (e.g., a merchant checkout). This is the protocol primitive that makes Secure Payment Confirmation possible under PSD2. Note that most of the SPC-specific processing must be handled by a compliant browser or client—this extension alone is not sufficient to implement a complete SPC flow.
+The `thirdPartyPayment` extension allows a credential registered at one origin (e.g., a bank) to be used for authentication in a context where a different party initiates the transaction (e.g., a merchant checkout). This is the protocol primitive that makes Secure Payment Confirmation possible under PSD2. Note that most of the SPC-specific processing must be handled by a compliant browser or client—this extension alone is not sufficient to implement a complete SPC flow.
 
 [NOTE]
 ====
-**Browser Support Required**: Secure Payment Confirmation requires coordinated browser support. Check our link:https://developers.yubico.com/WebAuthn/WebAuthn_Browser_Support/[browser support matrix] before implementing SPC workflows, as browser adoption is still evolving.
+*Browser Support Required*: Secure Payment Confirmation requires coordinated browser support. Check our link:https://developers.yubico.com/WebAuthn/WebAuthn_Browser_Support/[browser support matrix] before implementing SPC workflows, as browser adoption is still evolving.
 ====
 
-===== hmac-secret-mc
+==== hmac-secret-mc
 
-Spec:: Adds secret derivation support to the MakeCredential operation, complementing the existing hmac-secret extension for GetAssertion.
+Spec:: Adds secret derivation support to the `authenticatorMakeCredential` operation, complementing the existing `hmac-secret` extension for `authenticatorGetAssertion`.
 Use Case:: Applications needing a per-credential secret immediately at registration—for example, password managers encrypting vaults or offline workstation access systems.
 Yubico Support:: Available in Yubico.NET SDK v1.14.0+, yubikit-android v2.9.0+, and python-fido2 v2.0.0+.
 
-The hmac-secret extension has existed since CTAP 2.1 and returns a credential-specific secret during GetAssertion. The hmac-secret-mc extension adds the ability to retrieve that secret during MakeCredential as well, enabling applications to immediately encrypt data with a hardware-backed secret without requiring the user to perform a separate authentication step first.
+The `hmac-secret` extension has existed since CTAP 2.1 and returns a credential-specific secret during `authenticatorGetAssertion`. The `hmac-secret-mc` extension adds the ability to retrieve that secret during `authenticatorMakeCredential` as well, enabling applications to immediately encrypt data with a hardware-backed secret without requiring the user to perform a separate authentication step first.
 
 [NOTE]
 ====
-**Relationship to WebAuthn PRF**: The WebAuthn PRF extension maps to the hmac-secret extension at the CTAP level for GetAssertion flows. PRF also gained MakeCredential support (via `evalByCredential`) at the WebAuthn layer, which is the browser-API equivalent of hmac-secret-mc—but they are distinct mechanisms operating at different layers of the stack.
+*Relationship to WebAuthn PRF*: The WebAuthn PRF extension maps to the `hmac-secret` extension at the CTAP level for `authenticatorGetAssertion` flows. PRF also gained `authenticatorMakeCredential` support at the WebAuthn layer via the `eval` field of the PRF extension input—this is the browser-API equivalent of `hmac-secret-mc`, and the two mechanisms operate at different layers of the stack.
+
+Note: `evalByCredential` is a separate, `authenticatorGetAssertion`-only field that allows the PRF to be evaluated against specific credential IDs when multiple credentials are eligible. It is not related to `authenticatorMakeCredential` support.
 
 For comprehensive implementation guidance, see our PRF extension documentation:
 
@@ -136,69 +164,101 @@ For comprehensive implementation guidance, see our PRF extension documentation:
 * link:https://developers.yubico.com/WebAuthn/Concepts/PRF_Extension/CTAP2_HMAC_Secret_Deep_Dive.html[CTAP2 HMAC-Secret Deep Dive]
 ====
 
-===== Hybrid Transport
+==== Hybrid Transport
 
 Spec:: Cross-device authentication protocol using QR codes and BLE proximity pairing.
 Use Case:: Enables FIDO authentication on devices without built-in authenticators by leveraging a phone's platform authenticator.
 Yubico Support:: Not applicable—hybrid transport is implemented by platform authenticators and clients, not roaming security keys.
 
-Hybrid transport allows a platform authenticator on a phone to complete authentication for sessions on other devices like desktops. The user scans a QR code displayed on the desktop, and the phone establishes a secure connection via BLE and an encrypted tunnel to complete the FIDO ceremony.
+Hybrid transport allows a platform authenticator on a phone to complete authentication for sessions on other devices like desktops. The user scans a QR code displayed on the desktop, and the phone establishes a secure connection via BLE and an encrypted network tunnel to complete the FIDO ceremony.
+
+CTAP 2.2 defines WebSocket-based tunnels as the data transfer channel for QR-initiated hybrid transactions. CTAP 2.3 extends this with Bluetooth Low Energy as an alternative channel. See the link:CTAP2.3.adoc[CTAP 2.3 guide] for details.
 
 [NOTE]
 ====
-**Implementation Note**: Browsers and operating systems handle hybrid transport. Application developers design flows that support both roaming authenticators and cross-device authentication, depending on user hardware availability.
+*Implementation Note*: Browsers and operating systems handle hybrid transport. Application developers design flows that support both roaming authenticators and cross-device authentication, depending on user hardware availability.
 ====
 
-===== JSON-Based Messaging
+==== JSON-Based Messaging
 
-Spec:: Optional JSON encoding for credential management commands, supplementing CBOR.
-Use Case:: Browser credential management UIs.
-Yubico Support:: Transparent to SDK usage—Yubico SDKs use CBOR when communicating with YubiKeys.
+Spec:: Adds support for Digital Credentials API requests using JSON-based messages over hybrid transport. Support is indicated by the `dc` capability in the hybrid handshake message.
+Use Case:: Browsers implementing the Digital Credentials API over cross-device hybrid transport.
+Yubico Support:: Transparent to SDK usage—Yubico SDKs use CBOR when communicating with YubiKeys directly.
 
-CTAP 2.2 allows JSON encoding for specific credential management operations. This simplifies browser implementations that would otherwise need CBOR decoding in JavaScript. The core protocol continues using CBOR.
+CTAP 2.2 defines a JSON-based message format for Digital Credentials API requests exchanged over hybrid transport channels. This allows browsers to process CTAP-compliant requests and responses without CBOR decoding at the JavaScript layer. The core protocol continues using CBOR for all direct CTAP communication.
 
-===== getInfo Metadata Extensions
+==== getInfo Metadata Extensions
 
 Spec:: Richer authenticator self-description including PIN complexity policies, attestation formats, UV counters, and more.
-Use Case:: Applications that adapt their behavior based on authenticator capabilities—for example, adjusting PIN requirements or choosing attestation verification strategies.
+Use Case:: Applications that adapt their behavior based on authenticator capabilities.
 Yubico Support:: Available in Yubico.NET SDK v1.14.0+, yubikit-android v2.9.0+, python-fido2 v2.0.0+, and exposed via libfido2/fido2-token.
 
-CTAP 2.2 expands the authenticatorGetInfo response with fields like `uvCountSinceLastPinEntry`, `attestationFormats`, `pinComplexityPolicy`, and `maxPinLength`. These metadata fields enable smarter application behavior without trial-and-error probing of authenticator capabilities.
+CTAP 2.2 expands the `authenticatorGetInfo` response with several new fields:
 
-==== Yubico SDKs and CTAP 2.2 Support
+[cols="1,2", options="header"]
+|===
+| Field | Purpose
 
-[cols="1,1,1", options="header"]
+| `uvCountSinceLastPinEntry`
+| Number of user verifications performed since the last PIN entry. Supports adaptive client logic—for example, determining whether a PIN prompt can be deferred.
+
+| `attestationFormats`
+| List of attestation statement formats supported by the authenticator. Allows relying parties to select a preferred format for verification without trial-and-error.
+
+| `pinComplexityPolicy`
+| Boolean indicating whether PIN complexity policy is enabled on the authenticator. Platforms should check this field before presenting PIN entry UI and adjust guidance accordingly.
+
+| `maxPINLength`
+| Maximum PIN length the authenticator will accept. Complements `minPINLength` (CTAP 2.1) to allow platforms to provide accurate PIN input constraints.
+
+|===
+
+=== Yubico SDKs and CTAP 2.2 Support
+
+[cols="1,1,3", options="header"]
 |===
 | SDK | CTAP 2.2 Support | Notes
-| python-fido2 | ✅ Full Support | v2.0.0+ supports PPUAT, hmac-secret-mc, thirdPartyPayment, and expanded getInfo fields. Note: thirdPartyPayment is not included in the default extensions list and requires a client that supports the WebAuthn payment extension.
-| Yubico.NET SDK | ✅ Extensive Support | v1.14.0+ supports PPUAT, PIN complexity policies, thirdPartyPayment, hmac-secret-mc, and expanded getInfo properties.
-| yubikit-android | ✅ Good Support | v2.9.0+ supports PPUAT, hmac-secret-mc, thirdPartyPayment, and expanded getInfo members. v3.0.0+ additionally supports CTAP 2.3. Actively maintained.
-| libfido2 / fido2-token | ⚠️ Limited | C library and command-line tools. Check the link:https://github.com/Yubico/libfido2[libfido2 release notes] for current CTAP 2.2 feature coverage.
-| yubikit-swift | ⚠️ Limited | Modern Swift SDK for iOS/macOS. CTAP 2.2 feature support under development.
-| yubikit-ios (Objective-C) | ⚠️ Limited | Legacy Objective-C SDK. Missing most CTAP 2.2 features. Consider yubikit-swift for new projects.
+
+| python-fido2
+| ✅ Full Support
+| v2.0.0+ supports PPUAT, `hmac-secret-mc`, `thirdPartyPayment`, and expanded `getInfo` fields. Note: `thirdPartyPayment` is not included in the default extensions list and requires a client that supports the WebAuthn payment extension.
+
+| Yubico.NET SDK
+| ✅ Extensive Support
+| v1.14.0+ supports PPUAT, PIN complexity policies, `thirdPartyPayment`, `hmac-secret-mc`, and expanded `getInfo` properties.
+
+| yubikit-android
+| ✅ Good Support
+| v2.9.0+ supports PPUAT, `hmac-secret-mc`, `thirdPartyPayment`, and expanded `getInfo` members. v3.0.0+ additionally supports CTAP 2.3. Actively maintained.
+
+| libfido2 / fido2-token
+| ⚠️ Limited
+| C library and command-line tools. Check the link:https://github.com/Yubico/libfido2[libfido2 release notes] for current CTAP 2.2 feature coverage.
+
+| yubikit-swift
+| ⚠️ Limited
+| Modern Swift SDK for iOS/macOS. CTAP 2.2 feature support under development.
+
+| yubikit-ios (Objective-C)
+| ⚠️ Limited
+| Legacy Objective-C SDK. Missing most CTAP 2.2 features. Consider yubikit-swift for new projects.
+
 |===
 
 [NOTE]
 ====
-**Feature Coverage**: Hybrid transport and JSON messaging are handled by browsers and operating systems, not SDK implementations.
+*Feature Coverage*: Hybrid transport and JSON messaging are handled by browsers and operating systems, not SDK implementations.
 ====
 
-===== References
+=== References
 
+* link:https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html[CTAP 2.2 Specification (FIDO Alliance)]
+* link:https://developers.yubico.com/WebAuthn/WebAuthn_Browser_Support/[WebAuthn Browser Support Matrix]
+* link:CTAP2.1.adoc[CTAP 2.1 Feature Reference]
+* link:CTAP2.3.adoc[CTAP 2.3 Feature Reference]
 * link:https://github.com/Yubico/Yubico.NET.SDK/[Yubico.NET SDK on GitHub]
 * link:https://github.com/Yubico/yubikit-android[yubikit-android on GitHub]
 * link:https://github.com/Yubico/python-fido2[python-fido2 on GitHub]
 * link:https://github.com/Yubico/libfido2[libfido2 on GitHub]
 * link:https://github.com/Yubico/yubikit-ios[yubikit-ios on GitHub]
 * link:https://github.com/Yubico/yubikit-swift[yubikit-swift on GitHub]
-* link:https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html[CTAP 2.2 Specification (FIDO Alliance)]
-* link:https://developers.yubico.com/WebAuthn/WebAuthn_Browser_Support/[WebAuthn Browser Support Matrix]
-
-==== Where to Learn More
-
-* link:https://fidoalliance.org/specifications/[FIDO Alliance Specifications]
-* link:https://github.com/Yubico[Yubico on GitHub]
-* link:https://support.yubico.com[Yubico Support]
-
-[.text-center]
-_Have questions about implementing CTAP 2.2 features? Visit our link:https://support.yubico.com[Support Portal] or join the conversation in our link:https://github.com/Yubico[GitHub repositories]._

--- a/content/CTAP/CTAP2.2.adoc
+++ b/content/CTAP/CTAP2.2.adoc
@@ -38,7 +38,7 @@ CTAP 2.2 strengthens the FIDO2 protocol with persistent PIN tokens, configurable
 
 The Client to Authenticator Protocol (CTAP) defines how authenticators communicate with clients for FIDO2 authentication. CTAP 2.2 strengthens the protocol with features that address enterprise deployment requirements and expand authentication options across the FIDO ecosystem.
 
-For roaming authenticators like YubiKeys, this release delivers capabilities that reduce friction in enterprise workflows: persistent PIN/UV auth tokens provide long-lived, read-only tokens for credential enumeration without repeated PIN entry; PIN complexity policies enable authenticators to advertise and enforce device-specific PIN requirements; and the `thirdPartyPayment` extension enables cross-domain authentication for regulated payment transactions.
+For roaming authenticators like YubiKeys, this release delivers capabilities that reduce friction in enterprise workflows: persistent PIN/UV auth tokens provide long-lived, read-only tokens for credential enumeration without repeated PIN entry; PIN complexity policies give platforms a standard way to query whether device-specific PIN requirements are active; and the `thirdPartyPayment` extension enables cross-domain authentication for regulated payment transactions.
 
 CTAP 2.2 also formalizes hybrid transport, a protocol mechanism for cross-device authentication using QR codes and proximity pairing. This allows a platform authenticator on a phone to authenticate sessions on other devices like desktops. Hybrid flows use platform authenticators (such as those on smartphones) or multi-device passkeys. For scenarios requiring attestation and non-exportable keys, hardware security keys remain the appropriate authenticator choice.
 
@@ -78,7 +78,7 @@ CTAP 2.2 introduces new protocol capabilities and expands features established i
 
 | *Attestation Formats Preference (`attestationFormatsPreference`)* _(New in 2.2)_
 | A new `authenticatorMakeCredential` option allowing the platform to send an ordered list of preferred attestation statement formats. The authenticator selects the most preferred format it supports.
-| Enables clients to signal format preferences (e.g., `packed` over `fido-u2f`), reducing format negotiation overhead and simplifying attestation verification logic.
+| Allows clients to signal preferred attestation statement formats. Authenticators that support multiple formats select the highest-priority match, reducing format negotiation overhead for relying parties.
 
 | *Enhanced Authenticator Metadata (`getInfo`)* _(Expanded in 2.2)_
 | Richer self-description capabilities including UV counters (`uvCountSinceLastPinEntry`), supported attestation formats (`attestationFormats`), PIN complexity policy status (`pinComplexityPolicy`), and maximum PIN length (`maxPINLength`).
@@ -96,7 +96,7 @@ CTAP 2.2 introduces new protocol capabilities and expands features established i
 ==== Persistent PIN/UV Auth Tokens (PPUAT)
 
 Spec:: Allows long-lived, read-only tokens for credential management operations without repeated PIN entry.
-Use Case:: Enterprise SSO portals performing background credential audits; password managers that resume enumeration across sessions.
+Use Case:: Enterprise SSO portals performing background credential audits; password managers that resume enumeration across sessions; browsers implementing autofill or conditional mediation UX for hardware security keys.
 Yubico Support:: Available in Yubico.NET SDK v1.14.0+, yubikit-android v2.9.0+, and python-fido2 v2.0.0+.
 
 CTAP 2.1 introduced `pinUvAuthToken` with a permissions model. A single PIN entry produces a token with `cm` (credential management) scope, valid for the duration of that session. PPUATs extend this by introducing a separate, narrower token that persists across power cycles and is scoped exclusively to _read-only_ credential management operations: `enumerateRPs`, `enumerateCredentials`, and `getCredentialMetadata`. This eliminates re-authentication in long-running or resumable enumeration workflows without granting the broader write access carried by a full `cm`-scoped token.
@@ -114,7 +114,7 @@ Spec:: Authenticators can enforce PIN rules beyond minimum length and can advert
 Use Case:: Enterprises with organizational PIN policies; devices configured for Common Criteria or equivalent certification requirements.
 Yubico Support:: Available in Yubico.NET SDK v1.14.0+, libfido2, and python-fido2 v2.0.0+.
 
-CTAP 2.1 introduced minimum PIN length enforcement via `minPINLength`. CTAP 2.2 expands this with the `pinComplexityPolicy` mechanism, allowing authenticators to advertise and enforce additional PIN quality rules.
+CTAP 2.1 introduced minimum PIN length enforcement via `minPINLength`. CTAP 2.2 expands this with the `pinComplexityPolicy` mechanism, allowing authenticators to advertise whether a PIN complexity policy is active.
 
 What this mechanism does—and does not—mandate:
 
@@ -125,10 +125,39 @@ What this mechanism does—and does not—mandate:
 
 Clients can query the `pinComplexityPolicy` field in `authenticatorGetInfo` to detect whether PIN complexity is enabled on a given device and adapt their UX accordingly.
 
-[NOTE]
-====
-*CTAP 2.3 and PIN Complexity*: CTAP 2.3 adds `pinComplexityPolicyURL`—a URL the authenticator can return pointing to device-specific PIN composition rules. This lets platforms tell users not just that their PIN was rejected, but why, and where to learn more. See the link:CTAP2.3.adoc[CTAP 2.3 guide] for details.
-====
+===== PIN Complexity Policy URL
+
+`pinComplexityPolicyURL` is an optional string field also introduced in CTAP 2.2's `authenticatorGetInfo` response. When present, it provides a URL where the platform can direct users to read the PIN composition rules that apply to their device.
+
+Before this mechanism, when a user entered a PIN that violated a complexity policy, the authenticator returned a generic rejection error. Platforms had no standard way to distinguish "PIN too short" from "PIN not complex enough," or to tell users where to read the applicable rules. This was particularly notable with devices that have firmware-enforced PIN complexity (YubiKey 5 FIPS Series, YubiKey 5 Enhanced PIN)—the user had no indication that complexity rather than length was the issue.
+
+Platforms building PIN rejection UX should:
+
+. Query `pinComplexityPolicy` on every session to detect whether complexity is active.
+. If `pinComplexityPolicy` is `true` and a PIN is rejected, display a message that specifically identifies the complexity failure (distinct from length failures).
+. If `pinComplexityPolicyURL` is present, offer a link so users can read the applicable rules.
+
+[cols="2,1,2", options="header"]
+|===
+| YubiKey Variant | PIN Complexity Default | Notes
+
+| YubiKey 5 Series (standard)
+| Off (requires configuration)
+| Can be enabled via custom pre-registration configuration
+
+| YubiKey 5 FIPS Series
+| On
+| Required by FIPS 140-3 / Common Criteria certification
+
+| YubiKey 5 Enhanced PIN Series
+| On
+| Always on; cannot be permanently disabled
+
+| Security Key Series
+| Off (enterprise variants: configurable)
+| —
+
+|===
 
 ==== thirdPartyPayment Extension
 
@@ -211,6 +240,9 @@ CTAP 2.2 expands the `authenticatorGetInfo` response with several new fields:
 | `maxPINLength`
 | Maximum PIN length the authenticator will accept. Complements `minPINLength` (CTAP 2.1) to allow platforms to provide accurate PIN input constraints.
 
+| `pinComplexityPolicyURL`
+| Optional URL pointing to device-specific PIN composition rules. When present, platforms should offer a link when rejecting a PIN for complexity reasons, directing users to the applicable policy documentation.
+
 |===
 
 === Yubico SDKs and CTAP 2.2 Support
@@ -232,8 +264,8 @@ CTAP 2.2 expands the `authenticatorGetInfo` response with several new fields:
 | v2.9.0+ supports PPUAT, `hmac-secret-mc`, `thirdPartyPayment`, and expanded `getInfo` members. v3.0.0+ additionally supports CTAP 2.3. Actively maintained.
 
 | libfido2 / fido2-token
-| ⚠️ Limited
-| C library and command-line tools. Check the link:https://github.com/Yubico/libfido2[libfido2 release notes] for current CTAP 2.2 feature coverage.
+| ✅ Full Support (v1.17.0+)
+| v1.17.0+ supports most CTAP 2.2 features. Check the link:https://github.com/Yubico/libfido2[libfido2 release notes] for specific feature coverage, or open an issue or pull request on GitHub if something is missing.
 
 | yubikit-swift
 | ⚠️ Limited

--- a/content/CTAP/CTAP2.3.adoc
+++ b/content/CTAP/CTAP2.3.adoc
@@ -1,0 +1,278 @@
+== CTAP 2.3: Protocol Refinements and PIN Complexity Improvements
+:description: Comprehensive guide to CTAP 2.3 features including BLE hybrid transport, PIN complexity policy URL, long touch for reset, and protocol clarifications. Learn what changed from CTAP 2.2.
+:keywords: CTAP 2.3, FIDO2, PIN complexity policy, hybrid transport, BLE, long touch reset, FIDO_2_3, authenticatorGetInfo, pinComplexityPolicyURL
+:author: Yubico Developer Relations
+:page-layout: technical-guide
+:page-category: Authentication Protocols
+:page-tags: CTAP 2.3, FIDO2, PIN Complexity, Hybrid Transport
+:toc: left
+:toclevels: 3
+:sectanchors:
+:source-highlighter: highlight.js
+:page-last-updated: 2026-05-22
+
+[.lead]
+CTAP 2.3 is an incremental, backwards-compatible update to CTAP 2.2. It refines PIN complexity interactions, adds `pinComplexityPolicyURL` to improve PIN rejection UX, extends hybrid transport with a BLE channel, and clarifies several protocol edge cases.
+
+++++
+<div class="last-updated-banner">
+    <!-- Simple clock icon -->
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+    <span>Last Updated on 22 May 2026</span>
+</div>
+++++
+
+[NOTE]
+====
+*WebAuthn and Browser Support*: While CTAP 2.3 features are available at the protocol level, WebAuthn applications depend on browser support for these capabilities. Consult our link:https://developers.yubico.com/WebAuthn/WebAuthn_Browser_Support/[WebAuthn Browser Support] page before implementation.
+====
+
+=== Relationship to CTAP 2.2
+
+The FIDO Alliance published CTAP 2.3 on February 26, 2026. It introduces no breaking changes: any CTAP 2.2-conformant implementation is automatically conformant to CTAP 2.3.
+
+Because no breaking changes were introduced, the Alliance did not create a separate certification category for CTAP 2.2. All FIDO2 authenticator certifications are issued against CTAP 2.3. There is no `FIDO_2_2` version string in `authenticatorGetInfo`; a device advertising CTAP 2.3 support reports `FIDO_2_3`.
+
+This means:
+
+* Existing CTAP 2.2 implementations do not need protocol changes to be CTAP 2.3 conformant.
+* New CTAP 2.3 features are additive—platforms and authenticators signal support via `authenticatorGetInfo` as always.
+
+For context on the features CTAP 2.2 introduced, see the link:CTAP2.2.adoc[CTAP 2.2 guide].
+
+=== What's New in CTAP 2.3
+
+[cols="2,3,3", options="header"]
+|===
+| Feature | Description | Developer Benefit
+
+| *BLE Data Transfer Channel for Hybrid* _(New in 2.3)_
+| QR-initiated hybrid transactions can now specify Bluetooth Low Energy as the data transfer channel, in addition to the WebSocket channel supported since CTAP 2.2.
+| Enables cross-device authentication in constrained or offline network environments where WebSocket connections to relay servers may be blocked.
+
+| *`FIDO_2_3` Version String* _(New in 2.3)_
+| The value `FIDO_2_3` is added to the `versions` array in `authenticatorGetInfo` to indicate CTAP 2.3 support. No `FIDO_2_2` value was defined.
+| Platforms can reliably detect CTAP 2.3 support and gate features accordingly.
+
+| *Long Touch for Reset* _(New in 2.3)_
+| Authenticators can advertise via `authenticatorGetInfo` that their reset ceremony requires a long touch. The `enableLongTouchForReset` subcommand of `authenticatorConfig` controls whether this behavior is active.
+| Platforms can display accurate reset instructions without guessing device-specific UX, preventing failed resets from insufficient touch duration.
+
+| *PIN Complexity + Minimum PIN Length Refinement* _(Refined in 2.3)_
+| The interaction between `pinComplexityPolicy` and `setMinPINLength` is clarified. `pinComplexityPolicyURL` is added, providing a URL where platforms can direct users to read device-specific PIN composition rules.
+| Enables platforms to surface actionable guidance when a PIN is rejected for complexity reasons—replacing a generic error with a specific explanation and a link to the applicable rules.
+
+| *`smart-card` Interface* _(New in 2.3)_
+| `smart-card` is added to the list of valid FIDO Interface values in `authenticatorGetInfo`.
+| Authenticators accessed via ISO 7816 contact readers can correctly advertise their interface type, improving interoperability with enterprise credential management systems.
+
+| *FIDO Applet Explicit Selection Required* _(New in 2.3)_
+| Authenticators are prohibited from allowing FIDO Applets to be implicitly selected or enabled. Explicit applet selection is required.
+| Hardens the security boundary around FIDO operations in multi-application smart-card scenarios, reducing the risk of unintended applet activation.
+
+| *`authenticatorReset` Clarification* _(Clarified in 2.3)_
+| Authenticators SHOULD support `authenticatorReset`, or MUST provide an alternate mechanism to return the device to factory default state.
+| Guarantees every CTAP 2.3 authenticator has a defined reset path, even if it is not via the CTAP reset command directly.
+
+| *`setMinPINLength` with Built-in UV* _(Clarified in 2.3)_
+| `setMinPINLength` may be used when the authenticator supports PIN entry via built-in user verification (e.g., on-device input), not only via client-side PIN collection.
+| Broadens the applicability of minimum PIN length policies to authenticators with integrated PIN input mechanisms.
+
+| *ISO 7816 (Contact + NFC) Clarification* _(Clarified in 2.3)_
+| The NFC evidence-of-user-interaction model is generalized to cover both NFC and ISO 7816 contact interfaces. Terminology updated and timeout behaviors for `NFCCTAP_GETRESPONSE` refined.
+| Eliminates ambiguity for authenticators that support both contact and contactless interfaces, ensuring consistent user-presence semantics across physical interface types.
+
+|===
+
+=== CTAP 2.3 Features Explained
+
+==== BLE Data Transfer Channel for Hybrid Transport
+
+Spec:: QR-initiated hybrid transactions can now negotiate a Bluetooth Low Energy channel as an alternative to the WebSocket channel defined in CTAP 2.2.
+Use Case:: Environments with restricted internet access, air-gapped networks, or scenarios requiring low-latency local radio communication.
+Yubico Support:: Not applicable to roaming security keys—hybrid transport is implemented by platform authenticators and clients.
+
+CTAP 2.2 specified WebSocket-based encrypted tunnels as the data transfer mechanism for QR-initiated hybrid authentication. CTAP 2.3 extends this by adding BLE as a negotiable alternative. The QR code payload specifies which channel the Credential Provider Hosting Device supports, and the client selects accordingly.
+
+This matters for enterprise deployments with strict network egress filtering, where WebSocket connections to FIDO relay servers may be blocked. A BLE channel allows cross-device authentication entirely over local radio, with no internet connectivity required for the data transfer phase.
+
+[NOTE]
+====
+*Platform and OS support required*: BLE hybrid transport requires coordinated support in both the initiating platform (desktop OS/browser) and the device providing the platform authenticator (phone). Check platform release notes for availability.
+====
+
+==== FIDO_2_3 Version String
+
+Spec:: `FIDO_2_3` is added to the supported version strings returned by `authenticatorGetInfo`. No `FIDO_2_2` string was defined.
+Use Case:: Platform feature detection for CTAP 2.3-specific behaviors.
+
+When a platform needs to gate a CTAP 2.3-only feature—such as BLE hybrid channels or `longTouchForReset`—it checks for `FIDO_2_3` in the `authenticatorGetInfo` `versions` array.
+
+There is a gap in version string granularity: no single version string distinguishes CTAP 2.2-only from CTAP 2.3. For CTAP 2.2 features specifically, platforms should use field-level feature detection via the relevant `authenticatorGetInfo` fields rather than relying on version strings.
+
+==== Long Touch for Reset
+
+Spec:: An authenticator can advertise via `authenticatorGetInfo` that its reset ceremony requires a long touch. The `enableLongTouchForReset` subcommand of `authenticatorConfig` controls whether this mode is active.
+Use Case:: Enterprise deployments where accidental resets are a concern; any device that uses sustained touch to differentiate reset from normal operation.
+Yubico Support:: Check Yubico release notes for firmware and SDK availability.
+
+Before CTAP 2.3, platforms had no standard way to know whether a device's reset ceremony required a brief touch or a sustained one. This caused UX confusion—users who didn't hold long enough would fail the reset without a clear explanation.
+
+With CTAP 2.3, an authenticator that requires a long touch sets `longTouchForReset: true` in `authenticatorGetInfo`. Platforms should check this before presenting reset instructions and adjust the UI accordingly.
+
+==== PIN Complexity Policy URL
+
+Spec:: `pinComplexityPolicyURL` is a new optional string field in the `authenticatorGetInfo` response. When present, it provides a URL where the platform can direct users to read the PIN composition rules that apply to their device.
+Use Case:: Platforms building PIN rejection UX for devices with firmware-level PIN complexity enabled.
+Yubico Support:: Check Yubico release notes for firmware and SDK availability.
+
+===== The Problem This Solves
+
+Before CTAP 2.3, when a user entered a PIN that violated a complexity policy, the authenticator returned a generic rejection error. Platforms had no standard way to:
+
+. Distinguish "PIN too short" from "PIN not complex enough"
+. Tell users what the complexity rules are or where to read them
+. Provide actionable guidance beyond a generic error message
+
+This was particularly notable with devices that have firmware-enforced PIN complexity via certification (Common Criteria, FIPS 140-3). A YubiKey 5 FIPS or Enhanced PIN device would reject a non-compliant PIN with a generic error; the user had no indication that complexity—rather than length—was the issue.
+
+===== What CTAP 2.3 Adds
+
+When `pinComplexityPolicyURL` is present in `authenticatorGetInfo`, platforms should:
+
+* Query `pinComplexityPolicy` on every session to detect whether complexity is active.
+* If `pinComplexityPolicy` is `true` and a PIN is rejected, display a message that specifically identifies the complexity failure (distinct from length failures).
+* If `pinComplexityPolicyURL` is present, offer a link so users can read the applicable rules.
+
+===== Relationship to `minPINLength`
+
+`pinComplexityPolicy` and `setMinPINLength` are complementary and may both be active on the same device. CTAP 2.3 clarifies the precedence of these two checks in the authenticator's PIN validation logic, ensuring consistent rejection behavior across authenticators.
+
+===== YubiKey-Specific Context
+
+PIN complexity behavior varies by YubiKey variant and firmware:
+
+[cols="2,1,2", options="header"]
+|===
+| YubiKey Variant | PIN Complexity Default | Notes
+
+| YubiKey 5 Series (standard)
+| Off (requires configuration)
+| Can be enabled via custom pre-registration configuration
+
+| YubiKey 5 FIPS Series
+| On
+| Required by FIPS 140-3 / Common Criteria certification
+
+| YubiKey 5 Enhanced PIN Series
+| On
+| Always on; cannot be permanently disabled
+
+| Security Key Series
+| Off (enterprise variants: configurable)
+| —
+
+|===
+
+YubiKey's PIN complexity policy blocks trivial and commonly-used values: sequential patterns, repeated digits, dictionary words, and values on a device-specific blocklist. This follows the NIST SP 800-63B recommendation to check PINs against commonly-used values, rather than requiring specific character types (which NIST SP 800-63B explicitly discourages).
+
+==== smart-card Interface
+
+Spec:: `smart-card` is added to the list of valid FIDO Interface values in `authenticatorGetInfo`.
+Use Case:: Authenticators accessed via ISO 7816 contact smart-card readers in enterprise deployments.
+Yubico Support:: Applicable to YubiKey deployments in contact smart-card reader environments.
+
+Prior to CTAP 2.3, the recognized transport/interface values were `usb`, `nfc`, `ble`, and `internal`. Smart-card (ISO 7816 contact) interfaces lacked a dedicated value, which caused ambiguity in enterprise environments where YubiKeys are inserted into smart-card readers rather than USB ports.
+
+Adding `smart-card` enables credential management systems and relying parties to accurately identify the physical interface in use and apply interface-specific policies—for example, requiring contact-based authentication for high-assurance operations.
+
+==== FIDO Applet Explicit Selection
+
+Spec:: Authenticators are prohibited from allowing FIDO Applets to be implicitly selected or enabled.
+Use Case:: Multi-application smart-card environments where FIDO and PIV or other applets coexist on the same device.
+
+In multi-applet environments—such as YubiKey, which supports FIDO2, PIV, OpenPGP, and OTP simultaneously—there was previously no normative requirement preventing a FIDO Applet from being activated without an explicit selection command. CTAP 2.3 normatively prohibits implicit selection, ensuring that FIDO operations can only begin after the platform has explicitly selected the FIDO Applet.
+
+==== authenticatorReset Clarification
+
+Spec:: `authenticatorReset` SHOULD be supported. If it is not, the authenticator MUST provide an alternate, documented mechanism for returning the device to factory default state.
+Use Case:: Enterprise device lifecycle management; security key recovery scenarios.
+
+This clarification ensures that every CTAP 2.3 authenticator provides a defined reset path. Platforms building device management workflows can assume a reset path exists, even if it is not via the CTAP `authenticatorReset` command.
+
+=== Feature Detection Guidance
+
+Because CTAP 2.3 introduced no breaking changes, platforms should use field-level feature detection rather than relying solely on version strings.
+
+[cols="2,2", options="header"]
+|===
+| Feature to detect | `authenticatorGetInfo` field to check
+
+| CTAP 2.3 advertised
+| `versions` contains `FIDO_2_3`
+
+| PIN Complexity is active
+| `pinComplexityPolicy: true`
+
+| PIN Complexity policy URL available
+| `pinComplexityPolicyURL` present and non-empty
+
+| Long Touch for Reset required
+| `longTouchForReset: true`
+
+| PPUAT (persistent read-only token)
+| `options.persistentUvAuthToken: true`
+
+| Minimum PIN length
+| `minPINLength` present (CTAP 2.1+)
+
+| Maximum PIN length
+| `maxPINLength` present (CTAP 2.2+)
+
+|===
+
+=== Yubico SDKs and CTAP 2.3 Support
+
+[cols="1,1,3", options="header"]
+|===
+| SDK | CTAP 2.3 Support | Notes
+
+| yubikit-android
+| ✅ v3.0.0+
+| Full CTAP 2.3 support. Actively maintained.
+
+| Yubico.NET SDK
+| ✅ In progress
+| Check link:https://docs.yubico.com/yesdk/users-manual/getting-started/whats-new.html[What's New in the SDK] for current CTAP 2.3 feature coverage.
+
+| python-fido2
+| ✅ v2.0.0+
+| CTAP 2.3 feature coverage follows FIDO Alliance spec additions. Check link:https://github.com/Yubico/python-fido2[python-fido2 release notes] for specific feature availability.
+
+| libfido2 / fido2-token
+| ⚠️ Partial
+| C library and command-line tools. Check link:https://github.com/Yubico/libfido2[libfido2 release notes] for current coverage.
+
+| yubikit-swift
+| ⚠️ In development
+| Modern Swift SDK for iOS/macOS. CTAP 2.3 feature support under development.
+
+| yubikit-ios (Objective-C)
+| ❌ Not planned
+| Legacy SDK. Migrate to yubikit-swift for new projects.
+
+|===
+
+=== References
+
+* link:https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html[CTAP 2.3 Specification (FIDO Alliance)]
+* link:https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html[CTAP 2.2 Specification (FIDO Alliance)]
+* link:https://developers.yubico.com/WebAuthn/WebAuthn_Browser_Support/[WebAuthn Browser Support Matrix]
+* link:CTAP2.2.adoc[CTAP 2.2 Feature Reference]
+* link:CTAP2.1.adoc[CTAP 2.1 Feature Reference]
+* link:https://docs.yubico.com/hardware/yubikey/yk-tech-manual/yk5-firmware-overview.html[YubiKey 5 Firmware Overview]
+* link:https://docs.yubico.com/yesdk/users-manual/getting-started/whats-new.html[Yubico .NET SDK — What's New]
+* link:https://github.com/Yubico/python-fido2[python-fido2 on GitHub]
+* link:https://github.com/Yubico/yubikit-android[yubikit-android on GitHub]

--- a/content/CTAP/CTAP2.3.adoc
+++ b/content/CTAP/CTAP2.3.adoc
@@ -12,7 +12,7 @@
 :page-last-updated: 2026-05-22
 
 [.lead]
-CTAP 2.3 is an incremental, backwards-compatible update to CTAP 2.2. It refines PIN complexity interactions, adds `pinComplexityPolicyURL` to improve PIN rejection UX, extends hybrid transport with a BLE channel, and clarifies several protocol edge cases.
+CTAP 2.3 is an incremental, backwards-compatible update to CTAP 2.2. It extends hybrid transport with a BLE channel, updates the long touch for reset timeout, and clarifies several protocol edge cases including smart-card interface handling and ISO 7816 user-presence semantics.
 
 ++++
 <div class="last-updated-banner">
@@ -56,13 +56,9 @@ For context on the features CTAP 2.2 introduced, see the link:CTAP2.2.adoc[CTAP 
 | The value `FIDO_2_3` is added to the `versions` array in `authenticatorGetInfo` to indicate CTAP 2.3 support. No `FIDO_2_2` value was defined.
 | Platforms can reliably detect CTAP 2.3 support and gate features accordingly.
 
-| *Long Touch for Reset* _(New in 2.3)_
-| Authenticators can advertise via `authenticatorGetInfo` that their reset ceremony requires a long touch. The `enableLongTouchForReset` subcommand of `authenticatorConfig` controls whether this behavior is active.
+| *Long Touch for Reset* _(Introduced in 2.2; updated in 2.3)_
+| Authenticators can advertise via `authenticatorGetInfo` that their reset ceremony requires a long touch. CTAP 2.3 reduces the required hold duration from 10 seconds to 5 seconds. The `enableLongTouchForReset` subcommand of `authenticatorConfig` allows toggling this behavior on authenticators that support it; note that YubiKeys do not support this toggle.
 | Platforms can display accurate reset instructions without guessing device-specific UX, preventing failed resets from insufficient touch duration.
-
-| *PIN Complexity + Minimum PIN Length Refinement* _(Refined in 2.3)_
-| The interaction between `pinComplexityPolicy` and `setMinPINLength` is clarified. `pinComplexityPolicyURL` is added, providing a URL where platforms can direct users to read device-specific PIN composition rules.
-| Enables platforms to surface actionable guidance when a PIN is rejected for complexity reasons—replacing a generic error with a specific explanation and a link to the applicable rules.
 
 | *`smart-card` Interface* _(New in 2.3)_
 | `smart-card` is added to the list of valid FIDO Interface values in `authenticatorGetInfo`.
@@ -114,79 +110,23 @@ There is a gap in version string granularity: no single version string distingui
 
 ==== Long Touch for Reset
 
-Spec:: An authenticator can advertise via `authenticatorGetInfo` that its reset ceremony requires a long touch. The `enableLongTouchForReset` subcommand of `authenticatorConfig` controls whether this mode is active.
+Spec:: An authenticator can advertise via `authenticatorGetInfo` that its reset ceremony requires a long touch. CTAP 2.3 reduces the required hold duration from 10 seconds to 5 seconds. The `enableLongTouchForReset` subcommand of `authenticatorConfig` allows toggling this behavior on authenticators that support it; YubiKeys do not support this toggle.
 Use Case:: Enterprise deployments where accidental resets are a concern; any device that uses sustained touch to differentiate reset from normal operation.
 Yubico Support:: Check Yubico release notes for firmware and SDK availability.
 
-Before CTAP 2.3, platforms had no standard way to know whether a device's reset ceremony required a brief touch or a sustained one. This caused UX confusion—users who didn't hold long enough would fail the reset without a clear explanation.
+Before CTAP 2.2, platforms had no standard way to know whether a device's reset ceremony required a brief touch or a sustained one. This caused UX confusion—users who didn't hold long enough would fail the reset without a clear explanation.
 
-With CTAP 2.3, an authenticator that requires a long touch sets `longTouchForReset: true` in `authenticatorGetInfo`. Platforms should check this before presenting reset instructions and adjust the UI accordingly.
-
-==== PIN Complexity Policy URL
-
-Spec:: `pinComplexityPolicyURL` is a new optional string field in the `authenticatorGetInfo` response. When present, it provides a URL where the platform can direct users to read the PIN composition rules that apply to their device.
-Use Case:: Platforms building PIN rejection UX for devices with firmware-level PIN complexity enabled.
-Yubico Support:: Check Yubico release notes for firmware and SDK availability.
-
-===== The Problem This Solves
-
-Before CTAP 2.3, when a user entered a PIN that violated a complexity policy, the authenticator returned a generic rejection error. Platforms had no standard way to:
-
-. Distinguish "PIN too short" from "PIN not complex enough"
-. Tell users what the complexity rules are or where to read them
-. Provide actionable guidance beyond a generic error message
-
-This was particularly notable with devices that have firmware-enforced PIN complexity via certification (Common Criteria, FIPS 140-3). A YubiKey 5 FIPS or Enhanced PIN device would reject a non-compliant PIN with a generic error; the user had no indication that complexity—rather than length—was the issue.
-
-===== What CTAP 2.3 Adds
-
-When `pinComplexityPolicyURL` is present in `authenticatorGetInfo`, platforms should:
-
-* Query `pinComplexityPolicy` on every session to detect whether complexity is active.
-* If `pinComplexityPolicy` is `true` and a PIN is rejected, display a message that specifically identifies the complexity failure (distinct from length failures).
-* If `pinComplexityPolicyURL` is present, offer a link so users can read the applicable rules.
-
-===== Relationship to `minPINLength`
-
-`pinComplexityPolicy` and `setMinPINLength` are complementary and may both be active on the same device. CTAP 2.3 clarifies the precedence of these two checks in the authenticator's PIN validation logic, ensuring consistent rejection behavior across authenticators.
-
-===== YubiKey-Specific Context
-
-PIN complexity behavior varies by YubiKey variant and firmware:
-
-[cols="2,1,2", options="header"]
-|===
-| YubiKey Variant | PIN Complexity Default | Notes
-
-| YubiKey 5 Series (standard)
-| Off (requires configuration)
-| Can be enabled via custom pre-registration configuration
-
-| YubiKey 5 FIPS Series
-| On
-| Required by FIPS 140-3 / Common Criteria certification
-
-| YubiKey 5 Enhanced PIN Series
-| On
-| Always on; cannot be permanently disabled
-
-| Security Key Series
-| Off (enterprise variants: configurable)
-| —
-
-|===
-
-YubiKey's PIN complexity policy blocks trivial and commonly-used values: sequential patterns, repeated digits, dictionary words, and values on a device-specific blocklist. This follows the NIST SP 800-63B recommendation to check PINs against commonly-used values, rather than requiring specific character types (which NIST SP 800-63B explicitly discourages).
+With CTAP 2.2, an authenticator that requires a long touch sets `longTouchForReset: true` in `authenticatorGetInfo`. CTAP 2.3 updates the required hold duration from 10 seconds to 5 seconds. Platforms should check this field before presenting reset instructions and adjust the UI accordingly.
 
 ==== smart-card Interface
 
 Spec:: `smart-card` is added to the list of valid FIDO Interface values in `authenticatorGetInfo`.
-Use Case:: Authenticators accessed via ISO 7816 contact smart-card readers in enterprise deployments.
-Yubico Support:: Applicable to YubiKey deployments in contact smart-card reader environments.
+Use Case:: Authenticators with an ISO 7816 contact smart-card form factor in enterprise deployments.
+Yubico Support:: Applicable to Yubico authenticators accessed via the ISO 7816 contact interface.
 
-Prior to CTAP 2.3, the recognized transport/interface values were `usb`, `nfc`, `ble`, and `internal`. Smart-card (ISO 7816 contact) interfaces lacked a dedicated value, which caused ambiguity in enterprise environments where YubiKeys are inserted into smart-card readers rather than USB ports.
+Prior to CTAP 2.3, the recognized transport/interface values were `usb`, `nfc`, `ble`, and `internal`. Authenticators with an ISO 7816 contact smart-card form factor had no dedicated value to advertise that interface.
 
-Adding `smart-card` enables credential management systems and relying parties to accurately identify the physical interface in use and apply interface-specific policies—for example, requiring contact-based authentication for high-assurance operations.
+Adding `smart-card` allows such authenticators to correctly report their interface type in `authenticatorGetInfo`.
 
 ==== FIDO Applet Explicit Selection
 
@@ -216,7 +156,7 @@ Because CTAP 2.3 introduced no breaking changes, platforms should use field-leve
 | PIN Complexity is active
 | `pinComplexityPolicy: true`
 
-| PIN Complexity policy URL available
+| PIN Complexity policy URL available (CTAP 2.2+)
 | `pinComplexityPolicyURL` present and non-empty
 
 | Long Touch for Reset required

--- a/content/CTAP/CTAP2.3.adoc
+++ b/content/CTAP/CTAP2.3.adoc
@@ -192,8 +192,8 @@ Because CTAP 2.3 introduced no breaking changes, platforms should use field-leve
 | CTAP 2.3 feature coverage follows FIDO Alliance spec additions. Check link:https://github.com/Yubico/python-fido2[python-fido2 release notes] for specific feature availability.
 
 | libfido2 / fido2-token
-| ⚠️ Partial
-| C library and command-line tools. Check link:https://github.com/Yubico/libfido2[libfido2 release notes] for current coverage.
+| ✅ Full Support (v1.17.0+)
+| v1.17.0+ supports most CTAP 2.3 features listed above. Check the link:https://github.com/Yubico/libfido2[libfido2 release notes] for specific feature coverage.
 
 | yubikit-swift
 | ⚠️ In development

--- a/content/CTAP/index.adoc
+++ b/content/CTAP/index.adoc
@@ -25,9 +25,9 @@ image::fido2_building_blocks.png[FIDO2 Architecture showing WebAuthn API and CTA
 
 NOTE: Web developers will typically never need to use CTAP directly. Instead, they will use the WebAuthn API that is supported by all major browsers. See our link:/WebAuthn/[WebAuthn] and link:/Passkeys/[Passkeys] for guidance on implementing FIDO authentication for web applications.
 
-==== What's New: CTAP 2.2
+==== What's New: CTAP 2.3 and CTAP 2.2
 
-The latest version of the protocol, CTAP 2.2, introduces significant enhancements for usability, enterprise security, and interoperability. These features address key developer and user challenges in the evolving passwordless ecosystem.
+CTAP 2.3 (published February 2026) is the current version of the protocol and the basis for all FIDO2 certifications. It is backwards-compatible with CTAP 2.2—no breaking changes were introduced. The features below span both versions.
 
 [cols="1,1,1", options="header"]
 |===
@@ -45,13 +45,17 @@ The latest version of the protocol, CTAP 2.2, introduces significant enhancement
 
 To help you build your application, we have created detailed guides for each major version of the CTAP specification.
 
+* *link:CTAP2.3.adoc[CTAP 2.3]*
++
+Covers the refinements introduced in CTAP 2.3: BLE hybrid transport channel, `pinComplexityPolicyURL` for improved PIN rejection UX, long touch for reset, and protocol clarifications. All FIDO2 certifications are now issued against CTAP 2.3.
+
 * *link:CTAP2.2.adoc[CTAP 2.2]*
 +
-Our comprehensive guide to the latest standard. Explains new features in plain language, compares them to previous versions, and shows where Yubico's SDKs and tools support them today.
+Comprehensive guide to CTAP 2.2 features: Persistent PIN/UV Auth Tokens (PPUAT), PIN complexity policies, `thirdPartyPayment`, `hmac-secret-mc`, hybrid transport, and richer authenticator metadata. Includes SDK support status across Yubico's developer tools.
 
 * *link:CTAP2.1.adoc[CTAP 2.1]*
 +
-A technical reference for the features and extensions introduced in CTAP 2.1, including enterprise attestation, credential management, and more.
+Technical reference for CTAP 2.1 features and extensions, including enterprise attestation, credential management, `alwaysUv`, minimum PIN length, and HMAC secret. Includes command-line examples using `fido2-token`.
 
 ==== CTAP Versions Explained
 


### PR DESCRIPTION
   CTAP2.2.adoc: fix PPUAT description, PIN complexity enforcement claims,
   hmac-secret-mc PRF eval field, JSON messaging description, field name
   casing (maxPINLength, minPINLength, pinComplexityPolicyURL); add
   attestationFormatsPreference, certification note, last-updated banner

   CTAP2.3.adoc: new page covering all CTAP 2.3 spec