### PR TITLE
Update 5.8 Docs

### DIFF
--- a/content/Passkeys/Passkey_concepts/Security_key_capabilities/Authenticator_Capability_Discovery.adoc
+++ b/content/Passkeys/Passkey_concepts/Security_key_capabilities/Authenticator_Capability_Discovery.adoc
@@ -22,7 +22,7 @@ YubiKey firmware 5.8 adds new fields to the `authenticatorGetInfo` response that
 
 == Compatibility
 
-On firmware older than 5.8 the authenticator omits these CBOR keys from the `getInfo` response. Client libraries typically fall back to sensible defaults when the keys are absent:
+On firmware older than 5.8 the authenticator omits these CBOR keys from the `authenticatorGetInfo` response. Client libraries typically fall back to sensible defaults when the keys are absent:
 
 [cols="1,1", options="header"]
 |===

--- a/content/Passkeys/Passkey_concepts/Security_key_capabilities/Authenticator_Capability_Discovery.adoc
+++ b/content/Passkeys/Passkey_concepts/Security_key_capabilities/Authenticator_Capability_Discovery.adoc
@@ -22,7 +22,7 @@ YubiKey firmware 5.8 adds new fields to the `authenticatorGetInfo` response that
 
 == Compatibility
 
-On firmware older than 5.8 the authenticator omits these CBOR keys from the `authenticatorGetInfo` response. Client libraries typically fall back to sensible defaults when the keys are absent:
+On firmware older than 5.8, the authenticator omits these CBOR keys from the `authenticatorGetInfo` response. Client libraries typically fall back to sensible defaults when the keys are absent:
 
 [cols="1,1", options="header"]
 |===

--- a/content/Passkeys/Passkey_concepts/Security_key_capabilities/Conditional_Mediation_for_Security_Keys.adoc
+++ b/content/Passkeys/Passkey_concepts/Security_key_capabilities/Conditional_Mediation_for_Security_Keys.adoc
@@ -17,7 +17,7 @@ A PPUAT is invalidated when:
 * The PIN is changed (including when forced by a minimum-PIN-length policy change)
 * The FIDO2 application is factory-reset
 
-== Persistent Credential Management Read Only (PCMR) Permission
+== Persistent Credential Management Read-only (PCMR) Permission
 
 The permission level assigned to a PPUAT. It grants read-only access to credential management operations:
 
@@ -49,7 +49,7 @@ The rotating ciphertext is a firmware-level guarantee.
 
 == encCredStoreState
 
-A 16-byte value that changes when credentials are added, removed, or the authenticator is reset. Platforms use it for cache invalidation:
+A 16-byte value that changes when credentials are added, removed, or the authenticator is reset. Like `encIdentifier`, it is returned encrypted (fresh IV on every `getInfo` call) using a key derived from the PPUAT, so the platform decrypts it before comparing. Platforms use it for cache invalidation:
 
 ----
 saved state == current state  ->  cache is valid, skip enumeration
@@ -79,10 +79,11 @@ Subsequent connections: No PIN required
 
 == Compatibility
 
-On firmware older than 5.8, the YubiKey does not support CTAP 2.2 persistent tokens: requests for a persistent token, the encrypted identifier, and the credential store state will not return values. Always check for support before attempting decryption, and fall back to the standard PIN flow when persistent tokens are unavailable.
+On firmware older than 5.8, the YubiKey does not support persistent tokens: requests for a persistent token, the encrypted identifier, and the credential store state will not return values. Always check for support before attempting decryption, and fall back to the standard PIN flow when persistent tokens are unavailable.
 
 == References
 
+* link:https://github.com/YubicoLabs/build-with-us/tree/main/quickstart[Build with Us quickstarts]: PPUAT demos for iOS, Android, .NET, and Python
 * link:https://docs.yubico.com/yesdk/users-manual/application-fido2/fido2-auth-tokens.html[FIDO2 auth tokens (PPUAT)]
 * link:https://docs.yubico.com/yesdk/users-manual/application-fido2/fido2-cred-mgmt.html[Credential management]
 * link:https://docs.yubico.com/yesdk/users-manual/application-fido2/fido2-authenticator-config.html[Authenticator configuration]

--- a/content/Passkeys/Passkey_concepts/Security_key_capabilities/Pseudo-Random_Function_PRF_Support.adoc
+++ b/content/Passkeys/Passkey_concepts/Security_key_capabilities/Pseudo-Random_Function_PRF_Support.adoc
@@ -30,7 +30,7 @@ The credential's internal key never leaves the authenticator. The output is encr
 | | `hmac-secret` | `hmac-secret-mc`
 | When secret is derived | During `GetAssertion` | During `MakeCredential`
 | User interactions | Two (register, then assert) | One (register)
