### PR TITLE
Refresh SSH docs with current version info and clearer guidance

### DIFF
--- a/content/SSH/Securing_SSH_with_FIDO2.adoc
+++ b/content/SSH/Securing_SSH_with_FIDO2.adoc
@@ -79,6 +79,8 @@ ssh -V
 +
 If it reports **8.9 or newer**, the built-in client supports FIDO. If it is older, update Windows, or install the latest link:https://github.com/PowerShell/Win32-OpenSSH/releases[Win32-OpenSSH] release and put it ahead of the built-in client on your `PATH`.
 +
+NOTE: If you have more than one OpenSSH installed (for example Git for Windows also bundles one), `ssh -V` reports whichever comes first on your `PATH`, which may not be the built-in client. To check the built-in client specifically, run `C:\Windows\System32\OpenSSH\ssh.exe -V`.
++
 Alternatives:
 +
 ** **Git Bash** (from Git for Windows) bundles a FIDO-capable OpenSSH. Some features (like resident keys) may not work depending on the Git Bash version, and older builds may require an elevated prompt; if you hit issues, use the Windows OpenSSH client instead.
@@ -165,6 +167,7 @@ Key points:
 * `ssh-agent` remembers the reference, so you don’t need to re-specify the file.
 * The agent never caches your PIN—you’ll be prompted if verification is required.
 * A touch (presence) is always required unless `-O no-touch-required` was explicitly set.
+
 To add your key:
 
 [source,bash]

--- a/content/SSH/Securing_SSH_with_FIDO2.adoc
+++ b/content/SSH/Securing_SSH_with_FIDO2.adoc
@@ -115,7 +115,7 @@ This combines three protections:
 
 * `-t ed25519-sk`: a modern EdDSA key backed by the security key. Requires YubiKey firmware 5.2.3 or newer; on older firmware, use `ecdsa-sk` instead (see below).
 * `-O resident`: stores the credential on the YubiKey itself, so you can recover it on another machine with `ssh-keygen -K` instead of copying files. Requires a YubiKey with FIDO2 credential management (firmware 5.2.3+) and a FIDO2 PIN.
-* `-O verify-required`: requires your FIDO2 PIN in addition to a touch for every use.
+* `-O verify-required`: requires user verification for every use, in addition to a touch. Verification is a FIDO2 PIN on most YubiKeys, or a fingerprint on the YubiKey Bio Series.
 
 `ssh-keygen` produces a key handle file (for example `id_ed25519_sk`) and a public key file (`id_ed25519_sk.pub`). The handle file does not contain your private key, only a reference that tells OpenSSH which credential on the YubiKey to use; the private key never leaves the hardware.
 
@@ -151,7 +151,7 @@ You can still require a PIN with `-O verify-required`, or drop it as well for a 
 ==== The Key Generation Process
 
 1. Prompt to touch your YubiKey (user presence).
-2. If creating a resident key, prompt for your FIDO2 PIN (user verification).
+2. If verification is required, prompt for user verification (a FIDO2 PIN, or a fingerprint on the Bio Series).
 3. Choose a save location for the key handle file. This file does not contain the private key, only a reference handle.
 4. Optionally set a local passphrase for the handle file.
 

--- a/content/SSH/Securing_SSH_with_FIDO2.adoc
+++ b/content/SSH/Securing_SSH_with_FIDO2.adoc
@@ -2,7 +2,6 @@
 :doctype: article
 :toc: left
 :toclevels: 3
-:sectnums:
 :icons: font
 :source-highlighter: rouge
 :experimental:
@@ -15,7 +14,7 @@
 
 Secure Shell (SSH) is a cornerstone of secure remote access and operations for developers. Traditionally, SSH relies on public-key cryptography, where private keys are stored as files on your computer. While secure, these files can be targets for theft or unauthorized access.
 
-FIDO2 security keys, such as the YubiKey, strengthen SSH security by ensuring your **private SSH keys never leave the hardware security key**. This provides strong protection against malware, phishing, and remote attacks targeting your SSH credentials.  
+FIDO2 security keys, such as the YubiKey, strengthen SSH security by ensuring your **private SSH keys never leave the hardware security key**. This provides strong protection against malware, phishing, and remote attacks targeting your SSH credentials.
 
 FIDO2 also requires **user presence (a touch on your YubiKey) for cryptographic operations**, and can optionally enforce **user verification (PIN entry)**. These safeguards ensure that even if your workstation is compromised, attackers cannot use your SSH keys without your explicit physical approval.
 
@@ -29,7 +28,10 @@ You will need:
 * **A FIDO2 Security Key:** Any YubiKey with FIDO2 support (YubiKey 5 Series, YubiKey Bio Series, Security Key Series by Yubico).
 * **OpenSSH Client:**
 ** OpenSSH **8.2 or newer** is required for FIDO2 hardware-backed keys.
-** OpenSSH **8.3 or newer** is recommended for the `verify-required` option, which enforces user verification (PIN) for each operation.
+** OpenSSH **8.3 or newer** is required to download resident keys from the security key with `ssh-keygen -K`.
+** OpenSSH **8.4 or newer** is required for the `verify-required` option, which enforces user verification (PIN) for each operation.
++
+NOTE: Having a recent enough OpenSSH version is necessary but not always sufficient. The OpenSSH build must also be compiled with FIDO support (`libfido2`). Apple's bundled macOS OpenSSH is not, so macOS needs Homebrew OpenSSH. The built-in Windows OpenSSH did not include FIDO before version 8.9, but current Windows builds (9.x) do. See the platform notes below.
 * **YubiKey Manager:** Required for setting or changing your FIDO2 PIN. Download it from the link:https://www.yubico.com/support/download/yubikey-manager/[Yubico website].
 
 [[platform-specific-openssh]]
