### PR TITLE
Add security key capabilities guides (YubiKey 5.8) under Passkey concepts

### DIFF
--- a/content/CTAP/index.adoc
+++ b/content/CTAP/index.adoc
@@ -41,6 +41,8 @@ CTAP 2.3 (published February 2026) is the current version of the protocol and th
 | Richer authenticator metadata | New `getInfo` properties | Applications can query authenticator capabilities like UV counters, attestation formats, and max PIN length to adapt their UX dynamically.
 |===
 
+NOTE: YubiKey firmware 5.8 implements these capabilities. For feature-by-feature developer guides, see link:/Passkeys/Passkey_concepts/Security_key_capabilities/[Security key capabilities] in the Passkeys section.
+
 ==== Learn More About CTAP Versions
 
 To help you build your application, we have created detailed guides for each major version of the CTAP specification.

--- a/content/Passkeys/Passkey_concepts/.conf.json
+++ b/content/Passkeys/Passkey_concepts/.conf.json
@@ -3,7 +3,8 @@
     "Authenticator_types",
     "Discoverable_vs_non-discoverable_credentials",
     "Single_device_vs_multi_device_credentials",
-    "User_verification"
+    "User_verification",
+    "Security_key_capabilities"
   ],
   "suggest-edits": {},
   "hidden": ["images"]

--- a/content/Passkeys/Passkey_concepts/Security_key_capabilities/.conf.json
+++ b/content/Passkeys/Passkey_concepts/Security_key_capabilities/.conf.json
@@ -1,0 +1,10 @@
+{
+  "order": [
+    "Conditional_Mediation_for_Security_Keys",
+    "Pseudo-Random_Function_PRF_Support",
+    "Signing_Extension_Preview",
+    "Third-Party_Payment_Extension",
+    "Authenticator_Capability_Discovery"
+  ],
+  "suggest-edits": {}
+}

--- a/content/Passkeys/Passkey_concepts/Security_key_capabilities/Authenticator_Capability_Discovery.adoc
+++ b/content/Passkeys/Passkey_concepts/Security_key_capabilities/Authenticator_Capability_Discovery.adoc
@@ -1,0 +1,44 @@
+= Authenticator Capability Discovery
+:description: Discover authenticator capabilities with the new authenticatorGetInfo fields in YubiKey firmware 5.8 - maxPINLength, pinComplexityPolicy, uvCountSinceLastPinEntry, transportsForReset, longTouchForReset, and attestationFormats.
+:keywords: authenticatorGetInfo, maxPINLength, pinComplexityPolicy, pinComplexityPolicyURL, uvCountSinceLastPinEntry, transportsForReset, longTouchForReset, attestationFormats, CTAP, YubiKey 5.8
+
+YubiKey firmware 5.8 adds new fields to the `authenticatorGetInfo` response that let applications discover PIN policy, reset capability, and attestation format support. Reading these fields is a read-only operation: no credentials are created and no PIN or touch is required.
+
+== PIN and User Verification
+
+* `maxPINLength`: Maximum PIN length in Unicode code points. There is also a separate 63-byte limit on the UTF-8 wire encoding, so multi-byte characters can hit the byte ceiling before the code-point ceiling. Check both when validating client-side so you can reject a PIN before the authenticator does and give the user a clear error message.
+* `pinComplexityPolicy`: Boolean. When `true`, the authenticator enforces requirements beyond minimum length (e.g. no repeated digits). Query this so you can warn users up front that extra rules apply, instead of letting them hit a vague rejection after they submit.
+* `pinComplexityPolicyURL`: Optional URL to a human-readable description of the PIN policy. Independent of `pinComplexityPolicy` and not guaranteed to be present even when complexity is enabled. When available, link users directly so they know exactly what the authenticator expects.
+* `uvCountSinceLastPinEntry`: Number of consecutive UV operations since the authenticator last required PIN entry. Use this to implement "re-enter your PIN after N biometric uses" policies so users don't go months without typing their PIN and then forget it.
+
+== Reset-Related Capability Discovery
+
+* `transportsForReset`: Array of transports that accept the CTAP reset command. USB-only prevents remote reset over NFC, which stops someone from wiping a key without physical USB access.
+* `longTouchForReset`: Boolean. When `true`, a sustained touch (~5 seconds) is required to confirm factory reset instead of a quick tap. This prevents accidental resets. Your UX needs to tell the user to hold the key, not just tap it, or the reset will fail silently.
+
+== Attestation Formats
+
+* `attestationFormats`: Supported attestation statement formats. Currently `packed`. This field is future-proofing for when alternate formats (e.g. post-quantum) are standardized. Not much to act on today, but worth logging so you know when that changes.
+
+== Compatibility
+
+On firmware older than 5.8 the authenticator omits these CBOR keys from the `getInfo` response. Client libraries typically fall back to sensible defaults when the keys are absent:
+
+[cols="1,1", options="header"]
+|===
+| Field | Typical default when absent
+| `maxPINLength` | `63` (the FIDO2 protocol maximum)
+| `pinComplexityPolicy` | unset
+| `pinComplexityPolicyURL` | unset
+| `uvCountSinceLastPinEntry` | unset
+| `transportsForReset` | empty list
+| `longTouchForReset` | `false`
+| `attestationFormats` | empty list
+|===
+
+== References
+
+* link:https://docs.yubico.com/yesdk/users-manual/application-fido2/fido2-authenticator-config.html[Authenticator configuration]
+* link:https://docs.yubico.com/yesdk/users-manual/sdk-programming-guide/pin-complexity-policy.html[PIN complexity policy]
+
+link:/Passkeys/Passkey_concepts/Security_key_capabilities/[Return to security key capabilities]