-| Firmware required | Any FIDO2-capable YubiKey | 5.8 or later
+| Firmware required | All modern YubiKeys | 5.8 or later
 |===
 
 === Two salts
@@ -39,7 +39,7 @@ Two 32-byte salts can be provided to receive 64 bytes of output (two independent
 
 == Compatibility
 
-`hmac-secret` has been supported since the first FIDO2-capable YubiKey (CTAP 2.0). `hmac-secret-mc` requires firmware 5.8+. Check the authenticator's supported extensions at runtime and fall back to the two-step `hmac-secret` flow when `hmac-secret-mc` is not available.
+`hmac-secret` was introduced in CTAP 2.0 and has long been supported on YubiKeys. `hmac-secret-mc` requires firmware 5.8+. Check the authenticator's supported extensions at runtime and fall back to the two-step `hmac-secret` flow when `hmac-secret-mc` is not available.
 
 On the browser side, both extensions surface through the WebAuthn PRF extension. The browser handles the negotiation; your RP doesn't need to know which CTAP extension is being used underneath.
 

--- a/content/Passkeys/Passkey_concepts/Security_key_capabilities/Pseudo-Random_Function_PRF_Support.adoc
+++ b/content/Passkeys/Passkey_concepts/Security_key_capabilities/Pseudo-Random_Function_PRF_Support.adoc
@@ -30,7 +30,7 @@ The credential's internal key never leaves the authenticator. The output is encr
 | | `hmac-secret` | `hmac-secret-mc`
 | When secret is derived | During `GetAssertion` | During `MakeCredential`
 | User interactions | Two (register, then assert) | One (register)
-| Firmware required | All modern YubiKeys | 5.8 or later
+| Firmware required | 5.2 or later | 5.8 or later
 |===
 
 === Two salts

--- a/content/Passkeys/Passkey_concepts/Security_key_capabilities/Signing_Extension_Preview.adoc
+++ b/content/Passkeys/Passkey_concepts/Security_key_capabilities/Signing_Extension_Preview.adoc
@@ -32,7 +32,7 @@ Deriving public keys is cheap, so you can generate them speculatively. This matt
 When you create a credential with previewSign, the YubiKey generates two key pairs internally. The private halves (`skBl`, `skKem`) never leave the YubiKey. It gives you the public halves:
 
 * *pkBl (blinding public key):* Used to derive new unique public keys offline. Each derivation produces a new ECDSA P-256 public key that looks completely unrelated to pkBl or any other derived key.
-* *pkKem (KEM public key):* Used to produce a ticket (`arkgArgs`) during derivation. This is what you send back to the YubiKey when signing so it can recreate the matching private key on the fly.
+* *pkKem (KEM public key):* Used to produce a ticket (`arkgArgs`) during derivation. This is what you send back to the YubiKey when signing so it can create the matching private key on the fly.
 
 Both public halves are returned together as a single COSE-encoded ARKG key (the seed public key).
 
@@ -64,8 +64,8 @@ Step C: Sign (touch YubiKey, one touch per signature)             [client]
   first, then sends the digest, the key handle from Step A, and the
   ticket from Step B to the YubiKey in a GetAssertion request (with
   the credential ID from Step A in the allow-list).
-  The YubiKey reads the ticket, recreates the matching private key,
-  signs the payload, returns the signature, then discards the private
+  The YubiKey reads the ticket, creates the matching private key,
+  signs those bytes, returns the signature, then discards the private
   key.
 
 Step D: Verify (offline, no YubiKey)                              [relying party]

--- a/content/Passkeys/Passkey_concepts/Security_key_capabilities/Signing_Extension_Preview.adoc
+++ b/content/Passkeys/Passkey_concepts/Security_key_capabilities/Signing_Extension_Preview.adoc
@@ -58,12 +58,14 @@ Step B: Derive Public Key (offline, no YubiKey, unlimited times)  [relying party
     - arkgArgs (the ticket): send it back to the client to sign.
 
 Step C: Sign (touch YubiKey, one touch per signature)             [client]
-  previewSign signs the input unaltered, so the client hashes the
-  message first, then sends the digest, the key handle from Step A,
-  and the ticket from Step B to the YubiKey in a GetAssertion request
-  (with the credential ID from Step A in the allow-list).
+  previewSign signs exactly the bytes provided in the request,
+  without wrapping or transforming them. Most protocols expect a
+  signature over a digest, so the client typically hashes the message
+  first, then sends the digest, the key handle from Step A, and the
+  ticket from Step B to the YubiKey in a GetAssertion request (with
+  the credential ID from Step A in the allow-list).
   The YubiKey reads the ticket, recreates the matching private key,
-  signs the digest, returns the signature, then discards the private
+  signs the payload, returns the signature, then discards the private
   key.
 
 Step D: Verify (offline, no YubiKey)                              [relying party]
@@ -105,6 +107,7 @@ previewSign requires firmware 5.8+. Check for the `"previewSign"` extension in t
 
 == References
 
+* link:https://github.com/YubicoLabs/build-with-us/tree/main/quickstart[Build with Us quickstarts]: ARKG demos for iOS, Android, .NET, and Python
 * link:https://yubicolabs.github.io/webauthn-sign-extension/[previewSign spec (version 4)]
 * link:https://github.com/w3c/webauthn/blob/main/explainers/raw-signing-extension.md[previewSign explainer]
 * link:https://www.ietf.org/archive/id/draft-bradleylundberg-cfrg-arkg-08.html[ARKG specification (IETF draft-bradleylundberg-cfrg-arkg-08)]

--- a/content/Passkeys/Passkey_concepts/Security_key_capabilities/index.adoc
+++ b/content/Passkeys/Passkey_concepts/Security_key_capabilities/index.adoc
@@ -2,13 +2,13 @@
 :description: Developer guides for advanced FIDO2/CTAP security key capabilities, including conditional mediation, Pseudo-Random Function (PRF) support, the previewSign signing extension, third-party payment, and authenticator capability discovery. Introduced in YubiKey firmware 5.8.
 :keywords: YubiKey 5.8, firmware, FIDO2, CTAP 2.2, CTAP 2.3, PPUAT, hmac-secret-mc, PRF, previewSign, ARKG, thirdPartyPayment, getInfo, passkey, conditional mediation, security key
 
-These capabilities were introduced in YubiKey firmware 5.8, which implements the major FIDO2 features defined in CTAP 2.2 and CTAP 2.3. The guides explain each capability from a protocol perspective: what it does, why it matters, and how the pieces fit together. They are language agnostic, so the concepts apply whichever client library or SDK you build with.
+These capabilities were introduced in YubiKey firmware 5.8, which implements the major FIDO2 features defined in CTAP 2.2 and CTAP 2.3. The guides explain each capability from a protocol perspective: what it does, why it matters, and how the pieces fit together.
 
 == Feature guides
 
 * *link:/Passkeys/Passkey_concepts/Security_key_capabilities/Conditional_Mediation_for_Security_Keys.html[Conditional Mediation for Security Keys]*
 +
-The primitives that support conditional mediation for hardware security keys: Persistent PIN User Access Tokens (PPUAT), the Persistent Credential Management Read Only (PCMR) permission, `encIdentifier`, and `encCredStoreState`. Together they let a platform silently recognize a YubiKey and populate passkey autofill after a single PIN entry.
+The primitives that support conditional mediation for hardware security keys: Persistent PIN User Access Tokens (PPUAT), the Persistent Credential Management Read-only (PCMR) permission, `encIdentifier`, and `encCredStoreState`. Together they let a platform silently recognize a YubiKey, list its discoverable credentials, and populate passkey autofill after a single PIN entry.
 
 * *link:/Passkeys/Passkey_concepts/Security_key_capabilities/Pseudo-Random_Function_PRF_Support.html[Pseudo-Random Function (PRF) Support]*
 +
@@ -20,11 +20,15 @@ Sign raw data with hardware-backed keys using the `previewSign` FIDO2 extension 
 
 * *link:/Passkeys/Passkey_concepts/Security_key_capabilities/Third-Party_Payment_Extension.html[Third-Party Payment Extension]*
 +
-Mark a credential for delegated payment use with the `thirdPartyPayment` extension, attach per-credential metadata via `credBlob`, and enforce user verification with `credProtect`. These are the building blocks for Secure Payment Confirmation flows.
+Mark a credential for delegated payment use with the `thirdPartyPayment` extension, optionally paired with `credBlob` for per-credential metadata and `credProtect` for user-verification enforcement. Together they provide the authenticator-side pieces for payment confirmation flows such as Secure Payment Confirmation (SPC).
 
 * *link:/Passkeys/Passkey_concepts/Security_key_capabilities/Authenticator_Capability_Discovery.html[Authenticator Capability Discovery]*
 +
 New `authenticatorGetInfo` fields in firmware 5.8: PIN policy metadata (`maxPINLength`, `pinComplexityPolicy`, `pinComplexityPolicyURL`, `uvCountSinceLastPinEntry`), reset capability (`transportsForReset`, `longTouchForReset`), and `attestationFormats`.
+
+== Code examples
+
+Working demos for these features live in the link:https://github.com/YubicoLabs/build-with-us[YubicoLabs Build with Us] repository, with link:https://github.com/YubicoLabs/build-with-us/tree/main/quickstart[quickstarts] for iOS, Android, .NET, and Python.
 
 == Related reading
 


### PR DESCRIPTION
Follow-up to https://github.com/Yubico/developers.yubico.com/pull/684 based on Copilot review comments and a pass against
the CTAP 2.2 spec and the 5.8 Firmware Specifics docs. Add links to the build-with-us-repo