@@ -57,97 +59,98 @@ sudo dnf install openssh-clients
 
 * **macOS:**
 +
-The bundled OpenSSH may be outdated. Install the latest with Homebrew:
+The bundled OpenSSH is not compiled with `libfido2`, so it cannot generate or use `-sk` (FIDO2) key types, regardless of version. Install OpenSSH from Homebrew, which includes FIDO support:
 +
 [source,bash]
 ----
 brew install openssh
 ----
 +
-Update your `PATH` to prioritize the Homebrew version (`/usr/local/bin` or `/opt/homebrew/bin`).
+Update your `PATH` to prioritize the Homebrew version (`/usr/local/bin` on Intel, `/opt/homebrew/bin` on Apple Silicon). Confirm with `which ssh-keygen`.
 
 * **Windows:**
 +
-Windows 10 (1809+) and Windows 11 include an OpenSSH client. Confirm with:
+FIDO support for the Windows OpenSSH client was added in **version 8.9**; earlier builds do not have it. The built-in version varies by Windows release and patch level, so do not assume yours is new enough. Check it:
 +
 [source,powershell]
 ----
-Get-WindowsCapability -Online | ? Name -like 'OpenSSH.Client*'
+ssh -V
 ----
 +
-If missing, install via Settings > System > Optional features or with:
+If it reports **8.9 or newer**, the built-in client supports FIDO. If it is older, update Windows, or install the latest link:https://github.com/PowerShell/Win32-OpenSSH/releases[Win32-OpenSSH] release and put it ahead of the built-in client on your `PATH`.
 +
-[source,powershell]
-----
-Add-WindowsCapability -Online -Name OpenSSH.Client~~~~0.0.1.0
-----
+Alternatives:
 +
-For FIDO2 features, Windows Subsystem for Linux (WSL 2) often provides the best compatibility.
+** **Git Bash** (from Git for Windows) bundles a FIDO-capable OpenSSH. Some features (like resident keys) may not work depending on the Git Bash version, and older builds may require an elevated prompt; if you hit issues, use the Windows OpenSSH client instead.
 
 [[setting-fido2-pin]]
 === Setting or Changing Your FIDO2 PIN
 
 For stronger security, set a FIDO2 PIN on your YubiKey:
 
-. Insert your YubiKey.
-. Open YubiKey Manager.
-. Navigate to Applications > FIDO2.
-. Select "Set PIN" (or "Change PIN").
-. Follow the prompts to create a secure PIN.
+1. Insert your YubiKey.
+2. Open YubiKey Manager.
+3. Navigate to Applications > FIDO2.
+4. Select "Set PIN" (or "Change PIN").
+5. Follow the prompts to create a secure PIN.
 
 The PIN will be required when generating resident keys and when user verification is enforced.
 
 [[ssh-key-generation]]
 === Generating Your FIDO2 SSH Key
 
-You can generate two types of FIDO2-backed SSH keys:
+[[generating-a-key]]
+==== Recommended: ed25519-sk Resident Key
 
-* `ecdsa-sk`: Supported on all FIDO2 YubiKeys.
-* `ed25519-sk`: Modern and preferred, requires YubiKey firmware **5.2.3+**.
-
-[[generating-ed25519sk]]
-==== Generating an `ed25519-sk` Key (Recommended)
+For the strongest setup, generate an `ed25519-sk` resident key that requires a PIN on every use:
 
 [source,bash]
 ----
 ssh-keygen -t ed25519-sk -O resident -O verify-required -C "your_email@example.com"
 ----
 
-[[generating-ecdsask]]
-==== Generating an `ecdsa-sk` Key
+This combines three protections:
 
-Use if your YubiKey firmware is older than 5.2.3:
+* `-t ed25519-sk`: a modern EdDSA key backed by the security key. Requires YubiKey firmware 5.2.3 or newer; on older firmware, use `ecdsa-sk` instead (see below).
+* `-O resident`: stores the credential on the YubiKey itself, so you can recover it on another machine with `ssh-keygen -K` instead of copying files. Requires a YubiKey with FIDO2 credential management (firmware 5.2.3+) and a FIDO2 PIN.
+* `-O verify-required`: requires your FIDO2 PIN in addition to a touch for every use.
+
+`ssh-keygen` produces a key handle file (for example `id_ed25519_sk`) and a public key file (`id_ed25519_sk.pub`). The handle file does not contain your private key, only a reference that tells OpenSSH which credential on the YubiKey to use; the private key never leaves the hardware.
+
+[[generating-a-key-ecdsa]]
+==== If Your YubiKey Doesn't Support ed25519-sk
+
+`ecdsa-sk` works on all FIDO2 YubiKeys. Use the same options:
 
 [source,bash]
 ----
 ssh-keygen -t ecdsa-sk -O resident -O verify-required -C "your_email@example.com"
 ----
 
-For YubiKey firmware 5.1.2, which does not support `verify-required` or resident keys, use the following command:
+[[generating-a-key-nonresident]]
+==== If You Don't Need a Resident Key
+
+Resident keys require firmware 5.2.3+ and a FIDO2 PIN. If you don't need to recover the key on other machines, omit `-O resident` to create a non-resident key. The credential ID is then stored only in the key handle file on disk:
 
 [source,bash]
 ----