--- a/content/Passkeys/Passkey_concepts/Security_key_capabilities/Conditional_Mediation_for_Security_Keys.adoc
+++ b/content/Passkeys/Passkey_concepts/Security_key_capabilities/Conditional_Mediation_for_Security_Keys.adoc
@@ -1,0 +1,90 @@
+= Conditional Mediation for Security Keys
+:description: How YubiKey firmware 5.8 supports conditional mediation for hardware security keys with Persistent PIN User Access Tokens (PPUAT), the PCMR permission, encIdentifier, and encCredStoreState.
+:keywords: PPUAT, PCMR, encIdentifier, encCredStoreState, persistent token, device identity, conditional mediation, passkey autofill, CTAP 2.2, YubiKey 5.8
+
+Firmware 5.8 implements the primitives that support conditional mediation for hardware security keys: PPUAT, PCMR, `encIdentifier`, and `encCredStoreState`.
+
+Before firmware 5.8, hardware keys were invisible to passkey autofill. A platform had no way to know which passkeys lived on a YubiKey without asking for the PIN every time. These four features change that: the user enters their PIN once, and from that point on the platform can silently recognize the key, check whether its credentials have changed, and populate the autofill dropdown without another PIN prompt.
+
+== Persistent PIN User Access Token (PPUAT)
+
+A long-lived authentication token acquired through PIN verification. Unlike a standard PIN/UV auth token, a PPUAT persists across sessions and application restarts: a client acquires the token once through PIN verification, saves it, and can load it into a new session later with no PIN prompt.
+
+This is what makes silent credential discovery possible. IDPs and password managers can query the key on every connection without interrupting the user.
+
+A PPUAT is invalidated when:
+
+* The PIN is changed (including when forced by a minimum-PIN-length policy change)
+* The FIDO2 application is factory-reset
+
+== Persistent Credential Management Read Only (PCMR) Permission
+
+The permission level assigned to a PPUAT. It grants read-only access to credential management operations:
+
+* Credential metadata: credential count and remaining slot count
+* Enumerating relying parties: list all RPs with stored credentials
+* Enumerating credentials per relying party
+
+PCMR explicitly does not grant delete or modify permissions. A compromised PPUAT cannot remove credentials.
+
+NOTE: A PPUAT with PCMR is for discovery and management only. It cannot perform a `GetAssertion` (i.e. log a user in). Actual login still requires a standard assertion with user interaction. The PPUAT just makes finding which credential to use much faster.
+
+== encIdentifier
+
+A stable 16-byte device identifier, encrypted using a key derived from the PPUAT via HKDF-SHA-256 + AES-128-CBC. The raw `getInfo` response returns a different ciphertext on each call (16-byte IV + 16-byte ciphertext), preventing correlation by observers. Only a valid PPUAT holder can decrypt it to the stable value.
+
+The identifier is constant across PIN changes, allowing a platform to map sessions to a physical authenticator.
+
+*Who can track the YubiKey?*
+
+[cols="1,1,2", options="header"]
+|===
+| Observer | Can they identify the key? | Why
+| Random website | No | `getInfo` returns a fresh IV + ciphertext every call
+| Unauthorized app | No | Cannot decrypt without the PPUAT
+| Authorized platform | Yes | Holds the PPUAT, can decrypt to the stable device ID
+|===
+
+The rotating ciphertext is a firmware-level guarantee.
+
+== encCredStoreState
+
+A 16-byte value that changes when credentials are added, removed, or the authenticator is reset. Platforms use it for cache invalidation:
+
+----
+saved state == current state  ->  cache is valid, skip enumeration
+saved state != current state  ->  re-enumerate credentials
+----
+
+This is what makes autofill instant. If the state hasn't changed since last time, the platform already knows what passkeys are on the key and skips enumeration entirely.
+
+== Typical platform flow
+
+----
+First connection: User enters PIN
+  Platform acquires PPUAT (PCMR permission)
+  Decrypts encIdentifier  ->  device ID
+  Decrypts encCredStoreState  ->  credential state
+  Enumerates credentials
+  Caches: { device ID, credential state, credential list }
+  Stores PPUAT
+
+Subsequent connections: No PIN required
+  Platform loads saved PPUAT into the session
+  Decrypts encIdentifier  ->  same device ID  ->  cache hit
+  Decrypts encCredStoreState  ->  compare with cached state
+  If unchanged: use cached credential list
+  If changed: re-enumerate
+----
+
+== Compatibility
+
+On firmware older than 5.8, the YubiKey does not support CTAP 2.2 persistent tokens: requests for a persistent token, the encrypted identifier, and the credential store state will not return values. Always check for support before attempting decryption, and fall back to the standard PIN flow when persistent tokens are unavailable.
+
+== References
+
+* link:https://docs.yubico.com/yesdk/users-manual/application-fido2/fido2-auth-tokens.html[FIDO2 auth tokens (PPUAT)]
+* link:https://docs.yubico.com/yesdk/users-manual/application-fido2/fido2-cred-mgmt.html[Credential management]
+* link:https://docs.yubico.com/yesdk/users-manual/application-fido2/fido2-authenticator-config.html[Authenticator configuration]
+
+link:/Passkeys/Passkey_concepts/Security_key_capabilities/[Return to security key capabilities]

