### PR TITLE
Fix broken NOTE icons in SSH FIDO2 guides

### DIFF
--- a/content/SSH/Securing_SSH_with_FIDO2.adoc
+++ b/content/SSH/Securing_SSH_with_FIDO2.adoc
@@ -2,7 +2,6 @@
 :doctype: article
 :toc: left
 :toclevels: 3
-:icons: font
 :source-highlighter: rouge
 :experimental:
 :revdate: {docdate}
@@ -30,9 +29,9 @@ You will need:
 ** OpenSSH **8.2 or newer** is required for FIDO2 hardware-backed keys.
 ** OpenSSH **8.3 or newer** is required to download resident keys from the security key with `ssh-keygen -K`.
 ** OpenSSH **8.4 or newer** is required for the `verify-required` option, which enforces user verification (PIN) for each operation.
-+
-NOTE: Having a recent enough OpenSSH version is necessary but not always sufficient. The OpenSSH build must also be compiled with FIDO support (`libfido2`). Apple's bundled macOS OpenSSH is not, so macOS needs Homebrew OpenSSH. The built-in Windows OpenSSH did not include FIDO before version 8.9, but current Windows builds (9.x) do. See the platform notes below.
 * **YubiKey Manager:** Required for setting or changing your FIDO2 PIN. Download it from the link:https://www.yubico.com/support/download/yubikey-manager/[Yubico website].
+
+NOTE: Having a recent enough OpenSSH version is necessary but not always sufficient. The OpenSSH build must also be compiled with FIDO support (`libfido2`). Apple's bundled macOS OpenSSH is not, so macOS needs Homebrew OpenSSH. The built-in Windows OpenSSH did not include FIDO before version 8.9, but current Windows builds (9.x) do. See the platform notes below.
 
 [[platform-specific-openssh]]
 ==== Platform-Specific OpenSSH Setup

--- a/content/SSH/Securing_git_with_SSH_and_FIDO2.adoc
+++ b/content/SSH/Securing_git_with_SSH_and_FIDO2.adoc
@@ -3,7 +3,6 @@
 :toc: left
 :toclevels: 3
 :sectnums:
-:icons: font
 :source-highlighter: rouge
 :experimental:
 :revdate: {docdate}


### PR DESCRIPTION
This attribute caused NOTE admonitions to render as broken images (`/usr/share/asciidoc/icons/note.png`) because the site's build environment doesn't provide those icon assets. Removing it aligns these files with the rest of the repo, where icons render as plain text labels

Before:
<img width="102" height="91" alt="image" src="https://github.com/user-attachments/assets/094fbdcf-c40d-4915-be02-e17390376df6" />

After:
<img width="96" height="87" alt="image" src="https://github.com/user-attachments/assets/41d4e33c-d4c9-49da-a12e-6fb14512aa90" />