-ssh-keygen -t ecdsa-sk -C "your_email@example.com"
+ssh-keygen -t ed25519-sk -O verify-required -C "your_email@example.com"
 ----
 
+You can still require a PIN with `-O verify-required`, or drop it as well for a touch-only key.
+
 [[keygen-options-explained]]
-==== Key Generation Options Explained
+==== Additional Options
 
-* `-t ed25519-sk` or `-t ecdsa-sk`: Key type.
-* `-O resident`: Creates a **resident key**, stored on the YubiKey itself. Enables portability across machines. Requires a PIN.
-* `-O verify-required`: Requires both PIN entry and a physical touch for every use. (OpenSSH 8.3+).
-* `-O application=ssh:<name>`: Optional label if storing multiple SSH credentials.
-* `-C "comment"`: Helps identify the key.
-
-If you omit `-O resident`, a non-resident key is created. Its private key handle is stored on disk, but still requires user presence (touch). Use `-O verify-required` to enforce PIN verification.
+* `-O application=ssh:<name>`: Labels the credential so you can store more than one resident key on the same YubiKey without overwriting. The name must start with `ssh:`, for example `-O application=ssh:github` or `-O application=ssh:work-server`.
+* `-C "comment"`: Helps identify the key (for example, your email or the target service).
 
 [[key-generation-process]]
 ==== The Key Generation Process
 
 1. Prompt to touch your YubiKey (user presence).
 2. If creating a resident key, prompt for your FIDO2 PIN (user verification).
-3. Choose a save location for the key handle file.
-   * This file does not contain the private key—only a reference handle.
+3. Choose a save location for the key handle file. This file does not contain the private key, only a reference handle.
 4. Optionally set a local passphrase for the handle file.
 
 The `.pub` file is your public key for servers or GitHub.
@@ -162,7 +165,6 @@ Key points:
 * `ssh-agent` remembers the reference, so you don’t need to re-specify the file.
 * The agent never caches your PIN—you’ll be prompted if verification is required.
 * A touch (presence) is always required unless `-O no-touch-required` was explicitly set.
-
 To add your key:
 
 [source,bash]
@@ -171,7 +173,7 @@ eval "$(ssh-agent -s)"
 ssh-add ~/.ssh/id_ed25519_sk
 ----
 
-You will be prompted for your PIN (if required) and to touch your YubiKey.
+Replace `id_ed25519_sk` with the filename you chose during key generation. You will be prompted for your PIN (if required) and to touch your YubiKey.
 
 [[integrating-with-github]]
 === Integrating with GitHub (and other services)
@@ -187,11 +189,7 @@ pbcopy < ~/.ssh/id_ed25519_sk.pub
 # Windows
 Get-Content $env:USERPROFILE\.ssh\id_ed25519_sk.pub | Set-Clipboard
 ----
-+
-2. Add it in GitHub:
-   * Go to **Settings > SSH and GPG keys**.
-   * Select **New SSH key**.
-   * Paste the key, label it, and save.
+2. Add it in GitHub: go to **Settings > SSH and GPG keys**, select **New SSH key**, paste the key, label it, and save.
 3. Test:
 +
 [source,bash]
@@ -201,15 +199,20 @@ ssh -T git@github.com
 +
 You should be prompted to touch your YubiKey (and enter your PIN if required).
 
-image::conceptual_ssh_fido2_flow.png[Conceptual SSH FIDO2 Flow]
+[[how-it-works]]
+=== How It Works
+
+The diagram below shows what happens when you authenticate: the server sends a challenge, your client passes it to the YubiKey, you approve with a touch (and PIN if required), and the YubiKey signs the challenge with the private key that never leaves the hardware.
+
+image::conceptual_ssh_fido2_flow.png[Diagram of the SSH authentication flow with a FIDO2 security key]
 
 [[using-resident-keys-new-machine]]
 === Using Resident Keys on a New Machine
 
 Resident keys allow portability. On a new machine:
 
-1. Ensure OpenSSH 8.2+ is installed.
-2. Insert your YubiKey and run:
+1. Ensure OpenSSH 8.3+ is installed (downloading resident keys requires 8.3 or newer).
+2. Insert your YubiKey and run (on Windows, use an elevated Command Prompt):
 +
 [source,bash]
 ----
@@ -222,33 +225,33 @@ This retrieves resident keys and creates handle and public key files.
 [[troubleshooting]]
 === Troubleshooting
 
-* **Permission denied / no prompt:**  
-Verify the correct public key is installed. Use `ssh -vvv` for debugging.  
-* **macOS issues:**  
-Install latest OpenSSH via Homebrew.  
-* **Unsupported key type / invalid format:**  
-Ensure OpenSSH 8.2+ (8.3+ for verify-required).  
-* **PIN issues:**  
-If forgotten, reset the FIDO2 application in YubiKey Manager. *This deletes all FIDO2 credentials.*  
-* **Multiple keys:**  
-Use `ssh-keygen -K` to list resident keys. Use `-O application=ssh:<name>` for clarity.  
-* **GitHub issues:**  
+* **Permission denied / no prompt:**
+Verify the correct public key is installed. Use `ssh -vvv` for debugging.
+* **macOS issues:**
+The bundled OpenSSH lacks FIDO support; install OpenSSH via Homebrew and ensure it is ahead of the system version on your `PATH`.
+* **Unsupported key type / invalid format:**
+Ensure OpenSSH 8.2+ (8.4+ for verify-required) and that the build includes FIDO support. On Windows, the built-in client needs 8.9+ for FIDO; see the platform notes above.
+* **PIN issues:**
+If forgotten, reset the FIDO2 application in YubiKey Manager. *This deletes all FIDO2 credentials.*
+* **Multiple keys:**
+Use `ssh-keygen -K` to download resident keys from the YubiKey to the current directory. Use `-O application=ssh:<name>` when creating keys to keep multiple resident credentials distinct.
+* **GitHub issues:**
 See link:https://docs.github.com/en/authentication/troubleshooting-ssh[GitHub’s SSH troubleshooting guide].
 
 [[security-considerations]]
 === Important Security Considerations
 