--- a/content/Passkeys/Passkey_concepts/Security_key_capabilities/Pseudo-Random_Function_PRF_Support.adoc
+++ b/content/Passkeys/Passkey_concepts/Security_key_capabilities/Pseudo-Random_Function_PRF_Support.adoc
@@ -1,0 +1,51 @@
+= Pseudo-Random Function (PRF) Support
+:description: Derive a 32-byte hardware-backed secret during credential creation with the hmac-secret-mc extension in YubiKey firmware 5.8, with one user interaction instead of two.
+:keywords: hmac-secret-mc, hmac-secret, PRF, Pseudo-Random Function, WebAuthn PRF extension, MakeCredential, key derivation, client-side encryption, CTAP 2.2, YubiKey 5.8
+
+The `hmac-secret-mc` extension derives a 32-byte secret during `MakeCredential`. On firmware 5.8 this completes in a single user interaction. Previous firmware required a separate `GetAssertion` call with the `hmac-secret` extension (two interactions).
+
+== Why this matters
+
+Before `hmac-secret-mc`, generating an encryption key from a hardware key meant two user touches: one to register, one to derive the secret via assertion. If your app needs both an authentication credential and an encryption key at signup, that's two taps back to back with no obvious reason from the user's perspective.
+
+With `hmac-secret-mc` the secret comes back in the registration response. One touch, done. This is what makes it practical to do things like:
+
+* *Client-side encryption at signup.* Derive a symmetric key during registration and use it to encrypt data in the browser or app before it ever hits your server.
+* *Per-purpose keys from one credential.* Use different salts to derive separate keys for authentication, file encryption, and transaction signing, all from the same credential.
+* *Federated key derivation.* A payment provider derives its own key from the merchant's credential using its own salt, no shared state needed.
+
+== How it works
+
+. The client provides a 32-byte salt.
+. The salt is attached to the `MakeCredential` request via the `hmac-secret-mc` extension.
+. The authenticator creates the credential, computes HMAC-SHA-256 over the salt using a credential-scoped internal key, and returns the 32-byte result in the registration response.
+. The client extracts and decrypts the secret from the authenticator data.
+
+The credential's internal key never leaves the authenticator. The output is encrypted in transit using the ECDH-derived shared secret between client and authenticator.
+
+=== hmac-secret vs. hmac-secret-mc
+
+[cols="1,1,1", options="header"]
+|===
+| | `hmac-secret` | `hmac-secret-mc`
+| When secret is derived | During `GetAssertion` | During `MakeCredential`
+| User interactions | Two (register, then assert) | One (register)
+| Firmware required | Any FIDO2-capable YubiKey | 5.8 or later
+|===
+
+=== Two salts
+
+Two 32-byte salts can be provided to receive 64 bytes of output (two independent 32-byte values). This supports key rotation: derive with both old and new salt in a single operation. It's also useful for standard encrypt-then-MAC designs where you need one key for AES encryption and a separate key for HMAC integrity, without reusing the same key for both.
+
+== Compatibility
+
+`hmac-secret` has been supported since the first FIDO2-capable YubiKey (CTAP 2.0). `hmac-secret-mc` requires firmware 5.8+. Check the authenticator's supported extensions at runtime and fall back to the two-step `hmac-secret` flow when `hmac-secret-mc` is not available.
+
+On the browser side, both extensions surface through the WebAuthn PRF extension. The browser handles the negotiation; your RP doesn't need to know which CTAP extension is being used underneath.
+
+== References
+
+* link:https://docs.yubico.com/yesdk/users-manual/application-fido2/hmac-secret.html[HMAC-Secret extensions]
+* link:https://github.com/w3c/webauthn/blob/main/explainers/prf-extension.md[PRF extension explainer (W3C)]
+
+link:/Passkeys/Passkey_concepts/Security_key_capabilities/[Return to security key capabilities]

--- a/content/Passkeys/Passkey_concepts/Security_key_capabilities/Signing_Extension_Preview.adoc
+++ b/content/Passkeys/Passkey_concepts/Security_key_capabilities/Signing_Extension_Preview.adoc
@@ -1,0 +1,112 @@
+= Signing Extension (Preview)
+:description: Sign raw data with hardware-backed keys using the previewSign FIDO2 extension and ARKG in YubiKey firmware 5.8. Generate unlimited unlinkable signing keys offline from a single credential.
+:keywords: previewSign, ARKG, raw signing, ECDSA P-256, asynchronous remote key generation, document signing, EUDI, SPIFFE, DPoP, CTAP, YubiKey 5.8
+
+The `previewSign` FIDO2 extension lets a YubiKey sign raw data. Standard FIDO2 signatures wrap your data in `authenticatorData || SHA-256(clientData)`, which means they only work with FIDO2 verifiers. With previewSign, the signed payload is your input unaltered, so the signature works with any protocol that accepts ECDSA P-256 signatures. The private key never leaves the YubiKey. Examples include PDF signing (PAdES), JWT/DPoP tokens, S/MIME email, C2PA content integrity, and SPIFFE workload identities.
+
+The 5.8 firmware implements this using ARKG (Asynchronous Remote Key Generation), specifically the `ARKG_P256_ESP256` algorithm. ARKG lets you generate unlimited unique signing keys offline from a single YubiKey credential. Each derived key is cryptographically unlinkable: a verifier cannot tell that two derived keys came from the same device. You only need to touch the YubiKey once to set up the signing key pair, and again each time you produce a signature.
+
+Deriving new public keys in between is free, and so is verification. Anyone with the derived public key can verify a signature using any standard ECDSA library, no YubiKey or Yubico SDK required.
+
+previewSign is algorithm-agnostic by design, so future firmware versions may offer different algorithms.
+
+WARNING: *Early Access Only.* The previewSign extension, its algorithm, and the algorithm ID (-65539) are not final and will change before general availability. Do not use this in production.
+
+NOTE: *Two sides: client and relying party.* previewSign splits into a client side and a relying-party (server) side. The client talks to the YubiKey: it enables the extension, reads the generated key back, requests a signature, and reads the signature back (Steps A and C below). The relying-party side derives public keys offline (Step B) and verifies signatures (Step D); those operations need no YubiKey and run on your server.
+
+== When to use this
+
+previewSign is for signing arbitrary data with hardware-backed keys. It is not for authentication.
+
+Real world examples:
+
+* *Digital identity (EUDI).* Present a wallet credential to different services, each presentation signed with a unique key, so the services cannot correlate you by a shared public key. This is key unlinkability only. Hiding or selectively disclosing attribute values (for example, proving "over 18" without revealing a birthdate) is a property of the credential format, not previewSign.
+* *Document signing.* Sign contracts, PDFs, or legal documents. The signature is standard ECDSA P-256, compatible with existing verification tools.
+* *Software signing.* Publish a derived public key as a release signing key. When you need to sign a release, touch the YubiKey to produce the signature.
+* *Workload identity.* Issue hardware-bound signing keys for SPIFFE or OAuth DPoP without exposing private key material to the host.
+
+Deriving public keys is cheap, so you can generate them speculatively. This matters for short-lived credentials like EUDI attribute certificates that expire after a week: you might derive 20 public keys upfront but only end up signing with a few of them. The unused ones cost nothing.
+
+== How ARKG works
+
+When you create a credential with previewSign, the YubiKey generates two key pairs internally. The private halves (`skBl`, `skKem`) never leave the YubiKey. It gives you the public halves:
+
+* *pkBl (blinding public key):* Used to derive new unique public keys offline. Each derivation produces a new ECDSA P-256 public key that looks completely unrelated to pkBl or any other derived key.
+* *pkKem (KEM public key):* Used to produce a ticket (`arkgArgs`) during derivation. This is what you send back to the YubiKey when signing so it can recreate the matching private key on the fly.
+
+Both public halves are returned together as a single COSE-encoded ARKG key (the seed public key).
+
+Algorithm: `ARKG_P256_ESP256` (-65539).
+
+== Flow
+
+----
+Step A: Generate Key (touch YubiKey, one time setup)              [client]
+  MakeCredential with the previewSign extension.
+  YubiKey returns the generated key (carrying pkBl + pkKem), a key
+  handle, and a credential ID. Save these to your database. You need
+  them to derive new keys and sign later.
+
+Step B: Derive Public Key (offline, no YubiKey, unlimited times)  [relying party]
+  Using the seed public key from Step A, the relying party derives a
+  unique signing key and an ARKG ticket (arkgArgs). Each derivation
+  uses fresh randomness (ikm), so every derived key is unique.
+  Run derivation as many times as you want for unlimited unlinkable
+  keys.
+    - derivedPublicKey: a unique P-256 public key. Share it with
+      verifiers.
+    - arkgArgs (the ticket): send it back to the client to sign.
+
+Step C: Sign (touch YubiKey, one touch per signature)             [client]
+  previewSign signs the input unaltered, so the client hashes the
+  message first, then sends the digest, the key handle from Step A,
+  and the ticket from Step B to the YubiKey in a GetAssertion request
+  (with the credential ID from Step A in the allow-list).
+  The YubiKey reads the ticket, recreates the matching private key,
+  signs the digest, returns the signature, then discards the private
+  key.
+
+Step D: Verify (offline, no YubiKey)                              [relying party]
+  The derived key is a plain P-256 key, so verification is standard
+  ECDSA against the signature, the message, and the derived public
+  key. Anyone with the derived public key can verify. No secrets, no
+  YubiKey needed.
+----
+
+=== What to store
+
+After Step A (once):
+
+* The credential ID: included in the assertion allow-list so the YubiKey knows which credential to use
+* The key handle of the generated signing key: supplied with each signing request (different from the credential ID; mixing them causes a firmware error)
+* The seed public key: the COSE ARKG key carrying pkBl + pkKem, used to derive future keys
+
+After Step B (per derived key):
+
+* Derived public key, to share with verifiers
+* ARKG ticket (`arkgArgs`), to request signatures from the YubiKey
+* Context label, for your own bookkeeping
+
+The random bytes (`ikm`) used for each derivation do not need to be stored. They are baked into the ticket.
+
+=== What the verifier receives
+
+Three things:
+
+* The original document
+* The ECDSA signature
+* The derived public key
+
+The derived public key is a standard P-256 key. The verifier does not need to know about ARKG, previewSign, or the YubiKey. They just run standard ECDSA verification.
+
+== Compatibility
+
+previewSign requires firmware 5.8+. Check for the `"previewSign"` extension in the authenticator's supported extensions and stop if it is missing.
+
+== References
+
+* link:https://yubicolabs.github.io/webauthn-sign-extension/[previewSign spec (version 4)]
+* link:https://github.com/w3c/webauthn/blob/main/explainers/raw-signing-extension.md[previewSign explainer]
+* link:https://www.ietf.org/archive/id/draft-bradleylundberg-cfrg-arkg-08.html[ARKG specification (IETF draft-bradleylundberg-cfrg-arkg-08)]
+
+link:/Passkeys/Passkey_concepts/Security_key_capabilities/[Return to security key capabilities]