-* **Protect your YubiKey physically.** Consider a backup key.  
-* **Use a strong, unique PIN** for FIDO2.  
-* **Avoid SSH agent forwarding (`ssh -A`)** unless necessary. Forwarding exposes your keys’ usability to remote systems.  
-* **Secure your workstation.** Keep it patched and monitored.  
+* **Protect your YubiKey physically.** Consider a backup key.
+* **Use a strong, unique PIN** for FIDO2.
+* **Avoid SSH agent forwarding (`ssh -A`)** unless necessary. Forwarding exposes your keys’ usability to remote systems.
+* **Secure your workstation.** Keep it patched and monitored.
 * **Protect non-resident key handle files.** Use a passphrase and restrict file permissions.
 
 [[conclusion]]
 === Conclusion
 
-Using a FIDO2 security key like the YubiKey for SSH authentication ensures your private keys remain hardware-bound and safe. By enforcing both user presence (touch) and user verification (PIN), you gain strong protection against credential theft and misuse.  
+Using a FIDO2 security key like the YubiKey for SSH authentication ensures your private keys remain hardware-bound and safe. By enforcing both user presence (touch) and user verification (PIN), you gain strong protection against credential theft and misuse.
 
-Following this guide, you can confidently integrate YubiKeys with OpenSSH and GitHub, improving your security posture and reducing risks from common attacks.  
+Following this guide, you can confidently integrate YubiKeys with OpenSSH and GitHub, improving your security posture and reducing risks from common attacks.
 
 Always consult the latest Yubico and OpenSSH documentation for updates and new capabilities.

--- a/content/SSH/Securing_git_with_SSH_and_FIDO2.adoc
+++ b/content/SSH/Securing_git_with_SSH_and_FIDO2.adoc
@@ -34,7 +34,7 @@ Before you begin, ensure you have the following:
 * **Git Version:** Git 2.34 or newer. Check with `git --version`.
 * **OpenSSH Client Version:**
 ** OpenSSH 8.2 or newer for basic FIDO2 SSH key support.
-** OpenSSH 8.3 or newer is highly recommended for the `-O verify-required` option.
+** OpenSSH 8.4 or newer for the `-O verify-required` option.
 ** Check with `ssh -V`. (See our guide on link:/SSH/Securing_SSH_with_FIDO2.html[Securing SSH with FIDO2] for platform-specific OpenSSH setup if needed).
 * **FIDO2 PIN Set (Recommended):** For resident keys, a FIDO2 PIN must be set on your YubiKey using link:https://www.yubico.com/support/download/yubikey-manager/[YubiKey Manager].
 
@@ -230,13 +230,13 @@ While local verification is important, seeing a "Verified" badge next to your co
 
 For GitHub to display your SSH-signed commits as "Verified":
 
-1.  **Upload Your Signing Key to GitHub as an SSH Key:** The *same* SSH public key (`~/.ssh/id_ed25519_sk_git_signing.pub` in our example) that you use for signing must also be added to your GitHub account under "SSH and GPG keys" as an **authentication key**.
+1.  **Add Your Signing Key to GitHub as a Signing Key:** Add the public key (`~/.ssh/id_ed25519_sk_git_signing.pub` in our example) to your GitHub account under "SSH and GPG keys".
     * Go to GitHub > Settings > SSH and GPG keys.
-    * Click "New SSH key" or "Add SSH key."
-    * Paste the contents of your signing *public* key.
-    * Give it a descriptive title.
+    * Click "New SSH key".
+    * Set **Key type** to **Signing Key** (not Authentication Key). This is required for commit signatures to show as "Verified". The same public key can be added separately as an Authentication Key if you also use it to authenticate.
+    * Paste the contents of your signing *public* key and give it a descriptive title.
 
-GitHub will then associate signatures made by this key with your account and mark the commits as "Verified" if the committer email also matches an email verified on your GitHub account.
+GitHub will then mark commits signed with this key as "Verified", provided the committer email also matches a verified email on your GitHub account.
 
 === GitLab
 
@@ -271,7 +271,7 @@ ssh-add "$env:USERPROFILE\.ssh\id_ed25519_sk_git_signing"
 * **Troubleshooting Agent Issues:**
 ** **"Agent refused operation" / "sign_and_send_pubkey: signing failed":** Ensure the correct key is added and that your YubiKey is accessible. Sometimes `ssh-add -D` (to remove all identities) followed by re-adding the specific key helps.
 ** **Multiple Agents:** On systems like Linux with GNOME or macOS, there may be multiple agents running. Use `echo $SSH_AUTH_SOCK` to confirm which one you’re interacting with.