--- a/content/Passkeys/Passkey_concepts/Security_key_capabilities/Third-Party_Payment_Extension.adoc
+++ b/content/Passkeys/Passkey_concepts/Security_key_capabilities/Third-Party_Payment_Extension.adoc
@@ -1,0 +1,43 @@
+= Third-Party Payment Extension
+:description: Use the thirdPartyPayment extension in YubiKey firmware 5.8 to mark credentials for delegated payment flows, with credBlob metadata and credProtect user-verification enforcement.
+:keywords: thirdPartyPayment, Secure Payment Confirmation, SPC, credBlob, credProtect, payment authentication, PSD2, CTAP 2.2, YubiKey 5.8
+
+The `thirdPartyPayment` extension marks a credential for delegated payment use: a credential created by one relying party (for example, a bank) can later be asserted in a transaction initiated by a third party (for example, a merchant), without redirects back to the bank. Combined with `credBlob` for per-credential metadata and `credProtect` for user-verification enforcement, it provides the authenticator-side building blocks for Secure Payment Confirmation (SPC) flows.
+
+== The three extensions
+
+* *thirdPartyPayment*: Marks a credential for delegated payment use. The YubiKey stores this flag with the credential; during a later assertion, the authenticator confirms the flag is set.
+* *credBlob*: Stores per-credential metadata, such as a card label. Platforms can display this in the payment UI (e.g. "Pay with Visa 4242") without a network round-trip.
+* *credProtect*: Enforces a protection policy on the credential. With user verification required, every assertion needs a PIN or biometric, preventing a stolen session from silently authorizing transactions.
+
+== Flow
+
+=== Step A: Bank registration
+
+The user registers a payment credential with their bank. With `thirdPartyPayment` enabled, this credential can later be used by a merchant site to confirm a transaction. No redirect back to the bank is needed.
+
+The registration request combines four elements:
+
+. *thirdPartyPayment:* Set the extension to `true` in the `MakeCredential` request. The YubiKey stores this flag with the credential.
+. *Discoverable credential (resident key):* Set the `rk` option to `true`. Required so the merchant can trigger an assertion without knowing the credential ID in advance.
+. *credProtect:* Set the policy to require user verification, so every assertion requires a PIN or biometric.
+. *credBlob:* Attach a card label (for example, "Visa 4242") as per-credential metadata.
+
+After creation, the client can verify the attestation signature to confirm the credential was created by a genuine authenticator, and confirm the `thirdPartyPayment` flag is set in the authenticator data.
+
+=== Step B: Merchant checkout
+
+A merchant site triggers payment confirmation using the bank credential. The platform (browser/OS) would show something like "Pay $42.00 with Visa 4242?" instead of a generic login prompt.
+
+In a real SPC flow, the merchant calls `navigator.credentials.get()` with the payment extension. At the CTAP level, the assertion request:
+
+. Requests `thirdPartyPayment` confirmation. The authenticator returns `true` if the credential was created with the extension enabled.
+. Requests the `credBlob` so the platform can display the card label.
+
+The assertion response confirms the credential is authorized for third-party payment flows, and the card label read back from `credBlob` can be shown in the payment UI.
+
+== Compatibility
+
+`thirdPartyPayment` is advertised in `getInfo.extensions`. Only YubiKeys with firmware 5.8+ support it. `credBlob` and `credProtect` are optional companions. Check the authenticator's supported extensions (and the maximum `credBlob` length) at runtime.
+
+link:/Passkeys/Passkey_concepts/Security_key_capabilities/[Return to security key capabilities]