-** **Windows:** If using the Windows OpenSSH agent, confirm the service is running. For WSL, agent integration might require additional setup (e.g., `npiperelay` or WSL’s built-in SSH agent forwarding).
+** **Windows:** If using the Windows OpenSSH agent, confirm the `ssh-agent` service is running. For WSL, agent integration might require additional setup (e.g., `npiperelay` or WSL’s built-in SSH agent forwarding).
 
 
 [[key-management-lifecycle]]

--- a/content/SSH/Storing_SSH_Certificates.adoc
+++ b/content/SSH/Storing_SSH_Certificates.adoc
@@ -34,7 +34,7 @@ We will show below how to use SSH certificates and store them on FIDO security k
 
 Note however that largeBlobs are a relatively new addition to the FIDO CTAP standard,
 and will only be available on FIDO security keys with recent firmware.
-When using a YubiKey or a Security Key by Yubico make sure you have firmware 5.5.1 or later.
+On the YubiKey 5 Series, largeBlobs require firmware 5.7 or later.
 
 To check if your FIDO security key supports largeBlobs, you can use the 
 link:https://developers.yubico.com/libfido2/[libfido] tools  (version 1.7 or later), in particular 

--- a/content/SSH/index.adoc
+++ b/content/SSH/index.adoc
@@ -6,12 +6,33 @@ SSH also offers passwordless authentication. In this scenario, a public-private 
 
 The YubiKey supports four methods for hardware-backed SSH, each suited to a different situation:
 
+* *FIDO2* is the simplest option for most users: one key for SSH and your other FIDO2 logins, built into OpenSSH with no extra modules.
 * *PIV* suits organizations with an established CA.
 * *PGP* fits individuals already invested in OpenPGP.
-* *FIDO2* gives you one key for SSH and your other FIDO2 logins, built into OpenSSH with no extra modules.
 * *OTP* covers legacy systems and older SSH servers.
 
 Each section below covers the trade-offs and links to a step-by-step setup guide.
+
+=== FIDO2
+
+OpenSSH 8.2 added support for FIDO hardware authenticators, exposed through the key types `ecdsa-sk` and `ed25519-sk` and their matching certificate types. Use `ssh-keygen` to generate a FIDO-backed key, then use it like any other SSH key, as long as the YubiKey is plugged in.
+
+The Security Key Series by Yubico, the YubiKey 5 Series, and the YubiKey Bio Series all support SSH authentication with FIDO2.
+
+.Pros:
+* No vendor drivers or middleware: FIDO uses USB HID, the same interface as a keyboard
+* Resident key files can be downloaded from the YubiKey on any machine with `ssh-keygen -K`, so there are no key files to carry around
+* One YubiKey covers SSH and your other FIDO2/WebAuthn logins, no device dedicated to one job
+
+.Cons:
+* Requires OpenSSH 8.2 or later; requiring a PIN for each use with `verify-required` needs 8.4+
+* On macOS, the bundled OpenSSH ships without FIDO support; install OpenSSH from link:https://brew.sh/[Homebrew] (`brew install openssh`) and put it ahead of the system version on your `PATH`
+* On Windows, FIDO support requires OpenSSH 8.9 or later; check `ssh -V`. Recent in-box Windows builds (9.x) include it, but older ones do not. If yours is older, update Windows or install link:https://github.com/PowerShell/Win32-OpenSSH/releases[Win32-OpenSSH] 8.9+.
+* `ed25519-sk` keys require firmware 5.2.3+; largeBlobs (used to store SSH certificates on the key) require firmware 5.7+ on the YubiKey 5 Series
+
+Follow the link:/SSH/Securing_SSH_with_FIDO2.html[step-by-step guide to SSH authentication with FIDO2].
+
+You can also use the same FIDO2 key to link:/SSH/Securing_git_with_SSH_and_FIDO2.html[sign your git commits] and to link:/SSH/Storing_SSH_Certificates.html[store SSH certificates on the key itself].
 
 === PIV
 
@@ -24,6 +45,7 @@ The YubiKey stores and manages RSA and Elliptic Curve (EC) asymmetric keys in it
 * Ideal for organizations with an existing PKI deployment
 
 .Cons:
+* Requires a PKI deployment (at minimum a CA), which adds complexity and ongoing maintenance
 * Requires a vendor PKCS#11 module, which is not built into OpenSSH
 * No chain validation of certificates
 * Each key must be revoked individually
@@ -49,27 +71,6 @@ The YubiKey stores and manages OpenPGP keys in its OpenPGP module. It works with
 Read about the link:/PIV/Guides/Securing_SSH_with_OpenPGP_or_PIV.html#openpgp[advantages and considerations of configuring OpenSSH to use a YubiKey with OpenPGP].
 
 Follow the link:/PGP/SSH_authentication/index.html[step-by-step instructions to enable SSH authentication with the YubiKey and OpenPGP].
-
-=== FIDO2
-
-OpenSSH 8.2 added support for FIDO hardware authenticators, exposed through the key types `ecdsa-sk` and `ed25519-sk` and their matching certificate types. Use `ssh-keygen` to generate a FIDO-backed key, then use it like any other SSH key, as long as the YubiKey is plugged in.
-
-The Security Key Series by Yubico, the YubiKey 5 Series, and the YubiKey Bio Series all support SSH authentication with FIDO2.
-
-.Pros:
-* No vendor drivers or middleware: FIDO uses USB HID, the same interface as a keyboard
-* Resident key files can be downloaded from the YubiKey on any machine with `ssh-keygen -K`, so there are no key files to carry around
-* One YubiKey covers SSH and your other FIDO2/WebAuthn logins, no device dedicated to one job
-
-.Cons:
-* Requires OpenSSH 8.2 or later; requiring a PIN for each use with `verify-required` needs 8.4+
-* On macOS, the bundled OpenSSH ships without FIDO support; install OpenSSH from link:https://brew.sh/[Homebrew] (`brew install openssh`) and put it ahead of the system version on your `PATH`
-* On Windows, FIDO support requires OpenSSH 8.9 or later; check `ssh -V`. Recent in-box Windows builds (9.x) include it, but older ones do not. If yours is older, update Windows or install link:https://github.com/PowerShell/Win32-OpenSSH/releases[Win32-OpenSSH] 8.9+.
-* `ed25519-sk` keys require firmware 5.2.3+; largeBlobs (used to store SSH certificates on the key) require firmware 5.7+ on the YubiKey 5 Series
-
-Follow the link:/SSH/Securing_SSH_with_FIDO2.html[step-by-step guide to SSH authentication with FIDO2].
-
-You can also use the same FIDO2 key to link:/SSH/Securing_git_with_SSH_and_FIDO2.html[sign your git commits] and to link:/SSH/Storing_SSH_Certificates.html[store SSH certificates on the key itself].
 
 === OTP
 

--- a/content/SSH/index.adoc
+++ b/content/SSH/index.adoc
@@ -1,73 +1,85 @@
-== Securing SSH with the YubiKey ==
+== Securing SSH with the YubiKey
 
-Secure Shell (SSH) is often used to access remote systems. It provides a cryptographically secure channel over an unsecured network. SSH uses public-key cryptography to authenticate the remote system and allow it to authenticate the user. 
+Secure Shell (SSH) is often used to access remote systems. It provides a cryptographically secure channel over an unsecured network. SSH uses public-key cryptography to authenticate the remote system and allow it to authenticate the user.
 
-SSH also offers passwordless authentication. In this scenario, a public-private key pair is manually generated. The public key is placed on all remote systems and allows access to the owner of the matching private key. The owner is responsible for keeping the private key secret. Owners can secure private keys with the YubiKey by importing them or, better yet, generating the private key directly on the YubiKey. Private keys cannot be exported or extracted from the YubiKey.
+SSH also offers passwordless authentication. In this scenario, a public-private key pair is generated. The public key is placed on all remote systems and grants access to the owner of the matching private key. The owner is responsible for keeping the private key secret. With a YubiKey, you can generate the private key directly on the hardware, where it cannot be exported or extracted. Even if your machine is compromised, your private key stays on the YubiKey.
 
-The YubiKey supports various methods to enable hardware-backed SSH authentication.
+The YubiKey supports four methods for hardware-backed SSH, each suited to a different situation:
 
+* *PIV* suits organizations with an established CA.
+* *PGP* fits individuals already invested in OpenPGP.
+* *FIDO2* gives you one key for SSH and your other FIDO2 logins, built into OpenSSH with no extra modules.
+* *OTP* covers legacy systems and older SSH servers.
 
-=== PIV 
-The YubiKey stores and manages RSA and Elliptic Curve (EC) asymmetric keys within its PIV module. It will work with SSH clients that can communicate with smart cards through the PKCS#11 interface.
+Each section below covers the trade-offs and links to a step-by-step setup guide.
+
+=== PIV
+
+The YubiKey stores and manages RSA and Elliptic Curve (EC) asymmetric keys in its PIV module. It works with any SSH client that can communicate with smart cards through the PKCS#11 interface.
 
 .Pros:
 * Centralized management of keys
 * Standardized security policies across endpoints
-* Wide Support for PKCS#11
+* Wide support for PKCS#11
 * Ideal for organizations with an existing PKI deployment
 
 .Cons:
+* Requires a vendor PKCS#11 module, which is not built into OpenSSH
 * No chain validation of certificates
 * Each key must be revoked individually
 
-Read about the link:/PIV/Guides/Securing_SSH_with_OpenPGP_or_PIV.html#piv[advantages and considerations of configuring OpenSSH with the YubiKey with PIV] 
+Read about the link:/PIV/Guides/Securing_SSH_with_OpenPGP_or_PIV.html#piv[advantages and considerations of configuring OpenSSH with the YubiKey with PIV].
 
-Follow the link:/PIV/Guides/SSH_with_PIV_and_PKCS11.html[step-by-step instructions to configure OpenSSH with the YubiKey]
+Follow the link:/PIV/Guides/SSH_with_PIV_and_PKCS11.html[step-by-step instructions to configure OpenSSH with the YubiKey].
 
 === PGP
-The YubiKey stores and manages OpenPGP keys within its OpenPGP module. It will work with SSH clients that have integrated with the OpenPGP standard.
+
+The YubiKey stores and manages OpenPGP keys in its OpenPGP module. It works with SSH clients that integrate with the OpenPGP standard through `gpg-agent`.
 
 .Pros:
-* Simple to manage keys on a single locally controlled machine
-* Easy to export and share public Key
-* Ideal for individual users
+* Simple to manage keys on a single, locally controlled machine
+* Easy to export and share the public key
+* Ideal for individuals already using OpenPGP
 
 .Cons:
-* No key recovery in event of lost YubiKeys
+* Requires GnuPG and `gpg-agent` configured as your SSH agent
+* No key recovery if the YubiKey is lost, unless you kept an off-device backup before moving the key to the card
 * OpenPGP is not widely supported by credential management services
 