--- a/content/Passkeys/Passkey_concepts/Security_key_capabilities/index.adoc
+++ b/content/Passkeys/Passkey_concepts/Security_key_capabilities/index.adoc
@@ -1,0 +1,33 @@
+= Security Key Capabilities
+:description: Developer guides for advanced FIDO2/CTAP security key capabilities, including conditional mediation, Pseudo-Random Function (PRF) support, the previewSign signing extension, third-party payment, and authenticator capability discovery. Introduced in YubiKey firmware 5.8.
+:keywords: YubiKey 5.8, firmware, FIDO2, CTAP 2.2, CTAP 2.3, PPUAT, hmac-secret-mc, PRF, previewSign, ARKG, thirdPartyPayment, getInfo, passkey, conditional mediation, security key
+
+These capabilities were introduced in YubiKey firmware 5.8, which implements the major FIDO2 features defined in CTAP 2.2 and CTAP 2.3. The guides explain each capability from a protocol perspective: what it does, why it matters, and how the pieces fit together. They are language agnostic, so the concepts apply whichever client library or SDK you build with.
+
+== Feature guides
+
+* *link:/Passkeys/Passkey_concepts/Security_key_capabilities/Conditional_Mediation_for_Security_Keys.html[Conditional Mediation for Security Keys]*
++
+The primitives that support conditional mediation for hardware security keys: Persistent PIN User Access Tokens (PPUAT), the Persistent Credential Management Read Only (PCMR) permission, `encIdentifier`, and `encCredStoreState`. Together they let a platform silently recognize a YubiKey and populate passkey autofill after a single PIN entry.
+
+* *link:/Passkeys/Passkey_concepts/Security_key_capabilities/Pseudo-Random_Function_PRF_Support.html[Pseudo-Random Function (PRF) Support]*
++
+Derive a 32-byte hardware-backed secret during credential creation with the `hmac-secret-mc` extension. On firmware 5.8 this completes in a single user interaction instead of the two required by the original `hmac-secret` flow.
+
+* *link:/Passkeys/Passkey_concepts/Security_key_capabilities/Signing_Extension_Preview.html[Signing Extension (Preview)]*
++
+Sign raw data with hardware-backed keys using the `previewSign` FIDO2 extension and ARKG (Asynchronous Remote Key Generation). Generate unlimited unlinkable signing keys offline from a single credential, with signatures verifiable by any standard ECDSA library.
+
+* *link:/Passkeys/Passkey_concepts/Security_key_capabilities/Third-Party_Payment_Extension.html[Third-Party Payment Extension]*
++
+Mark a credential for delegated payment use with the `thirdPartyPayment` extension, attach per-credential metadata via `credBlob`, and enforce user verification with `credProtect`. These are the building blocks for Secure Payment Confirmation flows.
+
+* *link:/Passkeys/Passkey_concepts/Security_key_capabilities/Authenticator_Capability_Discovery.html[Authenticator Capability Discovery]*
++
+New `authenticatorGetInfo` fields in firmware 5.8: PIN policy metadata (`maxPINLength`, `pinComplexityPolicy`, `pinComplexityPolicyURL`, `uvCountSinceLastPinEntry`), reset capability (`transportsForReset`, `longTouchForReset`), and `attestationFormats`.
+
+== Related reading
+
+These features are defined by the CTAP specification. For the protocol-level view, see the link:/CTAP/CTAP2.2.html[CTAP 2.2] and link:/CTAP/CTAP2.3.html[CTAP 2.3] guides.
+
+link:/Passkeys/Passkey_concepts/[Return to passkey concepts]