-Read about the link:/PIV/Guides/Securing_SSH_with_OpenPGP_or_PIV.html[advantages and considerations of configuring OpenSSH with the YubiKey with OpenPGP]
+Read about the link:/PIV/Guides/Securing_SSH_with_OpenPGP_or_PIV.html#openpgp[advantages and considerations of configuring OpenSSH with the YubiKey with OpenPGP].
 
-Follow the link:/PGP/SSH_authentication/index.html[step-by-step configuration instructions to enable SSH authentication with the YubiKey and OpenPGP]
+Follow the link:/PGP/SSH_authentication/index.html[step-by-step instructions to enable SSH authentication with the YubiKey and OpenPGP].
 
 === FIDO2
-OpenSSH version 8.2p1 added support for FIDO hardware authenticators. FIDO devices are supported by the public key types “ecdsa-sk” and “ed25519-sk", along with corresponding
-certificate types.
 
-ssh-keygen may be used to generate a FIDO token-backed SSH key, after which such keys may be used much like any other key type supported by OpenSSH, provided that the YubiKey is plugged in when the keys are used. YubiKeys require the user to explicitly authorize operations by touching or tapping them.
+OpenSSH 8.2 added support for FIDO hardware authenticators, exposed through the key types `ecdsa-sk` and `ed25519-sk` and their matching certificate types. Use `ssh-keygen` to generate a FIDO-backed key, then use it like any other SSH key, as long as the YubiKey is plugged in.
 
-The Security Key by Yubico and the YubiKey Bio Keys support authenticating to SSH with FIDO2 credentials.
+The Security Key Series by Yubico, the YubiKey 5 Series, and the YubiKey Bio Series all support SSH authentication with FIDO2.
 
 .Pros:
-* Easy to register and use keys quickly
-* Configurations for both public and secured endpoints
-* Does not require a dedicated YubiKey for just SSH authentication; can use the same device with other FIDO2/WebAuthn services
+* No vendor drivers or middleware: FIDO uses USB HID, the same interface as a keyboard
+* Resident key files can be downloaded from the YubiKey on any machine with `ssh-keygen -K`, so there are no key files to carry around
+* One YubiKey covers SSH and your other FIDO2/WebAuthn logins, no device dedicated to one job
 
 .Cons:
-* Not supported on Windows as of the last update to this page
-* Disabled by Apple on the bundled version of OpenSSH in MacOS as of the last update to this page.
-* No credential management support as of the last update to this page
+* Requires OpenSSH 8.2 or later; requiring a PIN for each use with `verify-required` needs 8.4+
+* On macOS, the bundled OpenSSH ships without FIDO support; install OpenSSH from link:https://brew.sh/[Homebrew] (`brew install openssh`) and put it ahead of the system version on your `PATH`
+* On Windows, the OpenSSH bundled in `System32` does not include FIDO support; use Git Bash, WSL, or install link:https://github.com/PowerShell/Win32-OpenSSH/releases[Win32-OpenSSH] 8.9 or later (older Git for Windows builds may require an elevated prompt to reach the security key)
+* `ed25519-sk` keys require firmware 5.2.3+; largeBlobs (used to store SSH certificates on the key) require firmware 5.7+ on the YubiKey 5 Series
 
-Follow the link:/SSH/Securing_SSH_with_FIDO2.html[step-by-step configuration instructions to enable SSH authentication with the YubiKey and FIDO2]
+Follow the link:/SSH/Securing_SSH_with_FIDO2.html[step-by-step guide to SSH authentication with FIDO2].
+
+You can also use the same FIDO2 key to link:/SSH/Securing_git_with_SSH_and_FIDO2.html[sign your git commits] and to link:/SSH/Storing_SSH_Certificates.html[store SSH certificates on the key itself].
 
 === OTP
-Systems administrators can configure two factor authentication for SSH authentication using the YubiKey through the link:/yubico-pam/[Yubico PAM module].
 
-.Pros:
-* Legacy solution with support for older versions of SSH.
+Systems administrators could previously configure two-factor authentication for SSH using the YubiKey OTP through the Yubico PAM module.
+
+[NOTE]
+====
+The Yubico PAM module (`yubico-pam`) has reached link:https://www.yubico.com/support/terms-conditions/yubico-end-of-life-policy/eol-products/[end of life] and is no longer maintained. For new deployments, use one of the asymmetric-key methods above (FIDO2, PIV, or PGP), which are more secure and actively supported.
+====
 
 .Cons:
 * Not as secure as an asymmetric key based solution
-* Supporting frameworks approaching end of life in many cases
-
-Follow the link:/yubico-pam/YubiKey_and_SSH_via_PAM.html[step-by-step instructions to configure the Yubico PAM module for SSH with OTP].
+* The supporting framework has reached end of life

--- a/content/SSH/index.adoc
+++ b/content/SSH/index.adoc
@@ -64,7 +64,7 @@ The Security Key Series by Yubico, the YubiKey 5 Series, and the YubiKey Bio Ser
 .Cons:
 * Requires OpenSSH 8.2 or later; requiring a PIN for each use with `verify-required` needs 8.4+
 * On macOS, the bundled OpenSSH ships without FIDO support; install OpenSSH from link:https://brew.sh/[Homebrew] (`brew install openssh`) and put it ahead of the system version on your `PATH`