--- a/content/Passkeys/Passkey_concepts/index.adoc
+++ b/content/Passkeys/Passkey_concepts/index.adoc
@@ -12,6 +12,7 @@ This page contains links to other reference resources to help further build your
 * link:/Passkeys/Passkey_concepts/Discoverable_vs_non-discoverable_credentials.html[Discoverable and non-discoverable credentials]
 * link:/Passkeys/Passkey_concepts/Single_device_vs_multi_device_credentials.html[Single device vs multi device credentials]
 * link:/Passkeys/Passkey_concepts/User_verification.html[User verification]
+* link:/Passkeys/Passkey_concepts/Security_key_capabilities/[Security key capabilities]
 //* [Hybrid flows](link to guidance)
 //* [Security and privacy considerations](link to guidance)
 


### PR DESCRIPTION
## What

Adds a new "Security Key Capabilities" section under /Passkeys/Passkey_concepts/
with language-agnostic developer guides for the FIDO2/CTAP capabilities
introduced in YubiKey firmware 5.8. Content is adapted from the fact-checked
Early Access Program quickstart guides, with all .NET SDK-specific material
removed and page titles aligned with the official "5.8 Firmware Specifics"
documentation.

The folder is deliberately named for the capability set rather than the
firmware version, so URLs stay evergreen as future firmware adds features.
Each page carries its own "requires firmware 5.8+" compatibility section,
and the landing page states the 5.8 introduction up front.

## New pages

- `Security_key_capabilities/index.adoc` — landing page linking each guide
- `Conditional_Mediation_for_Security_Keys.adoc` — PPUAT, PCMR permission,
  encIdentifier, encCredStoreState; the primitives behind passkey autofill
  for hardware security keys
- `Pseudo-Random_Function_PRF_Support.adoc` — hmac-secret-mc: one-touch
  secret derivation during MakeCredential
- `Signing_Extension_Preview.adoc` — previewSign extension + ARKG raw
  signing (marked preview/early access; algorithm ID not final)
- `Third-Party_Payment_Extension.adoc` — thirdPartyPayment with credBlob
  and credProtect for Secure Payment Confirmation flows
- `Authenticator_Capability_Discovery.adoc` — new authenticatorGetInfo
  fields: PIN policy, reset capability, attestation formats

## Navigation

- New `.conf.json` ordering the five guides within the section
- Section added to `Passkey_concepts/.conf.json` and the concepts list in
  `Passkey_concepts/index.adoc`
- Cross-reference NOTE added to the CTAP index (its "What's New" table
  already mentions these features by name)