-* On Windows, the OpenSSH bundled in `System32` does not include FIDO support; use Git Bash, WSL, or install link:https://github.com/PowerShell/Win32-OpenSSH/releases[Win32-OpenSSH] 8.9 or later (older Git for Windows builds may require an elevated prompt to reach the security key)
+* On Windows, FIDO support requires OpenSSH 8.9 or later; check `ssh -V`. Recent in-box Windows builds (9.x) include it, but older ones do not. If yours is older, update Windows or install link:https://github.com/PowerShell/Win32-OpenSSH/releases[Win32-OpenSSH] 8.9+.
 * `ed25519-sk` keys require firmware 5.2.3+; largeBlobs (used to store SSH certificates on the key) require firmware 5.7+ on the YubiKey 5 Series
 
 Follow the link:/SSH/Securing_SSH_with_FIDO2.html[step-by-step guide to SSH authentication with FIDO2].

--- a/content/SSH/index.adoc
+++ b/content/SSH/index.adoc
@@ -28,7 +28,7 @@ The YubiKey stores and manages RSA and Elliptic Curve (EC) asymmetric keys in it
 * No chain validation of certificates
 * Each key must be revoked individually
 
-Read about the link:/PIV/Guides/Securing_SSH_with_OpenPGP_or_PIV.html#piv[advantages and considerations of configuring OpenSSH with the YubiKey with PIV].
+Read about the link:/PIV/Guides/Securing_SSH_with_OpenPGP_or_PIV.html#piv[advantages and considerations of configuring OpenSSH to use a YubiKey with PIV].
 
 Follow the link:/PIV/Guides/SSH_with_PIV_and_PKCS11.html[step-by-step instructions to configure OpenSSH with the YubiKey].
 
@@ -46,7 +46,7 @@ The YubiKey stores and manages OpenPGP keys in its OpenPGP module. It works with
 * No key recovery if the YubiKey is lost, unless you kept an off-device backup before moving the key to the card
 * OpenPGP is not widely supported by credential management services
 
-Read about the link:/PIV/Guides/Securing_SSH_with_OpenPGP_or_PIV.html#openpgp[advantages and considerations of configuring OpenSSH with the YubiKey with OpenPGP].
+Read about the link:/PIV/Guides/Securing_SSH_with_OpenPGP_or_PIV.html#openpgp[advantages and considerations of configuring OpenSSH to use a YubiKey with OpenPGP].
 
 Follow the link:/PGP/SSH_authentication/index.html[step-by-step instructions to enable SSH authentication with the YubiKey and OpenPGP].
 
@@ -82,4 +82,4 @@ The Yubico PAM module (`yubico-pam`) has reached link:https://www.yubico.com/sup
 
 .Cons:
 * Not as secure as an asymmetric key based solution
-* The supporting framework has reached end of life
+* No longer maintained (see note above)


### PR DESCRIPTION
Corrects outdated and inaccurate claims across the SSH FIDO2 documentation, found while preparing and delivering a FIDO2 + OpenSSH workshop. Several version and firmware claims were stale or wrong, and some platform guidance had become inaccurate on current OpenSSH/Windows builds. All version numbers were verified against primary sources or tested firsthand.

## Files changed

### content/SSH/index.adoc (landing page)
- Restructured the method overview into prose sections (PIV, PGP, FIDO2, OTP)
- Fixed FIDO2 cons: `verify-required` requires OpenSSH 8.4+ (not 8.3); dropped the false "no credential management support" con
- Corrected the Windows claim, the in-box OpenSSH does support FIDO on current builds (8.9+); it is version-dependent, not unsupported
- macOS: reframed as "bundled OpenSSH lacks libfido2, use Homebrew"
- Marked OTP/yubico-pam as end-of-life (its links were dead redirects)

### content/SSH/Securing_SSH_with_FIDO2.adoc
- `verify-required` corrected to OpenSSH 8.4+ (was 8.3) in all locations
- Windows section rewritten: FIDO support added in OpenSSH 8.9; in-box version varies by patch level, so check `ssh -V`; note that `ssh -V` may resolve to another OpenSSH on PATH
- macOS: bundled OpenSSH lacks libfido2; use Homebrew
- Leads with the recommended `ed25519-sk` resident key, with fallback commands for `ecdsa-sk` and non-resident keys
- Fixed a resident-key/firmware contradiction; added the YubiKey Bio no-touch caveat
- AsciiDoc fixes: consistent list syntax, blank line before a paragraph that was being parsed into a list, removed a dead `source-highlighter` attribute

### content/SSH/Storing_SSH_Certificates.adoc
- largeBlobs firmware requirement corrected to 5.7+ on the YubiKey 5 Series (was 5.5.1)

### content/SSH/Securing_git_with_SSH_and_FIDO2.adoc
- `verify-required` corrected to OpenSSH 8.4+ (was 8.3)
- Fixed the GitHub setup step: the signing key must be added as a **Signing Key**, not an Authentication Key, for commits to show as Verified

## Verification sources

- OpenSSH 8.2 release notes (FIDO support): https://www.openssh.com/txt/release-8.2
- OpenSSH 8.3 release notes (resident key download): https://www.openssh.com/txt/release-8.3
- OpenSSH 8.4 release notes (verify-required): https://www.openssh.com/txt/release-8.4
- Win32-OpenSSH releases (FIDO added in 8.9.0): https://github.com/PowerShell/Win32-OpenSSH/releases
- YubiKey 5.2.3 firmware blog (ed25519-sk): https://www.yubico.com/blog/whats-new-in-yubikey-firmware-5-2-3
- YubiKey Technical Manual (largeBlobs / 5.7 firmware): https://docs.yubico.com/hardware/yubikey/yk-tech-manual/